### PR TITLE
Switch organization before fetch SPARC information

### DIFF
--- a/mapserver/pennsieve.py
+++ b/mapserver/pennsieve.py
@@ -41,11 +41,13 @@ PENNSIEVE_API_PRODUCTION = 'https://api.pennsieve.io'
 ## Environment...
 # export LOGIN_API_URL="https://api.pennsieve.io"
 # export SPARC_ORGANISATION_ID=N:organization:618e8dd9-f8d2-4dc4-9abb-c6aaab2e78a0
+# export SPARC_ORGANISATION_INT_ID=367
 # export SPARC_ANNOTATION_TEAM_ID=N:team:031b434c-41ab-4ecf-92a9-050fc1b3211a
 
 PENNSIEVE_API_ENDPOINT = os.environ.get('PENNSIEVE_API_ENDPOINT', PENNSIEVE_API_PRODUCTION)
 
 SPARC_ORGANISATION_ID = os.environ.get('SPARC_ORGANISATION_ID')
+SPARC_ORGANISATION_INT_ID = os.environ.get('SPARC_ORGANISATION_INT_ID')
 SPARC_ANNOTATION_TEAM_ID = os.environ.get('SPARC_ANNOTATION_TEAM_ID')
 
 #===============================================================================
@@ -65,8 +67,12 @@ def query(url) -> Any:
 #===============================================================================
 
 def get_annotation_team(key: str) -> Optional[list[str]]:
-    if SPARC_ORGANISATION_ID is None or SPARC_ANNOTATION_TEAM_ID is None:
+    if SPARC_ORGANISATION_ID is None or SPARC_ORGANISATION_INT_ID is None or SPARC_ANNOTATION_TEAM_ID is None:
         settings['LOGGER'].warning('Pennsieve IDs of SPARC and MAP Annotation Team are not defined')
+    try:
+        switch_organization = query(f'{PENNSIEVE_API_ENDPOINT}/session/switch-organization?organization_id=${SPARC_ORGANISATION_INT_ID}&api_key=${key}')
+    except Exception as e:
+        settings['LOGGER'].warning(f"Failed to switch organization: {e}")
     team_query = query(f'{PENNSIEVE_API_ENDPOINT}/organizations/{SPARC_ORGANISATION_ID}/teams/{SPARC_ANNOTATION_TEAM_ID}/members?api_key={key}')
     if 'error' not in team_query:
         return [id for member in team_query if (id := member.get('id')) is not None]

--- a/mapserver/pennsieve.py
+++ b/mapserver/pennsieve.py
@@ -52,9 +52,9 @@ SPARC_ANNOTATION_TEAM_ID = os.environ.get('SPARC_ANNOTATION_TEAM_ID')
 
 #===============================================================================
 
-def query(url) -> Any:
+def query(url, method: Optional[str]='GET') -> Any:
     headers = {"accept": "*/*"}
-    response = requests.get(url, headers=headers)
+    response = requests.request(method, url, headers=headers)
     if response.status_code == 200:
         try:
             return json.loads(response.text)
@@ -70,7 +70,7 @@ def get_annotation_team(key: str) -> Optional[list[str]]:
     if SPARC_ORGANISATION_ID is None or SPARC_ORGANISATION_INT_ID is None or SPARC_ANNOTATION_TEAM_ID is None:
         settings['LOGGER'].warning('Pennsieve IDs of SPARC and MAP Annotation Team are not defined')
     try:
-        switch_organization = query(f'{PENNSIEVE_API_ENDPOINT}/session/switch-organization?organization_id=${SPARC_ORGANISATION_INT_ID}&api_key=${key}')
+        switch_organization = query(f'{PENNSIEVE_API_ENDPOINT}/session/switch-organization?organization_id={SPARC_ORGANISATION_INT_ID}&api_key={key}', 'PUT')
     except Exception as e:
         settings['LOGGER'].warning(f"Failed to switch organization: {e}")
     team_query = query(f'{PENNSIEVE_API_ENDPOINT}/organizations/{SPARC_ORGANISATION_ID}/teams/{SPARC_ANNOTATION_TEAM_ID}/members?api_key={key}')


### PR DESCRIPTION
The changes will implement a similar thing as the portal here - https://github.com/nih-sparc/sparc-app-2/blob/main/pages/user/profile/index.vue#L480

The new query is going to force an update of the pennsive session, which should make sure the map viewer annotator will not be affected when the opened organization is changed.

The query response will look like this:
`{'id': 'N:user:edbd64a2-3f75-4875-b58a-85f3bdb8be70', 'email': 'jyu748@aucklanduni.ac.nz', 'firstName': 'David', 'middleInitial': 'J', 'lastName': 'Yu', 'degree': None, 'credential': '', 'color': '#F45D01', 'url': '', 'authyId': 0, 'isSuperAdmin': False, 'isIntegrationUser': False, 'createdAt': '2024-02-07T20:59:15.812461Z', 'updatedAt': '2025-02-06T21:50:05.444665Z', 'preferredOrganization': 'N:organization:618e8dd9-f8d2-4dc4-9abb-c6aaab2e78a0', 'orcid': {'name': 'David', 'orcid': '0009-0000-6865-1502', 'scope': ['/read-limited', '/activities/update']}, 'pennsieveTermsOfService': {'version': '20210710000000'}, 'customTermsOfService': [], 'isOwner': None, 'storage': None, 'role': None, 'isPublisher': None, 'intId': 1660}`