### PR TITLE
Add required competency queries to queries.yaml.

### DIFF
--- a/mapserver/competency/data/queries.yaml
+++ b/mapserver/competency/data/queries.yaml
@@ -60,7 +60,7 @@ queries:
         type: string
 
   - id: 3
-    label: Neuron populations with an evidence
+    label: Neuron populations supported by evidence
     sql: >
       SELECT DISTINCT term_id AS path_id, source_id
       FROM feature_evidence
@@ -89,7 +89,7 @@ queries:
         type: string
 
   - id: 4
-    label: Evidences for a neuron population and a species
+    label: Evidence for a neuron population and a species
     sql: >
       SELECT DISTINCT fe.evidence_id, fe.source_id
       FROM feature_evidence fe
@@ -123,7 +123,7 @@ queries:
         type: string
 
   - id: 5
-    label: Neuron populations connecting two locations
+    label: Neuron populations connecting two anatomical locations
     sql: >
       WITH
       RECURSIVE
@@ -220,7 +220,7 @@ queries:
         type: string
 
   - id: 6
-    label: Parasympathetic neuron populations connecting two locations
+    label: Parasympathetic neuron populations that connect two locations
     sql: >
       WITH
       RECURSIVE
@@ -325,7 +325,7 @@ queries:
         type: string
 
   - id: 7
-    label: Sympathetic neuron populations connecting two locations
+    label: Sympathetic neuron populations that connect two locations
     sql: >
       WITH
       RECURSIVE
@@ -463,7 +463,7 @@ queries:
         type: string
 
   - id: 9
-    label: Nerves terminating at a location
+    label: Nerves that terminate at a location
     sql: >
       SELECT DISTINCT fnerve.source_id, fnerve.feature_id AS nerve_id, ft.label
       FROM path_edges pe
@@ -570,7 +570,7 @@ queries:
         type: string
 
   - id: 11
-    label: Nerves related to a specific neuron population
+    label: Nerves associated to a specific neuron population
     sql: >
       SELECT ft.source_id, ft.term_id as nerve_id, f.label
       FROM feature_types ft 
@@ -604,7 +604,7 @@ queries:
         type: string
 
   - id: 12
-    label: All nerves available and relate them to neuron population
+    label: All available nerves and their corresponding neuron populations
     sql: >
       SELECT ft.source_id, ft.term_id as nerve_id, f.label, pnf.path_id
       FROM feature_types ft 
@@ -637,7 +637,7 @@ queries:
         type: string
 
   - id: 13
-    label: Nodes as the target of a nerve including those in the forward connection
+    label: Nodes targeted by a nerve, including those in the forward connections
     sql: >
       WITH RECURSIVE 
       path_routes AS (
@@ -719,7 +719,7 @@ queries:
         type: string
 
   - id: 14
-    label: Nodes as the origin of a nerve including those in the forward connection
+    label: Nodes serving as the origin of a nerve, including those in the forward connections
     sql: >
       WITH RECURSIVE 
       path_routes AS (
@@ -804,7 +804,7 @@ queries:
         type: string
 
   - id: 15
-    label: Nodes as the origin and destination of a nerve (regarding paths only)
+    label: Nodes serving as the origin or destination of a nerve (considering paths only)
     sql: >
       SELECT DISTINCT
         pnt.source_id,
@@ -852,7 +852,7 @@ queries:
         type: string
   
   - id: 16
-    label: Different neuron populations between species
+    label: Differences in neuron populations between species
     sql: >
       SELECT source_id, taxon_id, path_id
       FROM path_taxons
@@ -891,7 +891,7 @@ queries:
         type: string
 
   - id: 17
-    label: Different neuron populations and evidences between species
+    label: Different neuron populations and their evidences between species
     sql: >
       SELECT pt.source_id, pt.taxon_id, pt.path_id, fe.evidence_id
       FROM path_taxons pt
@@ -945,7 +945,7 @@ queries:
         type: string
 
   - id: 18
-    label: Parasympathetic forward connection, soma source, axon-terminal target, and route related to a location
+    label: Parasympathetic forward connections with soma as source, axon-terminal as target, and routes related to a location
     sql: >
       WITH RECURSIVE
         para_pre AS (
@@ -1057,7 +1057,7 @@ queries:
         type: list
 
   - id: 19
-    label: Sympathetic forward connection, soma source, axon-terminal target, and route related to a location
+    label: Sympathetic forward connections with soma as source, axon-terminal as target, and routes related to a location
     sql: >
       WITH RECURSIVE
         sym_pre AS (
@@ -1170,7 +1170,7 @@ queries:
         type: list
 
   - id: 20
-    label: Anatomical structure might be affected by perturbation at a location
+    label: Anatomical structures that might be affected by perturbation at a location
     sql: >
       WITH selected_paths AS (
         SELECT DISTINCT path_id, source_id, node_id 
@@ -1220,7 +1220,7 @@ queries:
         type: string
 
   - id: 21
-    label: Downstream or upstream anatomical structure as axon_terminal might be affected by perturbation at a location
+    label: Anatomical structures as axon terminals that might be affected by perturbation at a location
     sql: >
       WITH RECURSIVE
         connected_paths AS (
@@ -1281,7 +1281,7 @@ queries:
         type: string
 
   - id: 22
-    label: Neuron populations that share at list a nerve with another neuron population
+    label: Neuron populations that share at least one nerve with another neuron population
     sql: >
       SELECT DISTINCT pnt_1.source_id, pnt_1.path_id
       FROM path_node_types pnt_0 
@@ -1312,7 +1312,7 @@ queries:
         type: string
 
   - id: 23
-    label: Neuron populations that share at list an edge with another neuron population
+    label: Neuron populations that share at least one edge with another neuron population
     sql: >
       SELECT DISTINCT pe_1.source_id, pe_1.path_id
       FROM path_edges pe_0 

--- a/mapserver/competency/data/queries.yaml
+++ b/mapserver/competency/data/queries.yaml
@@ -58,3 +58,1285 @@ queries:
       - key: axon_terminal
         label: Axon terminal
         type: string
+
+  - id: 3
+    label: Neuron populations with an evidence
+    sql: >
+      SELECT DISTINCT term_id AS path_id, source_id
+      FROM feature_evidence
+      WHERE %CONDITIONS%
+    parameters:
+      - id: evidence_id
+        column: evidence_id
+        label: Evidence from specific papers
+        type: string
+        multiple: true
+      - id: source_id
+        column: source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: path_id
+        label: Neuron population
+        type: string
+
+  - id: 4
+    label: Evidences for a neuron population and a species
+    sql: >
+      SELECT DISTINCT fe.evidence_id, fe.source_id
+      FROM feature_evidence fe
+      JOIN path_taxons pt 
+      ON pt.path_id = fe.term_id AND pt.source_id = fe.source_id
+      WHERE %CONDITIONS%
+    parameters:
+      - id: path_id
+        column: pt.path_id
+        label: Neuron population
+        type: string
+      - id: taxon_id
+        column: pt.taxon_id
+        label: Species
+        type: string  
+      - id: source_id
+        column: pt.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: evidence_id
+        label: Evidence from specific papers
+        type: string
+
+  - id: 5
+    label: Neuron populations connecting two locations
+    sql: >
+      WITH
+      RECURSIVE
+        path_fc AS (
+        SELECT
+          source_id,
+          path_id,
+          forward_path_id,
+          path_id || ' > ' || forward_path_id AS connected_paths
+        FROM path_forward_connections
+        UNION ALL
+        SELECT
+          pfc.source_id,
+          pfc.path_id,
+          pf.forward_path_id,
+          pfc.path_id || ' > ' || pf.connected_paths AS connected_paths
+        FROM path_forward_connections pfc JOIN path_fc pf
+          ON pfc.source_id = pf.source_id
+          AND pfc.forward_path_id = pf.path_id
+        WHERE pf.connected_paths NOT LIKE '%' || pfc.forward_path_id || '%'
+        ),
+        path_fc_nodes AS(
+        SELECT 
+          pfc.*, 
+          pnfp.node_id AS path_node_id, 
+          pnfp.feature_id AS path_feature_id, 
+          pntp.type_id AS path_type_id, 
+          pnff.node_id AS forward_path_node_id, 
+          pnff.feature_id AS forward_path_feature_id, 
+          pntf.type_id AS forward_path_type_id
+        FROM path_fc pfc JOIN path_node_features pnfp ON pfc.source_id = pnfp.source_id AND pfc.path_id = pnfp.path_id
+                         JOIN path_node_features pnff ON pfc.source_id = pnff.source_id AND pfc.forward_path_id = pnff.path_id
+                         JOIN path_node_types pntp ON pnfp.source_id = pntp.source_id AND pnfp.path_id = pntp.path_id AND pnfp.node_id = pntp.node_id
+                         JOIN path_node_types pntf ON pnff.source_id = pntf.source_id AND pnff.path_id = pntf.path_id AND pnff.node_id = pntf.node_id
+        )
+      SELECT DISTINCT 
+        pfn_0.path_node_id AS soma,
+        pfn_0.path_id AS path_start_0, 
+        pfn_0.forward_path_id AS path_destination_0,
+        pfn_0.connected_paths AS connected_paths_0,
+        pfn_1.path_id AS path_start_1, 
+        pfn_1.forward_path_id AS path_destination_1,
+        pfn_1.connected_paths AS connected_paths_1,
+        pfn_1.source_id
+      FROM path_fc_nodes pfn_0 
+        JOIN path_fc_nodes pfn_1 
+          ON pfn_0.source_id = pfn_1.source_id AND pfn_0.path_node_id = pfn_1.path_node_id
+      WHERE pfn_0.path_type_id = 'ilxtr:hasSomaLocatedIn' AND pfn_1.path_type_id = 'ilxtr:hasSomaLocatedIn'
+        AND %CONDITIONS%
+    parameters:
+      - id: feature_id_0
+        column: pfn_0.forward_path_feature_id
+        label: Anatomical terms for locations 0
+        type: string
+        multiple: true
+      - id: feature_id_1
+        column: pfn_1.forward_path_feature_id
+        label: Anatomical terms for locations 1
+        type: string
+        multiple: true
+      - id: source_id
+        column: pfn_0.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: soma
+        label: Soma connecting locations
+        type: string
+      - key: path_start_0
+        label: Location_0 neuron population start
+        type: string
+      - key: path_destination_0
+        label: Location_0 neuron population destination
+        type: string
+      - key: connected_paths_0
+        label: Location_0 neuron population path
+        type: string
+      - key: path_start_1
+        label: Location_1 neuron population start
+        type: string
+      - key: path_destination_1
+        label: Location_1 neuron population destination
+        type: string
+      - key: connected_paths_1
+        label: Location_1 neuron population path
+        type: string
+
+  - id: 6
+    label: Parasympathetic neuron populations connecting two locations
+    sql: >
+      WITH
+      RECURSIVE
+      path_fc AS (
+      SELECT
+        source_id,
+        path_id,
+        forward_path_id,
+        path_id || ' > ' || forward_path_id AS connected_paths
+      FROM path_forward_connections
+      UNION ALL
+      SELECT
+        pfc.source_id,
+        pfc.path_id,
+        pf.forward_path_id,
+        pfc.path_id || ' > ' || pf.connected_paths AS connected_paths
+      FROM path_forward_connections pfc JOIN path_fc pf
+        ON pfc.source_id = pf.source_id
+        AND pfc.forward_path_id = pf.path_id
+      WHERE pf.connected_paths NOT LIKE '%' || pfc.forward_path_id || '%'
+      ),
+      path_fc_nodes AS(
+      SELECT 
+        pfc.*, 
+        pnfp.node_id AS path_node_id, 
+        pnfp.feature_id AS path_feature_id, 
+        pntp.type_id AS path_type_id, 
+        pnp.phenotype AS path_phenotype,
+        pnff.node_id AS forward_path_node_id, 
+        pnff.feature_id AS forward_path_feature_id, 
+        pntf.type_id AS forward_path_type_id,
+        pnf.phenotype AS forward_path_phenotype
+      FROM path_fc pfc JOIN path_node_features pnfp ON pfc.source_id = pnfp.source_id AND pfc.path_id = pnfp.path_id
+              JOIN path_node_features pnff ON pfc.source_id = pnff.source_id AND pfc.forward_path_id = pnff.path_id
+              JOIN path_node_types pntp ON pnfp.source_id = pntp.source_id AND pnfp.path_id = pntp.path_id AND pnfp.node_id = pntp.node_id
+              JOIN path_node_types pntf ON pnff.source_id = pntf.source_id AND pnff.path_id = pntf.path_id AND pnff.node_id = pntf.node_id
+              JOIN path_phenotypes pnp ON pnp.source_id = pnfp.source_id AND pnp.path_id = pnfp.path_id
+              JOIN path_phenotypes pnf ON pnf.source_id = pnff.source_id AND pnf.path_id = pnff.path_id
+      )
+      SELECT DISTINCT 
+      pfn_0.path_node_id AS soma,
+      pfn_0.path_id AS path_start_0, 
+      pfn_0.forward_path_id AS path_destination_0,
+      pfn_0.connected_paths AS connected_paths_0,
+      pfn_1.path_id AS path_start_1, 
+      pfn_1.forward_path_id AS path_destination_1,
+      pfn_1.connected_paths AS connected_paths_1,
+      pfn_1.source_id
+      FROM path_fc_nodes pfn_0 
+      JOIN path_fc_nodes pfn_1 
+        ON pfn_0.source_id = pfn_1.source_id AND pfn_0.path_node_id = pfn_1.path_node_id
+      WHERE pfn_0.path_type_id = 'ilxtr:hasSomaLocatedIn' AND pfn_1.path_type_id = 'ilxtr:hasSomaLocatedIn'
+        AND pfn_0.path_phenotype IN ('ilxtr:ParasympatheticPhenotype', 'ilxtr:neuron-phenotype-para-pre', 'ilxtr:neuron-phenotype-para-post')
+        AND pfn_0.forward_path_phenotype IN ('ilxtr:ParasympatheticPhenotype', 'ilxtr:neuron-phenotype-para-pre', 'ilxtr:neuron-phenotype-para-post')
+        AND pfn_1.path_phenotype IN ('ilxtr:ParasympatheticPhenotype', 'ilxtr:neuron-phenotype-para-pre', 'ilxtr:neuron-phenotype-para-post')
+        AND pfn_1.forward_path_phenotype IN ('ilxtr:ParasympatheticPhenotype', 'ilxtr:neuron-phenotype-para-pre', 'ilxtr:neuron-phenotype-para-post')
+        AND %CONDITIONS%
+    parameters:
+      - id: feature_id_0
+        column: pfn_0.forward_path_feature_id
+        label: Anatomical terms for locations 0
+        type: string
+        multiple: true
+      - id: feature_id_1
+        column: pfn_1.forward_path_feature_id
+        label: Anatomical terms for locations 1
+        type: string
+        multiple: true
+      - id: source_id
+        column: pfn_0.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: soma
+        label: Soma connecting locations
+        type: string
+      - key: path_start_0
+        label: Location_0 neuron population start
+        type: string
+      - key: path_destination_0
+        label: Location_0 neuron population destination
+        type: string
+      - key: connected_paths_0
+        label: Location_0 neuron population path
+        type: string
+      - key: path_start_1
+        label: Location_1 neuron population start
+        type: string
+      - key: path_destination_1
+        label: Location_1 neuron population destination
+        type: string
+      - key: connected_paths_1
+        label: Location_1 neuron population path
+        type: string
+
+  - id: 7
+    label: Sympathetic neuron populations connecting two locations
+    sql: >
+      WITH
+      RECURSIVE
+      path_fc AS (
+      SELECT
+        source_id,
+        path_id,
+        forward_path_id,
+        path_id || ' > ' || forward_path_id AS connected_paths
+      FROM path_forward_connections
+      UNION ALL
+      SELECT
+        pfc.source_id,
+        pfc.path_id,
+        pf.forward_path_id,
+        pfc.path_id || ' > ' || pf.connected_paths AS connected_paths
+      FROM path_forward_connections pfc JOIN path_fc pf
+        ON pfc.source_id = pf.source_id
+        AND pfc.forward_path_id = pf.path_id
+      WHERE pf.connected_paths NOT LIKE '%' || pfc.forward_path_id || '%'
+      ),
+      path_fc_nodes AS(
+      SELECT 
+        pfc.*, 
+        pnfp.node_id AS path_node_id, 
+        pnfp.feature_id AS path_feature_id, 
+        pntp.type_id AS path_type_id, 
+        pnp.phenotype AS path_phenotype,
+        pnff.node_id AS forward_path_node_id, 
+        pnff.feature_id AS forward_path_feature_id, 
+        pntf.type_id AS forward_path_type_id,
+        pnf.phenotype AS forward_path_phenotype
+      FROM path_fc pfc JOIN path_node_features pnfp ON pfc.source_id = pnfp.source_id AND pfc.path_id = pnfp.path_id
+              JOIN path_node_features pnff ON pfc.source_id = pnff.source_id AND pfc.forward_path_id = pnff.path_id
+              JOIN path_node_types pntp ON pnfp.source_id = pntp.source_id AND pnfp.path_id = pntp.path_id AND pnfp.node_id = pntp.node_id
+              JOIN path_node_types pntf ON pnff.source_id = pntf.source_id AND pnff.path_id = pntf.path_id AND pnff.node_id = pntf.node_id
+              JOIN path_phenotypes pnp ON pnp.source_id = pnfp.source_id AND pnp.path_id = pnfp.path_id
+              JOIN path_phenotypes pnf ON pnf.source_id = pnff.source_id AND pnf.path_id = pnff.path_id
+      )
+      SELECT DISTINCT 
+      pfn_0.path_node_id AS soma,
+      pfn_0.path_id AS path_start_0, 
+      pfn_0.forward_path_id AS path_destination_0,
+      pfn_0.connected_paths AS connected_paths_0,
+      pfn_1.path_id AS path_start_1, 
+      pfn_1.forward_path_id AS path_destination_1,
+      pfn_1.connected_paths AS connected_paths_1,
+      pfn_1.source_id
+      FROM path_fc_nodes pfn_0 
+      JOIN path_fc_nodes pfn_1 
+        ON pfn_0.source_id = pfn_1.source_id AND pfn_0.path_node_id = pfn_1.path_node_id
+      WHERE pfn_0.path_type_id = 'ilxtr:hasSomaLocatedIn' AND pfn_1.path_type_id = 'ilxtr:hasSomaLocatedIn'
+        AND pfn_0.path_phenotype IN ('ilxtr:SympatheticPhenotype', 'ilxtr:neuron-phenotype-sym-pre', 'ilxtr:neuron-phenotype-sym-post')
+        AND pfn_0.forward_path_phenotype IN ('ilxtr:SympatheticPhenotype', 'ilxtr:neuron-phenotype-sym-pre', 'ilxtr:neuron-phenotype-sym-post')
+        AND pfn_1.path_phenotype IN ('ilxtr:SympatheticPhenotype', 'ilxtr:neuron-phenotype-sym-pre', 'ilxtr:neuron-phenotype-sym-post')
+        AND pfn_1.forward_path_phenotype IN ('ilxtr:SympatheticPhenotype', 'ilxtr:neuron-phenotype-sym-pre', 'ilxtr:neuron-phenotype-sym-post')
+        AND %CONDITIONS%
+    parameters:
+      - id: feature_id_0
+        column: pfn_0.forward_path_feature_id
+        label: Anatomical terms for locations 0
+        type: string
+        multiple: true
+      - id: feature_id_1
+        column: pfn_1.forward_path_feature_id
+        label: Anatomical terms for locations 1
+        type: string
+        multiple: true
+      - id: source_id
+        column: pfn_0.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: soma
+        label: Soma connecting locations
+        type: string
+      - key: path_start_0
+        label: Location_0 neuron population start
+        type: string
+      - key: path_destination_0
+        label: Location_0 neuron population destination
+        type: string
+      - key: connected_paths_0
+        label: Location_0 neuron population path
+        type: string
+      - key: path_start_1
+        label: Location_1 neuron population start
+        type: string
+      - key: path_destination_1
+        label: Location_1 neuron population destination
+        type: string
+      - key: connected_paths_1
+        label: Location_1 neuron population path
+        type: string
+
+  - id: 8
+    label: Motoric neuron populations associated with a location
+    sql: >
+      SELECT pp.path_id, pp.source_id
+      FROM path_phenotypes pp
+      JOIN path_node_types pnt ON pp.path_id = pnt.path_id AND pp.source_id = pnt.source_id
+      JOIN path_node_features pnf ON pnt.path_id = pnf.path_id AND pnt.source_id = pnf.source_id AND pnt.node_id = pnf.node_id
+      WHERE pp.phenotype = 'ilxtr:MotorPhenotype'
+        AND pnt.type_id = 'ilxtr:hasSomaLocatedIn'
+        AND %CONDITIONS%
+    parameters:
+      - id: feature_id
+        column: pnf.feature_id
+        label: Anatomical terms for locations
+        type: string
+        multiple: true
+      - id: source_id
+        column: pnf.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: path_id
+        label: Neuron population
+        type: string
+
+  - id: 9
+    label: Nerves terminating at a location
+    sql: >
+      SELECT DISTINCT fnerve.source_id, fnerve.feature_id AS nerve_id, ft.label
+      FROM path_edges pe
+      JOIN path_node_types tnerve ON pe.source_id = tnerve.source_id AND pe.path_id = tnerve.path_id  AND pe.node_0 = tnerve.node_id
+      JOIN path_node_features fnerve ON pe.source_id = fnerve.source_id AND pe.path_id = fnerve.path_id AND pe.node_0 = fnerve.node_id
+      JOIN path_node_features fdest ON pe.source_id = fdest.source_id AND pe.path_id = fdest.path_id AND pe.node_1 = fdest.node_id
+      JOIN feature_terms ft ON fnerve.source_id = ft.source_id AND fnerve.feature_id = ft.term_id
+      WHERE tnerve.type_id = 'nerve'
+        AND %CONDITIONS%
+    parameters:
+      - id: feature_id
+        column: fdest.feature_id
+        label: Anatomical terms for locations
+        type: string
+        multiple: true
+      - id: source_id
+        column: fdest.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: nerve_id
+        label: Nerve term id
+        type: string
+      - key: label
+        label: Nerve term label
+        type: string
+
+  - id: 10
+    label: Nerves projecting (directly or indirectly) to a location
+    sql: >
+      WITH
+      RECURSIVE
+        path_fc AS (
+          SELECT
+          source_id,
+          path_id,
+          forward_path_id,
+          path_id || ' > ' || forward_path_id AS connected_paths
+        FROM path_forward_connections
+        UNION ALL
+          SELECT
+          pfc.source_id,
+          pfc.path_id,
+          pf.forward_path_id,
+          pfc.path_id || ' > ' || pf.connected_paths AS connected_paths
+        FROM path_forward_connections pfc JOIN path_fc pf
+          ON pfc.source_id = pf.source_id
+          AND pfc.forward_path_id = pf.path_id
+        WHERE pf.connected_paths NOT LIKE '%' || pfc.forward_path_id || '%'
+        ),
+        path_fc_connected AS(
+        SELECT pfc.source_id, pfc.connected_paths, pfc.path_id, pnf.node_id, pnf.feature_id, pnt.type_id
+        FROM path_fc pfc JOIN path_node_features pnf ON pfc.source_id = pnf.source_id AND pfc.path_id = pnf.path_id
+                        JOIN path_node_types pnt ON pnf.source_id = pnt.source_id AND pnf.path_id = pnt.path_id AND pnf.node_id = pnt.node_id
+        UNION
+        SELECT pfc.source_id, pfc.connected_paths, pfc.forward_path_id, pnf.node_id, pnf.feature_id, pnt.type_id
+        FROM path_fc pfc JOIN path_node_features pnf ON pfc.source_id = pnf.source_id AND pfc.forward_path_id = pnf.path_id
+                        JOIN path_node_types pnt ON pnf.source_id = pnt.source_id AND pnf.path_id = pnt.path_id AND pnf.node_id = pnt.node_id
+        UNION 
+        SELECT pn.source_id, pn.path_id, pn.path_id, pnf.node_id, pnf.feature_id, pnt.type_id
+        FROM path_nodes pn JOIN path_node_features pnf ON pn.source_id = pnf.source_id AND pn.path_id = pnf.path_id
+                          JOIN path_node_types pnt ON pnf.source_id = pnt.source_id AND pnf.path_id = pnt.path_id AND pnf.node_id = pnt.node_id
+        WHERE pn.path_id NOT IN (SELECT path_id FROM path_fc UNION SELECT forward_path_id FROM path_fc)
+        )
+
+      SELECT DISTINCT pfc_0.source_id, pfc_0.feature_id AS nerve_id, ft.label
+      FROM path_fc_connected pfc_0
+      JOIN path_fc_connected pfc_1 ON pfc_0.connected_paths = pfc_1.connected_paths AND pfc_0.source_id = pfc_1.source_id
+      JOIN feature_terms ft ON pfc_0.source_id = ft.source_id AND pfc_0.feature_id = ft.term_id
+      WHERE pfc_0.type_id = 'nerve'
+        AND %CONDITIONS%
+    parameters:
+      - id: feature_id
+        column: pfc_1.feature_id
+        label: Anatomical terms for locations
+        type: string
+        multiple: true
+      - id: source_id
+        column: pfc_1.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: nerve_id
+        label: Nerve term id
+        type: string
+      - key: label
+        label: Nerve term label
+        type: string
+
+  - id: 11
+    label: Nerves related to a specific neuron population
+    sql: >
+      SELECT ft.source_id, ft.term_id as nerve_id, f.label
+      FROM feature_types ft 
+      JOIN feature_terms f ON ft.source_id = f.source_id AND ft.term_id = f.term_id
+      JOIN path_node_features pnf ON ft.source_id = pnf.source_id AND ft.term_id = pnf.feature_id
+      WHERE ft.type_id = 'nerve' 
+      AND %CONDITIONS%
+    parameters:
+      - id: path_id
+        column: pnf.path_id
+        label: Neuron population
+        type: string
+      - id: source_id
+        column: pnf.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: nerve_id
+        label: Nerve term id
+        type: string
+      - key: label
+        label: Nerve term label
+        type: string
+
+  - id: 12
+    label: All nerves available and relate them to neuron population
+    sql: >
+      SELECT ft.source_id, ft.term_id as nerve_id, f.label, pnf.path_id
+      FROM feature_types ft 
+      JOIN feature_terms f ON ft.source_id = f.source_id AND ft.term_id = f.term_id
+      JOIN path_node_features pnf ON ft.source_id = pnf.source_id AND ft.term_id = pnf.feature_id
+      WHERE ft.type_id = 'nerve' 
+      AND %CONDITIONS%
+    parameters:
+      - id: source_id
+        column: ft.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: nerve_id
+        label: Nerve term id
+        type: string
+      - key: label
+        label: Nerve term label
+        type: string
+      - key: path_id
+        label: Neuron population
+        type: string
+
+  - id: 13
+    label: Nodes as the target of a nerve including those in the forward connection
+    sql: >
+      WITH RECURSIVE 
+      path_routes AS (
+        SELECT DISTINCT
+          ARRAY_REMOVE(ARRAY[pn.path_id, p.forward_path_id], NULL) AS path_ids,
+          pn.path_id AS start_path_id,
+          p.forward_path_id AS destination_path_id,
+          pn.source_id
+        FROM path_node_features pn
+        LEFT JOIN path_forward_connections p ON p.path_id = pn.path_id AND p.source_id = pn.source_id
+        WHERE %CONDITIONS%
+        UNION ALL
+        SELECT 
+          r.path_ids || t.forward_path_id,
+          r.start_path_id,
+          t.forward_path_id,
+          r.source_id
+        FROM path_routes r
+        JOIN path_forward_connections t ON r.destination_path_id = t.path_id AND r.source_id = t.source_id
+        WHERE NOT r.path_ids @> ARRAY[t.forward_path_id]
+      ),
+      path_route_edges AS (
+        SELECT DISTINCT p.path_ids, p.path_id, p.source_id, pe.node_0, pe.node_1
+        FROM (
+          SELECT DISTINCT r.path_ids, unnest(r.path_ids) as path_id, r.source_id
+          FROM path_routes r
+        ) AS p
+        JOIN path_edges pe ON p.path_id = pe.path_id AND p.source_id = pe.source_id
+      ),
+      node_routes AS (
+        SELECT DISTINCT
+          p.path_ids,
+          p.source_id,
+          p.path_id,
+          ARRAY[p.node_0, p.node_1] AS node_ids,
+          p.node_0 AS start_node_id, 
+          p.node_1 AS destination_node_id
+        FROM path_route_edges p
+        JOIN path_node_features pn ON p.node_0 = pn.node_id AND p.path_id = pn.path_id AND p.source_id = pn.source_id
+        WHERE %CONDITIONS%
+        
+        UNION ALL
+
+        SELECT
+          r.path_ids,
+          r.source_id,
+          t.path_id,
+          r.node_ids || t.node_1,
+          r.start_node_id, 
+          t.node_1
+        FROM node_routes r
+        JOIN path_route_edges t ON r.destination_node_id = t.node_0 AND r.path_ids = t.path_ids AND r.source_id = t.source_id
+        WHERE NOT r.node_ids @> ARRAY[t.node_1]
+      )
+      SELECT DISTINCT pnt.node_id as destination, pnt.source_id
+        FROM node_routes nr JOIN path_node_types pnt ON nr.destination_node_id = pnt.node_id AND nr.path_id = pnt.path_id AND nr.source_id = pnt.source_id 
+        WHERE pnt.type_id IN ('ilxtr:hasAxonPresynapticElementIn', 'ilxtr:hasAxonSensorySubcellularElementIn') 
+    parameters:
+      - id: feature_id
+        column: pn.feature_id
+        label: Anatomical terms for nerves
+        type: string
+        multiple: true
+      - id: source_id
+        column: pn.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: destination
+        label: Node as destination
+        type: string
+
+  - id: 14
+    label: Nodes as the origin of a nerve including those in the forward connection
+    sql: >
+      WITH RECURSIVE 
+      path_routes AS (
+        SELECT DISTINCT
+          ARRAY_REMOVE(ARRAY[p.path_id, pn.path_id], NULL) AS path_ids,
+          p.path_id AS start_path_id,
+          pn.path_id AS destination_path_id,
+        pn.source_id
+        FROM path_node_features pn
+        LEFT JOIN path_forward_connections p ON p.forward_path_id = pn.path_id AND p.source_id = pn.source_id
+        WHERE %CONDITIONS%
+
+        UNION ALL
+
+        SELECT 
+          t.path_id || r.path_ids,
+          t.path_id,
+          r.destination_path_id,
+        r.source_id
+        FROM path_routes r
+        JOIN path_forward_connections t ON r.start_path_id = t.path_id AND r.source_id = t.source_id
+        WHERE NOT r.path_ids @> ARRAY[t.path_id]
+      ),
+      path_route_edges AS (
+        SELECT DISTINCT p.path_ids, p.path_id, p.source_id, pe.node_0, pe.node_1
+        FROM (
+        SELECT DISTINCT r.path_ids, unnest(r.path_ids) as path_id, r.source_id
+        FROM path_routes r
+        ) AS p
+        JOIN path_edges pe ON p.path_id = pe.path_id AND p.source_id = pe.source_id
+      ),
+      node_routes AS (
+        SELECT DISTINCT
+          p.path_ids,
+          p.source_id,
+        p.path_id,
+        ARRAY[p.node_0, p.node_1] AS node_ids,
+        p.node_0 AS start_node_id, 
+        p.node_1 AS destination_node_id
+        FROM path_route_edges p
+        JOIN path_node_features pn ON p.node_1 = pn.node_id AND p.path_id = pn.path_id AND p.source_id = pn.source_id
+        WHERE %CONDITIONS%
+        
+        UNION ALL
+
+        SELECT
+          r.path_ids,
+          r.source_id,
+        t.path_id,
+        t.node_0 || r.node_ids,
+        t.node_0,
+        r.destination_node_id
+        FROM node_routes r
+        JOIN path_route_edges t ON r.start_node_id = t.node_1 AND r.path_ids = t.path_ids AND r.source_id = t.source_id
+        WHERE NOT r.node_ids @> ARRAY[t.node_0]
+      )
+      SELECT DISTINCT pnt.source_id, pnt.node_id as origin
+        FROM node_routes nr
+        JOIN path_node_types pnt ON nr.start_node_id = pnt.node_id AND nr.path_id = pnt.path_id AND nr.source_id = pnt.source_id
+        WHERE pnt.type_id IN ('ilxtr:hasSomaLocatedIn')
+    parameters:
+      - id: feature_id
+        column: pn.feature_id
+        label: Anatomical terms for nerves
+        type: string
+        multiple: true
+      - id: source_id
+        column: pn.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: origin
+        label: Node as origin
+        type: string
+
+  - id: 15
+    label: Nodes as the origin and destination of a nerve (regarding paths only)
+    sql: >
+      SELECT DISTINCT
+        pnt.source_id,
+        pnt.node_id,
+        CASE
+          WHEN pnt.type_id IN ('ilxtr:hasSomaLocatedIn') THEN 'soma'
+        WHEN pnt.type_id IN ('ilxtr:hasAxonSensorySubcellularElementIn', 'ilxtr:hasAxonPresynapticElementIn') THEN 'axon-terminal'
+        END AS type
+      FROM path_node_types as pnt
+      JOIN (
+          SELECT DISTINCT path_id, source_id
+          FROM path_node_features
+          WHERE %CONDITIONS%
+        ) as pt
+        ON pnt.path_id = pt.path_id and pnt.source_id = pt.source_id
+      WHERE pnt.type_id IN (
+        'ilxtr:hasSomaLocatedIn',   -- soma 
+        'ilxtr:hasAxonSensorySubcellularElementIn', 'ilxtr:hasAxonPresynapticElementIn' -- axon-terminal
+        )
+        AND pnt.source_id = pt.source_id
+    parameters:
+      - id: feature_id
+        column: feature_id
+        label: Anatomical terms for nerves
+        type: string
+        multiple: true
+      - id: source_id
+        column: source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: node_id
+        label: Anatomical node
+        type: string
+      - key: type
+        label: Anatomical node type ('soma' or 'axon-terminal')
+        type: string
+  
+  - id: 16
+    label: Different neuron populations between species
+    sql: >
+      SELECT source_id, taxon_id, path_id
+      FROM path_taxons
+      WHERE %CONDITIONS%
+        AND path_id IN (
+          SELECT path_id
+          FROM path_taxons
+          WHERE %CONDITIONS%
+          GROUP BY path_id
+          HAVING COUNT(DISTINCT taxon_id) = 1
+        )
+    parameters:
+      - id: taxon_id
+        column: taxon_id
+        label: taxon terms for species
+        type: string
+        multiple: true
+      - id: source_id
+        column: source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: taxon_id
+        label: Species taxon term
+        type: string
+      - key: path_id
+        label: Neuron population
+        type: string
+
+  - id: 17
+    label: Different neuron populations and evidences between species
+    sql: >
+      SELECT pt.source_id, pt.taxon_id, pt.path_id, fe.evidence_id
+      FROM path_taxons pt
+      JOIN path_node_features pnf ON pt.path_id = pnf.path_id AND pt.source_id = pnf.source_id
+      LEFT JOIN feature_evidence fe ON pt.path_id = fe.term_id AND pt.source_id = fe.source_id
+      WHERE %CONDITION_1%
+        AND pt.path_id IN (
+        SELECT pt.path_id
+        FROM path_taxons pt
+        WHERE %CONDITION_2%
+        GROUP BY pt.path_id
+        HAVING COUNT(DISTINCT pt.taxon_id) = 1
+        )
+        AND %CONDITION_2%
+      ORDER BY fe.evidence_id, pt.taxon_id, pt.path_id
+    parameters:
+      - id: taxon_id
+        column: pt.taxon_id
+        condition: CONDITION_1
+        label: taxon terms for species
+        type: string
+        multiple: true
+      - id: source_id
+        column: pt.source_id
+        condition: CONDITION_1
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+      - id: feature_id
+        column: pnf.feature_id
+        label: Anatomical terms for locations
+        condition: CONDITION_2
+        type: string
+        multiple: true      
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: taxon_id
+        label: Species taxon term
+        type: string
+      - key: path_id
+        label: Neuron population
+        type: string
+      - key: evidence_id
+        label: Evidence from specific papers
+        type: string
+
+  - id: 18
+    label: Parasympathetic forward connection, soma source, axon-terminal target, and route related to a location
+    sql: >
+      WITH RECURSIVE
+        para_pre AS (
+          SELECT DISTINCT p0.path_id, p0.source_id
+          FROM path_phenotypes p0 JOIN path_phenotypes p1 ON p0.path_id = p1.path_id AND p0.source_id = p1.source_id
+          WHERE p0.phenotype = 'ilxtr:ParasympatheticPhenotype'
+            AND p1.phenotype = 'ilxtr:PreGanglionicPhenotype'
+            OR p0.phenotype = 'ilxtr:neuron-phenotype-para-pre'
+        ), 
+        para_post AS (
+          SELECT DISTINCT pf.path_id, pf.source_id
+            FROM path_node_features pf JOIN path_node_types pt ON pf.path_id = pt.path_id AND pf.source_id = pt.source_id
+            WHERE pt.type_id IN ('ilxtr:hasAxonSensorySubcellularElementIn', 'ilxtr:hasAxonPresynapticElementIn')
+              AND %CONDITIONS%
+              AND (pf.path_id, pf.source_id) IN (
+              SELECT DISTINCT p0.path_id, p0.source_id
+              FROM path_phenotypes p0 JOIN path_phenotypes p1 ON p0.path_id = p1.path_id AND p0.source_id = p1.source_id
+              WHERE p0.phenotype = 'ilxtr:ParasympatheticPhenotype'
+                AND p1.phenotype = 'ilxtr:PostGanglionicPhenotype'
+                OR p0.phenotype = 'ilxtr:neuron-phenotype-para-post'
+              )
+        ),
+        para_pre_post AS (
+          SELECT source_id, path_id, forward_path_id
+            FROM path_forward_connections p
+            WHERE p.path_id IN (SELECT path_id FROM para_pre)
+            AND p.forward_path_id IN (SELECT path_id FROM para_post)
+        ),
+        para_edges AS (
+          SELECT p.source_id, p.path_id, p.forward_path_id, p.path_id AS pe_path_id, pe.node_0, pe.node_1
+          FROM para_pre_post p
+          JOIN path_edges pe ON p.source_id = pe.source_id AND p.path_id = pe.path_id
+          UNION ALL
+          SELECT p.source_id, p.path_id, p.forward_path_id, p.forward_path_id, pe.node_0, pe.node_1
+          FROM para_pre_post p
+          JOIN path_edges pe ON p.source_id = pe.source_id AND p.forward_path_id = pe.path_id
+        ),
+        para_routes AS (
+          SELECT 
+            source_id,
+            path_id,
+            forward_path_id,
+            pe_path_id,
+            node_0 AS soma,
+            node_1,
+            ARRAY[node_0, node_1] AS node_ids
+          FROM para_edges p
+          WHERE p.path_id = p.pe_path_id 
+            AND p.node_0 IN (SELECT node_id FROM path_node_types WHERE source_id = p.source_id AND path_id = p.path_id AND type_id = 'ilxtr:hasSomaLocatedIn')
+          UNION ALL
+          SELECT
+            r.source_id,
+            r.path_id,
+            r.forward_path_id,
+            e.pe_path_id,
+            r.soma,
+            e.node_1,
+            r.node_ids || e.node_1
+          FROM para_routes r JOIN para_edges e 
+            ON r.source_id = e.source_id AND r.path_id = e.path_id AND r.forward_path_id = e.forward_path_id AND r.node_1 = e.node_0
+          WHERE NOT r.node_ids @> ARRAY[e.node_1]
+        )
+      SELECT DISTINCT
+        p.source_id,
+        p.path_id,
+        p.forward_path_id,
+        p.soma,
+        p.node_1 AS axon_terminal,
+        p.node_ids
+      FROM para_routes p JOIN path_node_types pnt
+        ON p.source_id = pnt.source_id AND p.pe_path_id = pnt.path_id AND p.node_1 = pnt.node_id AND pnt.type_id IN ('ilxtr:hasAxonSensorySubcellularElementIn', 'ilxtr:hasAxonPresynapticElementIn')
+      JOIN path_node_features pf 
+        ON p.source_id = pf.source_id AND p.pe_path_id = pf.path_id AND p.node_1 = pf.node_id
+      WHERE p.forward_path_id = p.pe_path_id
+        AND %CONDITIONS%
+    parameters:
+      - id: feature_id
+        column: pf.feature_id
+        label: Anatomical terms for locations
+        type: string
+        multiple: true      
+      - id: source_id
+        column: pf.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: path_id
+        label: Neuron population
+        type: string
+      - key: forward_path_id
+        label: Forward neuron population
+        type: string
+      - key: soma
+        label: Soma
+        type: string
+      - key: axon_terminal
+        label: Axon terminal
+        type: string
+      - key: node_ids
+        label: Route from soma to axon terminal
+        type: list
+
+  - id: 19
+    label: Sympathetic forward connection, soma source, axon-terminal target, and route related to a location
+    sql: >
+      WITH RECURSIVE
+        sym_pre AS (
+          SELECT DISTINCT p0.path_id, p0.source_id
+          FROM path_phenotypes p0 JOIN path_phenotypes p1 ON p0.path_id = p1.path_id AND p0.source_id = p1.source_id
+          WHERE p0.phenotype = 'ilxtr:SympatheticPhenotype'
+            AND p1.phenotype = 'ilxtr:PreGanglionicPhenotype'
+            OR p0.phenotype = 'ilxtr:neuron-phenotype-sym-pre'
+        ), 
+        sym_post AS (
+          SELECT DISTINCT pf.path_id, pf.source_id
+            FROM path_node_features pf JOIN path_node_types pt ON pf.path_id = pt.path_id AND pf.source_id = pt.source_id
+            WHERE pt.type_id IN ('ilxtr:hasAxonSensorySubcellularElementIn', 'ilxtr:hasAxonPresynapticElementIn')
+              AND %CONDITIONS%
+              AND (pf.path_id, pf.source_id) IN (
+              SELECT DISTINCT p0.path_id, p0.source_id
+              FROM path_phenotypes p0 JOIN path_phenotypes p1 ON p0.path_id = p1.path_id AND p0.source_id = p1.source_id
+              WHERE p0.phenotype = 'ilxtr:SympatheticPhenotype'
+                AND p1.phenotype = 'ilxtr:PostGanglionicPhenotype'
+                OR p0.phenotype = 'ilxtr:neuron-phenotype-sym-post'
+              )
+        ),
+        sym_pre_post AS (
+          SELECT DISTINCT source_id, path_id, forward_path_id
+            FROM path_forward_connections p
+          WHERE p.path_id IN (SELECT path_id FROM sym_pre)
+            AND p.forward_path_id IN (SELECT path_id FROM sym_post)
+        ),
+        sym_edges AS (
+          SELECT p.source_id, p.path_id, p.forward_path_id, p.path_id AS pe_path_id, pe.node_0, pe.node_1
+          FROM sym_pre_post p
+          JOIN path_edges pe ON p.source_id = pe.source_id AND p.path_id = pe.path_id
+          UNION ALL
+          SELECT p.source_id, p.path_id, p.forward_path_id, p.forward_path_id, pe.node_0, pe.node_1
+          FROM sym_pre_post p
+          JOIN path_edges pe ON p.source_id = pe.source_id AND p.forward_path_id = pe.path_id
+        ),
+        sym_routes AS (
+          SELECT 
+            source_id,
+            path_id,
+            forward_path_id,
+            pe_path_id,
+            node_0 AS soma,
+            node_1,
+            ARRAY[node_0, node_1] AS node_ids
+          FROM sym_edges p
+          WHERE p.path_id = p.pe_path_id 
+            AND p.node_0 IN (SELECT node_id FROM path_node_types WHERE source_id = p.source_id AND path_id = p.path_id AND type_id = 'ilxtr:hasSomaLocatedIn')
+          UNION ALL
+          SELECT
+              r.source_id,
+            r.path_id,
+            r.forward_path_id,
+            e.pe_path_id,
+            r.soma,
+            e.node_1,
+            r.node_ids || e.node_1
+          FROM sym_routes r JOIN sym_edges e 
+            ON r.source_id = e.source_id AND r.path_id = e.path_id AND r.forward_path_id = e.forward_path_id AND r.node_1 = e.node_0
+          WHERE NOT r.node_ids @> ARRAY[e.node_1]
+        )
+      SELECT DISTINCT
+        p.source_id,
+        p.path_id,
+        p.forward_path_id,
+        p.soma,
+        p.node_1 AS axon_terminal,
+        pf.feature_id,
+        p.node_ids
+      FROM sym_routes p JOIN path_node_types pnt
+        ON p.source_id = pnt.source_id AND p.pe_path_id = pnt.path_id AND p.node_1 = pnt.node_id AND pnt.type_id IN ('ilxtr:hasAxonSensorySubcellularElementIn', 'ilxtr:hasAxonPresynapticElementIn')
+      JOIN path_node_features pf 
+        ON p.source_id = pf.source_id AND p.pe_path_id = pf.path_id AND p.node_1 = pf.node_id
+      WHERE p.forward_path_id = p.pe_path_id
+        AND %CONDITIONS%
+    parameters:
+      - id: feature_id
+        column: pf.feature_id
+        label: Anatomical terms for locations
+        type: string
+        multiple: true      
+      - id: source_id
+        column: pf.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: path_id
+        label: Neuron population
+        type: string
+      - key: forward_path_id
+        label: Forward neuron population
+        type: string
+      - key: soma
+        label: Soma
+        type: string
+      - key: axon_terminal
+        label: Axon terminal
+        type: string
+      - key: node_ids
+        label: Route from soma to axon terminal
+        type: list
+
+  - id: 20
+    label: Anatomical structure might be affected by perturbation at a location
+    sql: >
+      WITH selected_paths AS (
+        SELECT DISTINCT path_id, source_id, node_id 
+        FROM path_node_features
+        WHERE %CONDITIONS%
+      )
+      SELECT 
+        sub.source_id, 
+        sub.node_id, 
+        ARRAY_AGG(label ORDER BY POSITION(feature_id IN sub.node_id)) AS label
+      FROM (
+          SELECT DISTINCT
+            node_id, 
+            source_id,
+            feature_id
+          FROM path_node_features
+          WHERE (path_id, source_id) IN (SELECT  path_id, source_id FROM selected_paths)
+          AND node_id NOT IN (SELECT node_id FROM selected_paths)
+        ) AS sub
+        JOIN feature_terms ft
+        ON sub.source_id = ft.source_id AND sub.feature_id = ft.term_id
+      GROUP BY sub.source_id, sub.node_id
+    parameters:
+      - id: feature_id
+        column: feature_id
+        label: Anatomical terms for locations
+        type: string
+        multiple: true      
+      - id: source_id
+        column: source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: node_id
+        label: Anatomical structure
+        type: string
+      - key: label
+        label: Anatomical structure label
+        type: string
+
+  - id: 21
+    label: Downstream or upstream anatomical structure as axon_terminal might be affected by perturbation at a location
+    sql: >
+      WITH RECURSIVE
+        connected_paths AS (
+          SELECT 
+            pe.source_id, 
+            pe.path_id, 
+            ARRAY[node_0, node_1] AS node_ids,
+            pe.node_1 AS dest_node_id
+          FROM path_edges pe JOIN path_node_features pf
+            ON pe.source_id = pf.source_id AND pe.path_id = pf.path_id AND pe.node_0 = pf.node_id
+          WHERE %CONDITIONS%
+          UNION ALL
+          SELECT
+            cp.source_id, 
+            cp.path_id, 
+            cp.node_ids || pe.node_1,
+            pe.node_1
+          FROM connected_paths cp JOIN path_edges pe
+            ON cp.source_id = pe.source_id AND cp.path_id = pe.path_id AND cp.dest_node_id = pe.node_0
+          WHERE NOT cp.node_ids @> ARRAY[pe.node_1]
+        )
+      SELECT p.source_id, p.node_id, ARRAY_AGG(label ORDER BY POSITION(feature_id IN p.node_id)) AS label
+      FROM (
+            SELECT DISTINCT pf.source_id, pf.node_id, pf.feature_id, pf.path_id
+            FROM connected_paths AS cp JOIN path_node_features pf
+            ON cp.source_id = pf.source_id AND cp.path_id = pf.path_id AND cp.dest_node_id = pf.node_id
+          ) AS p
+      JOIN feature_terms ft
+        ON p.source_id = ft.source_id AND p.feature_id = ft.term_id
+      JOIN path_node_types AS pt
+        ON p.source_id = pt.source_id AND p.node_id = pt.node_id AND p.path_id = pt.path_id
+      WHERE pt.type_id IN ('ilxtr:hasAxonSensorySubcellularElementIn', 'ilxtr:hasAxonPresynapticElementIn')
+      GROUP BY p.source_id, p.node_id, p.path_id
+    parameters:
+      - id: feature_id
+        column: pf.feature_id
+        label: Anatomical terms for locations
+        type: string
+        multiple: true      
+      - id: source_id
+        column: pf.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: node_id
+        label: Anatomical structure
+        type: string
+      - key: label
+        label: Anatomical structure label
+        type: string
+
+  - id: 22
+    label: Neuron populations that share at list a nerve with another neuron population
+    sql: >
+      SELECT DISTINCT pnt_1.source_id, pnt_1.path_id
+      FROM path_node_types pnt_0 
+      JOIN path_node_types pnt_1 ON pnt_0.source_id = pnt_1.source_id AND pnt_0.node_id = pnt_1.node_id
+      WHERE pnt_0.type_id = 'nerve'
+        AND pnt_0.path_id <> pnt_1.path_id
+        AND %CONDITIONS%
+    parameters:
+      - id: path_id
+        column: pnt_0.path_id
+        label: Neuron population
+        type: string
+      - id: source_id
+        column: pnt_0.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: path_id
+        label: Neuron population
+        type: string
+
+  - id: 23
+    label: Neuron populations that share at list an edge with another neuron population
+    sql: >
+      SELECT DISTINCT pe_1.source_id, pe_1.path_id
+      FROM path_edges pe_0 
+      JOIN path_edges pe_1 ON pe_0.source_id = pe_1.source_id AND pe_0.node_0 = pe_1.node_0 AND pe_0.node_1 = pe_1.node_1
+      WHERE pe_0.path_id <> pe_1.path_id
+        AND %CONDITIONS%
+    parameters:
+      - id: path_id
+        column: pe_0.path_id
+        label: Neuron population
+        type: string
+      - id: source_id
+        column: pe_0.source_id
+        label: Knowledge source
+        type: string
+        default_msg: the latest source is used
+        default_sql: >
+          select source_id from knowledge_sources where source_id like 'sckan%'
+          order by source_id desc limit 1
+    order: ''
+    results:
+      - key: source_id
+        label: Knowledge source
+        type: string
+      - key: path_id
+        label: Neuron population
+        type: string


### PR DESCRIPTION
#15 
The added queries:
- 3. Neuron populations supported by evidence
- 4. Evidence for a neuron population and a species
- 5. Neuron populations connecting two anatomical locations
- 6. Parasympathetic neuron populations that connect two locations
- 7. Sympathetic neuron populations that connect two locations
- 8. Motoric neuron populations associated with a location
- 9. Nerves that terminate at a location
- 10. Nerves projecting (directly or indirectly) to a location
- 11. Nerves associated to a specific neuron population
- 12. All available nerves and their corresponding neuron populations
- 13. Nodes targeted by a nerve, including those in the forward connections
- 14. Nodes serving as the origin of a nerve, including those in the forward connections
- 15. Nodes serving as the origin or destination of a nerve (considering paths only)
- 16. Differences in neuron populations between species
- 17. Different neuron populations and their evidences between species
- 18. Parasympathetic forward connections with soma as source, axon-terminal as target, and routes related to a location
- 19. Sympathetic forward connections with soma as source, axon-terminal as target, and routes related to a location
- 20. Anatomical structures that might be affected by perturbation at a location
- 21. Anatomical structures as axon terminals that might be affected by perturbation at a location
- 22. Neuron populations that share at least one nerve with another neuron population
- 23. Neuron populations that share at least one edge with another neuron population