### PR TITLE
Add query_24.yaml and query_25.yaml to retrieve neuron populations using nodes or anatomical terms as source, via, and destination.

### DIFF
--- a/mapserver/competency/queries.d/query_24.yaml
+++ b/mapserver/competency/queries.d/query_24.yaml
@@ -51,6 +51,7 @@ queries:
       column: pws.source_id
       label: Knowledge source
       type: string
+      multiple: true
       default_msg: the latest source is used
       default_sql: >
         select source_id from knowledge_sources where source_id like 'sckan%'

--- a/mapserver/competency/queries.d/query_24.yaml
+++ b/mapserver/competency/queries.d/query_24.yaml
@@ -1,0 +1,65 @@
+queries:
+  - id: 24
+    label: Neuron populations that have source, via, and destination nodes
+    sql: >
+      WITH
+        path_with_source AS (
+          SELECT source_id, path_id, node_id AS source_node_id
+        FROM path_node_types
+        WHERE type_id = 'ilxtr:hasSomaLocatedIn'
+        ),
+        path_with_destination AS (
+        SELECT source_id, path_id, node_id AS dest_node_id
+        FROM path_node_types
+        WHERE type_id IN ('ilxtr:hasAxonPresynapticElementIn', 'ilxtr:hasAxonSensorySubcellularElementIn')
+        ),
+        path_with_via AS (
+        SELECT source_id, path_id, node_id AS via_node_id
+        FROM path_node_types
+        WHERE type_id IN ('ilxtr:hasAxonLeadingToSensorySubcellularElementIn', 'ilxtr:hasAxonLocatedIn')
+        )
+
+      SELECT DISTINCT pws.source_id, pws.path_id
+      FROM path_with_source pws NATURAL JOIN path_with_destination pwd NATURAL JOIN path_with_via pwv
+      WHERE %CONDITIONS%
+    parameters:
+    - id: source_node_id
+      column: pws.source_node_id
+      label: Anatomical nodes as sources
+      type: string
+      multiple: true
+      default_msg: An empty string is used for the source node. To include all nodes, set the 'negate' attribute to True.
+      default_sql: >
+        select ''
+    - id: via_node_id
+      column: pwv.via_node_id
+      label: Anatomical nodes as vias
+      type: string
+      multiple: true
+      default_msg: An empty string is used for the via node. To include all nodes, set the 'negate' attribute to True.
+      default_sql: >
+        select ''
+    - id: dest_node_id
+      column: pwd.dest_node_id
+      label: Anatomical nodes as destinations
+      type: string
+      multiple: true
+      default_msg: An empty string is used for the destination node. To include all nodes, set the 'negate' attribute to True.
+      default_sql: >
+        select ''
+    - id: source_id
+      column: pws.source_id
+      label: Knowledge source
+      type: string
+      default_msg: the latest source is used
+      default_sql: >
+        select source_id from knowledge_sources where source_id like 'sckan%'
+        order by source_id desc limit 1
+    order: ''
+    results:
+    - key: source_id
+      label: Knowledge source
+      type: string
+    - key: path_id
+      label: Neuron population
+      type: string

--- a/mapserver/competency/queries.d/query_25.yaml
+++ b/mapserver/competency/queries.d/query_25.yaml
@@ -51,6 +51,7 @@ queries:
       column: pws.source_id
       label: Knowledge source
       type: string
+      multiple: true
       default_msg: the latest source is used
       default_sql: >
         select source_id from knowledge_sources where source_id like 'sckan%'

--- a/mapserver/competency/queries.d/query_25.yaml
+++ b/mapserver/competency/queries.d/query_25.yaml
@@ -1,0 +1,65 @@
+queries:
+  - id: 25
+    label: Neuron populations that have source, via, and destination locations
+    sql: >
+      WITH
+        path_with_source AS (
+          SELECT source_id, path_id, node_id AS source_node_id, feature_id AS source_feature_id
+        FROM path_node_types NATURAL JOIN path_node_features
+        WHERE type_id = 'ilxtr:hasSomaLocatedIn'
+        ),
+        path_with_destination AS (
+        SELECT source_id, path_id, node_id AS dest_node_id, feature_id AS dest_feature_id
+        FROM path_node_types NATURAL JOIN path_node_features
+        WHERE type_id IN ('ilxtr:hasAxonPresynapticElementIn', 'ilxtr:hasAxonSensorySubcellularElementIn')
+        ),
+        path_with_via AS (
+        SELECT source_id, path_id, node_id AS via_node_id, feature_id AS via_feature_id
+        FROM path_node_types NATURAL JOIN path_node_features
+        WHERE type_id IN ('ilxtr:hasAxonLeadingToSensorySubcellularElementIn', 'ilxtr:hasAxonLocatedIn')
+        )
+
+      SELECT DISTINCT pws.source_id, pws.path_id
+      FROM path_with_source pws NATURAL JOIN path_with_destination pwd NATURAL JOIN path_with_via pwv
+      WHERE %CONDITIONS%
+    parameters:
+    - id: source_feature_id
+      column: pws.source_feature_id
+      label: Anatomical terms for source locations
+      type: string
+      multiple: true
+      default_msg: An empty string is used for the source location. To include all locations, set the 'negate' attribute to True.
+      default_sql: >
+        select ''
+    - id: via_feature_id
+      column: pwv.via_feature_id
+      label: Anatomical terms for via locations
+      type: string
+      multiple: true
+      default_msg: An empty string is used for the via location. To include all locations, set the 'negate' attribute to True.
+      default_sql: >
+        select ''
+    - id: dest_feature_id
+      column: pwd.dest_feature_id
+      label: Anatomical terms for destination locations
+      type: string
+      multiple: true
+      default_msg: An empty string is used for the destination location. To include all locations, set the 'negate' attribute to True.
+      default_sql: >
+        select ''
+    - id: source_id
+      column: pws.source_id
+      label: Knowledge source
+      type: string
+      default_msg: the latest source is used
+      default_sql: >
+        select source_id from knowledge_sources where source_id like 'sckan%'
+        order by source_id desc limit 1
+    order: ''
+    results:
+    - key: source_id
+      label: Knowledge source
+      type: string
+    - key: path_id
+      label: Neuron population
+      type: string

--- a/tests/test_query_24.py
+++ b/tests/test_query_24.py
@@ -1,0 +1,132 @@
+import pytest
+from utility import cq_request, assert_valid_query_response, SCKAN_VERSION, RAT_UUID
+
+def test_sckan():
+    # test query with complete source, via, and destination nodes
+    query = {
+        'query_id': '24',
+        'parameters': [
+            {'column': 'source_id', 'value': SCKAN_VERSION},
+            {'column': 'source_node_id', 'value': ['["ILX:0787009", []]']},                 # twelfth thoracic ganglion
+            {'column': 'via_node_id', 'value': ['["ILX:0793559", []]']},                    # bladder nerve
+            {'column': 'dest_node_id', 'value': ['["UBERON:0035965", ["ILX:0793664"]]']}    # wall of blood vessel/arteriole in connective tissue of bladder dome
+        ]
+    }
+    response = cq_request(query)
+    expected_path_ids = ['ilxtr:neuron-type-keast-4']
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=1,
+        expected_column_values={'path_id': expected_path_ids}
+    )
+
+    # test query with source and destination nodes only
+    query = {
+        'query_id': '24',
+        'parameters': [
+            {'column': 'source_id', 'value': SCKAN_VERSION},
+            {'column': 'source_node_id', 'value': ['["ILX:0787009", []]']},                 # twelfth thoracic ganglion
+            {'column': 'via_node_id', 'value': [], 'negate': True},
+            {'column': 'dest_node_id', 'value': ['["UBERON:0035965", ["ILX:0793664"]]']}    # wall of blood vessel/arteriole in connective tissue of bladder dome
+        ]
+    }
+    response = cq_request(query)
+    expected_path_ids = ['ilxtr:neuron-type-keast-4']
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=1,
+        expected_column_values={'path_id': expected_path_ids}
+    )
+
+    # test query with via nodes only
+    query = {
+        'query_id': '24',
+        'parameters': [
+            {'column': 'source_id', 'value': SCKAN_VERSION},
+            {'column': 'source_node_id', 'value': [], 'negate': True},
+            {'column': 'via_node_id', 'value': ['["ILX:0793559", []]']},                    # bladder nerve
+            {'column': 'dest_node_id', 'value': [], 'negate': True}
+        ]
+    }
+    response = cq_request(query)
+    expected_path_ids = [
+        'ilxtr:neuron-type-keast-1',
+        'ilxtr:neuron-type-keast-10',
+        'ilxtr:neuron-type-keast-11',
+        'ilxtr:neuron-type-keast-2',
+        'ilxtr:neuron-type-keast-3',
+        'ilxtr:neuron-type-keast-4'
+    ]
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=6,
+        expected_column_values={'path_id': expected_path_ids}
+    )
+
+def test_rat_map():
+    # test query with complete source, via, and destination nodes
+    query = {
+        'query_id': '24',
+        'parameters': [
+            {'column': 'source_id', 'value': RAT_UUID},
+            {'column': 'source_node_id', 'value': ['["ILX:0787009", []]']},                 # twelfth thoracic ganglion
+            {'column': 'via_node_id', 'value': ['["ILX:0793559", []]']},                    # bladder nerve
+            {'column': 'dest_node_id', 'value': ['["UBERON:0035965", ["UBERON:0006082"]]']} # wall of blood vessel/fundus of urinary bladder
+        ]
+    }
+    response = cq_request(query)
+    expected_path_ids = ['ilxtr:neuron-type-keast-4']
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=1,
+        expected_column_values={'path_id': expected_path_ids}
+    )
+
+    # test query with source and destination nodes only
+    query = {
+        'query_id': '24',
+        'parameters': [
+            {'column': 'source_id', 'value': RAT_UUID},
+            {'column': 'source_node_id', 'value': ['["ILX:0787009", []]']},                 # twelfth thoracic ganglion
+            {'column': 'via_node_id', 'value': [], 'negate': True},
+            {'column': 'dest_node_id', 'value': ['["UBERON:0035965", ["UBERON:0006082"]]']} # wall of blood vessel/fundus of urinary bladder
+        ]
+    }
+    response = cq_request(query)
+    expected_path_ids = ['ilxtr:neuron-type-keast-4']
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=1,
+        expected_column_values={'path_id': expected_path_ids}
+    )
+
+     # test query with via nodes only
+    query = {
+        'query_id': '24',
+        'parameters': [
+            {'column': 'source_id', 'value': RAT_UUID},
+            {'column': 'source_node_id', 'value': [], 'negate': True},
+            {'column': 'via_node_id', 'value': ['["ILX:0793559", []]']},                    # bladder nerve
+            {'column': 'dest_node_id', 'value': [], 'negate': True}
+        ]
+    }
+    response = cq_request(query)
+    expected_path_ids = [
+        'ilxtr:neuron-type-keast-1',
+        'ilxtr:neuron-type-keast-10',
+        'ilxtr:neuron-type-keast-11',
+        'ilxtr:neuron-type-keast-2',
+        'ilxtr:neuron-type-keast-3',
+        'ilxtr:neuron-type-keast-4'
+    ]
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=6,
+        expected_column_values={'path_id': expected_path_ids}
+    )

--- a/tests/test_query_25.py
+++ b/tests/test_query_25.py
@@ -1,0 +1,132 @@
+import pytest
+from utility import cq_request, assert_valid_query_response, SCKAN_VERSION, RAT_UUID
+
+def test_sckan():
+    # test query with complete source, via, and destination nodes
+    query = {
+        'query_id': '25',
+        'parameters': [
+            {'column': 'source_id', 'value': SCKAN_VERSION},
+            {'column': 'source_feature_id', 'value': ['ILX:0787009']}, # twelfth thoracic ganglion
+            {'column': 'via_feature_id', 'value': ['ILX:0793559']},    # bladder nerve
+            {'column': 'dest_feature_id', 'value': ['ILX:0793664']}    # arteriole in connective tissue of bladder dome
+        ]
+    }
+    response = cq_request(query)
+    expected_path_ids = ['ilxtr:neuron-type-keast-4']
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=1,
+        expected_column_values={'path_id': expected_path_ids}
+    )
+
+    # test query with source and destination nodes only
+    query = {
+        'query_id': '25',
+        'parameters': [
+            {'column': 'source_id', 'value': SCKAN_VERSION},
+            {'column': 'source_feature_id', 'value': ['ILX:0787009']}, # twelfth thoracic ganglion
+            {'column': 'via_feature_id', 'value': [], 'negate': True},
+            {'column': 'dest_feature_id', 'value': ['ILX:0793664']}    # arteriole in connective tissue of bladder dome
+        ]
+    }
+    response = cq_request(query)
+    expected_path_ids = ['ilxtr:neuron-type-keast-4']
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=1,
+        expected_column_values={'path_id': expected_path_ids}
+    )
+
+    # test query with via nodes only
+    query = {
+        'query_id': '25',
+        'parameters': [
+            {'column': 'source_id', 'value': SCKAN_VERSION},
+            {'column': 'source_feature_id', 'value': [], 'negate': True},
+            {'column': 'via_feature_id', 'value': ['ILX:0793559']},    # bladder nerve
+            {'column': 'dest_feature_id', 'value': [], 'negate': True}
+        ]
+    }
+    response = cq_request(query)
+    expected_path_ids = [
+        'ilxtr:neuron-type-keast-1',
+        'ilxtr:neuron-type-keast-10',
+        'ilxtr:neuron-type-keast-11',
+        'ilxtr:neuron-type-keast-2',
+        'ilxtr:neuron-type-keast-3',
+        'ilxtr:neuron-type-keast-4'
+    ]
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=6,
+        expected_column_values={'path_id': expected_path_ids}
+    )
+
+def test_rat_map():
+    # test query with complete source, via, and destination nodes
+    query = {
+        'query_id': '25',
+        'parameters': [
+            {'column': 'source_id', 'value': RAT_UUID},
+            {'column': 'source_feature_id', 'value': ['ILX:0787009']}, # twelfth thoracic ganglion
+            {'column': 'via_feature_id', 'value': ['ILX:0793559']},    # bladder nerve
+            {'column': 'dest_feature_id', 'value': ['UBERON:0006082']} # wall of blood vessel/fundus of urinary bladder
+        ]
+    }
+    response = cq_request(query)
+    expected_path_ids = ['ilxtr:neuron-type-keast-4']
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=1,
+        expected_column_values={'path_id': expected_path_ids}
+    )
+
+    # test query with source and destination nodes only
+    query = {
+        'query_id': '25',
+        'parameters': [
+            {'column': 'source_id', 'value': RAT_UUID},
+            {'column': 'source_feature_id', 'value': ['ILX:0787009']}, # twelfth thoracic ganglion
+            {'column': 'via_feature_id', 'value': [], 'negate': True},
+            {'column': 'dest_feature_id', 'value': ['UBERON:0006082']} # wall of blood vessel/fundus of urinary bladder
+        ]
+    }
+    response = cq_request(query)
+    expected_path_ids = ['ilxtr:neuron-type-keast-4']
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=1,
+        expected_column_values={'path_id': expected_path_ids}
+    )
+
+     # test query with via nodes only
+    query = {
+        'query_id': '25',
+        'parameters': [
+            {'column': 'source_id', 'value': RAT_UUID},
+            {'column': 'source_feature_id', 'value': [], 'negate': True},
+            {'column': 'via_feature_id', 'value': ['ILX:0793559']},    # bladder nerve
+            {'column': 'dest_feature_id', 'value': [], 'negate': True}
+        ]
+    }
+    response = cq_request(query)
+    expected_path_ids = [
+        'ilxtr:neuron-type-keast-1',
+        'ilxtr:neuron-type-keast-10',
+        'ilxtr:neuron-type-keast-11',
+        'ilxtr:neuron-type-keast-2',
+        'ilxtr:neuron-type-keast-3',
+        'ilxtr:neuron-type-keast-4'
+    ]
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=6,
+        expected_column_values={'path_id': expected_path_ids}
+    )

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -1,0 +1,55 @@
+import requests
+
+END_POINT = 'https://mapcore-demo.org/devel/flatmap/v4/competency/query'
+HEADERS = {'Content-Type': 'application/json'}
+
+MALE_UUID = '2b76d336-5c56-55e3-ab1e-795d6c63f9c1'
+FEMALE_UUID = '91359a0f-9e32-5309-b365-145d9956817d'
+RAT_UUID = 'fb6d0345-cb70-5c7e-893c-d744a6313c95'
+SCKAN_VERSION = 'sckan-2024-09-21'
+
+def cq_request(query: dict):
+    response = requests.post(END_POINT, json=query, headers=HEADERS)
+    return response
+
+def assert_valid_query_response(
+    response,
+    expected_num_keys=None,
+    expected_num_values=None,
+    expected_column_values=None,
+    expected_rows=None
+):
+    assert response.status_code in (200, 201), f'Unexpected status code: {response.status_code}'
+    json_response = response.json()
+
+    results = json_response.get('results', {})
+    keys = results.get('keys', [])
+    values = results.get('values', [])
+
+    if expected_num_keys:
+        assert len(keys) == expected_num_keys, f"Expected {expected_num_keys} keys but got {len(keys)}"
+
+    if expected_num_values:
+        assert len(values) == expected_num_values, f"Expected {expected_num_values} value rows but got {len(values)}"
+
+    if expected_column_values:
+        for col, expected_values in expected_column_values.items():
+            assert col in keys, f"Column '{col}' not found in result keys"
+            idx = keys.index(col)
+            actual_values = [
+                tuple(row[idx]) if isinstance(row[idx], list) else row[idx]
+                for row in values
+            ]
+            expected_values = [
+                tuple(value) if isinstance(value, list) else value
+                for value in expected_values
+            ]
+            assert set(actual_values) == set(expected_values), (
+                f"Expected values in column '{col}' to be {expected_values}, but got {actual_values}"
+            )
+
+    if expected_rows:
+        for row in expected_rows:
+            assert any(
+                all(item in value for item in row) for value in values
+            ), f"Missing expected row: {row}"


### PR DESCRIPTION
This PR is for issue #29 