### PR TITLE
Improve term hierarchy construction and add hierarchical competency queries for anatomical nodes and paths

### DIFF
--- a/mapserver/competency/flatmap.py
+++ b/mapserver/competency/flatmap.py
@@ -36,6 +36,7 @@ from ..settings import settings
 from ..utils import json_map_metadata
 
 from .knowledge import CompetencyKnowledge
+from ..knowledge.hierarchy import SparcHierarchy, NPO_ONTOLOGY, UBERON_ONTOLOGY
 
 #===============================================================================
 
@@ -121,6 +122,7 @@ def anatomical_map_knowledge(map_uuid: str, competency_db: CompetencyKnowledge) 
         nerve_terms.update(term for node in knowledge_terms[path_id]['nerves'] for term in [node[0]] + node[1])
 
     # Non-path features with an anatomical term
+    hierarchy = SparcHierarchy(UBERON_ONTOLOGY, NPO_ONTOLOGY)
     for feature_id, properties in annotated_features.items():
         if feature_id not in knowledge_terms:
             label = properties.get('label', properties.get('name', feature_id))
@@ -129,6 +131,8 @@ def anatomical_map_knowledge(map_uuid: str, competency_db: CompetencyKnowledge) 
                 'source': map_uuid,
                 'label': label,
                 'long-label': descriptions.get(feature_id, label),
+                'descendants': hierarchy.terminal_path_terms({feature_id}).intersection(knowledge_terms.keys())
+                                if hierarchy.has(feature_id) else []
             }
             if properties.get('type') == 'nerve' or feature_id in nerve_terms:
                 knowledge_terms[feature_id]['type'] = NERVE_TYPE

--- a/mapserver/competency/queries.d/query_29.yaml
+++ b/mapserver/competency/queries.d/query_29.yaml
@@ -1,0 +1,50 @@
+queries:
+  - id: 29
+    label: Neuron populations associated with a location and its children
+    sql: >
+      WITH term_data AS(
+        SELECT term_id, source_id
+        FROM feature_terms
+        WHERE %CONDITIONS%
+      ),
+      descendants AS (
+        SELECT DISTINCT fp.feature_0 AS child_id, fp.source_id, td.term_id AS parent_id
+        FROM feature_relationship fp JOIN term_data td
+          ON fp.source_id = td.source_id and fp.feature_1 = td.term_id
+        WHERE fp.relationship = 'descendant-ancestor'
+        UNION
+        SELECT term_id, source_id, term_id FROM term_data
+      ),
+      descendant_nodes AS (
+        SELECT DISTINCT pnf.path_id, pnf.node_id, pnf.source_id
+        FROM descendants d JOIN path_node_features pnf
+          ON d.child_id = pnf.feature_id AND d.source_id = pnf.source_id
+        GROUP BY pnf.node_id, pnf.source_id, pnf.path_id
+        HAVING COUNT(DISTINCT d.parent_id) = (
+          SELECT COUNT(*) FROM term_data
+        )
+      )
+      SELECT DISTINCT path_id, source_id FROM descendant_nodes
+    parameters:
+    - id: feature_id
+      column: term_id
+      label: Anatomical terms for locations
+      type: string
+      multiple: true
+    - id: source_id
+      column: source_id
+      label: Knowledge source
+      type: string
+      default_msg: the latest source is used
+      default_sql: >
+        select source_id from knowledge_sources where source_id like 'sckan%'
+        order by source_id desc limit 1
+    order: ''
+    results:
+    - key: source_id
+      label: Knowledge source
+      type: string
+    - key: path_id
+      label: Neuron population
+      type: string
+

--- a/mapserver/competency/queries.d/query_30.yaml
+++ b/mapserver/competency/queries.d/query_30.yaml
@@ -1,0 +1,50 @@
+queries:
+  - id: 30
+    label: Nodes as children
+    sql: >
+      WITH term_data AS(
+        SELECT term_id, source_id
+        FROM feature_terms
+        WHERE %CONDITIONS%
+      ),
+      descendants AS (
+        SELECT DISTINCT fp.feature_0 AS child_id, fp.source_id, td.term_id AS parent_id
+        FROM feature_relationship fp JOIN term_data td
+          ON fp.source_id = td.source_id and fp.feature_1 = td.term_id
+        WHERE fp.relationship = 'descendant-ancestor'
+        UNION
+        SELECT term_id, source_id, term_id FROM term_data
+      ),
+      descendant_nodes AS (
+        SELECT DISTINCT pnf.path_id, pnf.node_id, pnf.source_id
+        FROM descendants d JOIN path_node_features pnf
+          ON d.child_id = pnf.feature_id AND d.source_id = pnf.source_id
+        GROUP BY pnf.node_id, pnf.source_id, pnf.path_id
+        HAVING COUNT(DISTINCT d.parent_id) = (
+          SELECT COUNT(*) FROM term_data
+        )
+      )
+      SELECT DISTINCT node_id, source_id FROM descendant_nodes
+    parameters:
+    - id: feature_id
+      column: term_id
+      label: Anatomical terms for locations
+      type: string
+      multiple: true
+    - id: source_id
+      column: source_id
+      label: Knowledge source
+      type: string
+      default_msg: the latest source is used
+      default_sql: >
+        select source_id from knowledge_sources where source_id like 'sckan%'
+        order by source_id desc limit 1
+    order: ''
+    results:
+    - key: source_id
+      label: Knowledge source
+      type: string
+    - key: node_id
+      label: Anatomical node
+      type: string
+

--- a/mapserver/knowledge/hierarchy.py
+++ b/mapserver/knowledge/hierarchy.py
@@ -287,7 +287,7 @@ class SparcHierarchy:
             else:
                 self.__add_ilx_child(ilx_term)
         depth = 0
-        while depth < 3 and len(have_ilx_parents):
+        while len(have_ilx_parents):
             new_parents = []
             for ilx_term in have_ilx_parents:
                 # Are all parents now in the graph?
@@ -296,10 +296,19 @@ class SparcHierarchy:
                     self.__add_ilx_child(ilx_term)
                 else:
                     new_parents.append(ilx_term)
+            if len(new_parents) == len(have_ilx_parents):
+                # No progress — remaining terms form a cycle or reference unknown parents
+                for t in set(new_parents):
+                    missing_parents = [p.id for p in t.parents if p.id not in self.__graph]
+                    settings['LOGGER'].warning(
+                        f'Unresolved Interlex term: {t.uri.id}; missing parents: {missing_parents}'
+                    )
+                break
             have_ilx_parents = new_parents
             depth += 1
-        if len(have_ilx_parents):
-            raise ValueError('Some Interlex parts are too deeply nested')
+            if len(have_ilx_parents) and depth >= 3:
+                settings['LOGGER'].warning('Some Interlex parts are too deeply nested')
+                break
 
     def __add_ilx_child(self, ilx: IlxTerm):
     #=======================================

--- a/mapserver/knowledge/hierarchy.py
+++ b/mapserver/knowledge/hierarchy.py
@@ -44,10 +44,10 @@ from .rdf_utils import ILX_BASE, Node, Triple, Uri
 #===============================================================================
 
 # Bump this to automatically rebuild the SPARC term hierarchy
-SPARC_HIERARCHY_VERSION = '1.0'
+SPARC_HIERARCHY_VERSION = '1.1'
 
 # Bump this to automatically rebuild map term hierarchies
-MAP_TREE_VERSION = '1.3'
+MAP_TREE_VERSION = '1.4'
 
 #===============================================================================
 

--- a/mapserver/knowledge/hierarchy.py
+++ b/mapserver/knowledge/hierarchy.py
@@ -246,7 +246,7 @@ class SparcHierarchy:
             with open(self.__hierarchy_file) as fp:
                 graph_json = json.load(fp)
                 self.__graph = nx.node_link_graph(graph_json, edges='links', directed=True)  # type: ignore
-                if self.__graph.get('graph', {}).get('version', '') < SPARC_HIERARCHY_VERSION:
+                if graph_json.get('graph', {}).get('version', '') < SPARC_HIERARCHY_VERSION:
                     self.__create_sparc_hierarchy(uberon_source, interlex_source)
         except Exception:
             self.__create_sparc_hierarchy(uberon_source, interlex_source)

--- a/mapserver/knowledge/ontologies/npo.ttl
+++ b/mapserver/knowledge/ontologies/npo.ttl
@@ -10,7 +10,6 @@
 @prefix definition: <http://purl.obolibrary.org/obo/IAO_0000115> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix FMA: <http://purl.org/sig/ont/fma/fma> .
-@prefix GO: <http://purl.obolibrary.org/obo/GO_> .
 @prefix hasPart: <http://purl.obolibrary.org/obo/BFO_0000051> .
 @prefix hasRole: <http://purl.obolibrary.org/obo/RO_0000087> .
 @prefix ILX: <http://uri.interlex.org/base/ilx_> .
@@ -19,6 +18,7 @@
 @prefix ilx.partOf: <http://uri.interlex.org/base/ilx_0112785> .
 @prefix ilx.relatedTo: <http://uri.interlex.org/base/ilx_0112796> .
 @prefix ilx.type: <http://uri.interlex.org/base/readable/type/> .
+@prefix ilxcr: <http://uri.interlex.org/composer/uris/readable/> .
 @prefix ilxr: <http://uri.interlex.org/base/readable/> .
 @prefix ilxtr: <http://uri.interlex.org/tgbugs/uris/readable/> .
 @prefix MIRO: <http://uri.interlex.org/MIRO/uris/readable/> .
@@ -29,7 +29,6 @@
 @prefix NLX: <http://uri.neuinfo.org/nif/nifstd/nlx_> .
 @prefix NLXANAT: <http://uri.neuinfo.org/nif/nifstd/nlx_anat_> .
 @prefix NLXMOL: <http://uri.neuinfo.org/nif/nifstd/nlx_mol_> .
-@prefix NLXORG: <http://uri.neuinfo.org/nif/nifstd/nlx_organ_> .
 @prefix NLXWIKI: <http://neurolex.org/wiki/> .
 @prefix npokb: <http://uri.interlex.org/npo/uris/neurons/> .
 @prefix OBI: <http://purl.obolibrary.org/obo/OBI_> .
@@ -59,7 +58,7 @@
     rdfs:label "The Neuron Phenotype Ontology" ;
     dc:title "The Neuron Phenotype Ontology" ;
     dc:description "An ontology of neuron types based on the phenotypic dimensions of cells that can be measure experimentally." ;
-    owl:versionInfo "2024-03-04" ;
+    owl:versionInfo "2026-01-21" ;
     dc:contributor "Bernard de Bono - https://orcid.org/0000-0003-0638-5274",
         "Fahim Imam - https://orcid.org/0000-0003-4752-543X",
         "Ilias Ziogas - https://orcid.org/0000-0002-9210-2455",
@@ -128,9 +127,6 @@ RO:0002433 a owl:ObjectProperty ;
 
 ### Annotation Properties
 
-definition: a owl:AnnotationProperty ;
-    rdfs:label "definition" .
-
 skos:hiddenLabel a owl:AnnotationProperty ;
     rdfs:label "hidden label" .
 
@@ -142,27 +138,6 @@ skos:prefLabel a owl:AnnotationProperty ;
 AIBSTL:301021674 a owl:Class .
 
 AIBSTL:543338518 a owl:Class .
-
-atom:Label a owl:Class ;
-    rdfs:label "parcellation label" ;
-    NIFRID:synonym "Parcellation Label",
-        "parcellation term",
-        "term" ;
-    rdfs:subClassOf UBERON:0001062 .
-
-BIRNLEX:1 a owl:Class ;
-    rdfs:label "Macromolecular complex" ;
-    ilxtr:hasExistingId BIRNLEX:1,
-        ILX:0106439 ;
-    ilxtr:hasExternalId BIRNLEX:1 ;
-    ilxtr:hasIlxId ILX:0106439 ;
-    ilxtr:hasIlxPreferredId BIRNLEX:1 .
-
-CHEBI:5291 a owl:Class ;
-    rdfs:label "gelatin" ;
-    NIFRID:synonym "Gelatine" ;
-    rdfs:subClassOf CHEBI:60004,
-        PR:000050567 .
 
 CHEBI:5686 a owl:Class ;
     rdfs:label "heterocyclic compound" ;
@@ -242,7 +217,9 @@ CHEBI:15428 a owl:Class ;
         "H2N-CH2-COOH",
         "Hgly",
         "Leimzucker" ;
-    rdfs:subClassOf CHEBI:26650 .
+    rdfs:subClassOf CHEBI:26650,
+        CHEBI:33704,
+        CHEBI:83813 .
 
 CHEBI:15705 a owl:Class ;
     rdfs:label "L-alpha-amino acid" ;
@@ -270,8 +247,10 @@ CHEBI:16015 a owl:Class ;
         "L-glutamic acid",
         "L-Glutaminic acid",
         "L-Glutaminsaeure" ;
-    rdfs:subClassOf CHEBI:18237,
-        CHEBI:24318 .
+    rdfs:subClassOf CHEBI:15705,
+        CHEBI:18237,
+        CHEBI:24318,
+        CHEBI:83813 .
 
 CHEBI:16670 a owl:Class ;
     rdfs:label "peptide" ;
@@ -344,7 +323,6 @@ CHEBI:18243 a owl:Class ;
         "Oxytyramine",
         "Revimine" ;
     rdfs:subClassOf CHEBI:33567,
-        NLXMOL:100306,
         SAO:1456045859 .
 
 CHEBI:22563 a owl:Class ;
@@ -354,10 +332,7 @@ CHEBI:22563 a owl:Class ;
         "Anionen",
         "aniones",
         "anions" ;
-    rdfs:subClassOf CHEBI:24870,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom CHEBI:24866 ] .
+    rdfs:subClassOf CHEBI:24870 .
 
 CHEBI:22660 a owl:Class ;
     rdfs:label "aspartic acid" ;
@@ -462,20 +437,6 @@ CHEBI:24833 a owl:Class ;
         "oxyacids" ;
     rdfs:subClassOf CHEBI:24651 .
 
-CHEBI:24866 a owl:Class ;
-    rdfs:label "salt" ;
-    NIFRID:synonym "ionic compound",
-        "ionic compounds",
-        "sal",
-        "sales",
-        "salt",
-        "salts",
-        "Salz",
-        "Salze",
-        "sel",
-        "sels" ;
-    rdfs:subClassOf CHEBI:37577 .
-
 CHEBI:24870 a owl:Class ;
     rdfs:label "ion" ;
     NIFRID:synonym "Ion",
@@ -493,7 +454,8 @@ CHEBI:25367 a owl:Class ;
         "molecules",
         "Molekuel",
         "neutral molecular compounds" ;
-    rdfs:subClassOf CHEBI:36357 .
+    rdfs:subClassOf CHEBI:24431,
+        CHEBI:36357 .
 
 CHEBI:25375 a owl:Class ;
     rdfs:label "monoamine molecular messenger" ;
@@ -551,17 +513,12 @@ CHEBI:26167 a owl:Class ;
         "polar amino-acids" ;
     rdfs:subClassOf CHEBI:33709 .
 
-CHEBI:26469 a owl:Class ;
-    rdfs:label "quaternary nitrogen compound" ;
-    rdfs:subClassOf CHEBI:35352 .
-
 CHEBI:26650 a owl:Class ;
     rdfs:label "serine family amino acid" ;
     NIFRID:synonym "3-phosphoglycerate family amino acid",
         "3-phosphoglycerate family amino acids",
         "serine family amino acids" ;
-    rdfs:subClassOf CHEBI:15705,
-        CHEBI:83813 .
+    rdfs:subClassOf CHEBI:33704 .
 
 CHEBI:27162 a owl:Class ;
     rdfs:label "tryptamines" ;
@@ -661,8 +618,8 @@ CHEBI:33308 a owl:Class ;
 
 CHEBI:33558 a owl:Class ;
     rdfs:label "alpha-amino-acid anion" ;
-    NIFRID:synonym "alpha-amino acid anions",
-        "alpha-amino-acid anion",
+    NIFRID:synonym "alpha-amino acid anion",
+        "alpha-amino acid anions",
         "alpha-amino-acid anions" ;
     rdfs:subClassOf CHEBI:37022 .
 
@@ -678,7 +635,8 @@ CHEBI:33567 a owl:Class ;
     NIFRID:synonym "Catecholamine",
         "catecholamines" ;
     rdfs:subClassOf CHEBI:25375,
-        CHEBI:33566 .
+        CHEBI:33566,
+        CHEBI:64365 .
 
 CHEBI:33570 a owl:Class ;
     rdfs:label "benzenediols" ;
@@ -851,10 +809,7 @@ CHEBI:33839 a owl:Class ;
         "polymer",
         "polymer molecule",
         "polymers" ;
-    rdfs:subClassOf CHEBI:36357,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom CHEBI:60027 ] .
+    rdfs:subClassOf CHEBI:36357 .
 
 CHEBI:33853 a owl:Class ;
     rdfs:label "phenols" ;
@@ -872,10 +827,7 @@ CHEBI:35267 a owl:Class ;
         "quaternary ammonium ion",
         "quaternary ammonium ions" ;
     rdfs:subClassOf CHEBI:25697,
-        CHEBI:35274,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom CHEBI:26469 ] .
+        CHEBI:35274 .
 
 CHEBI:35274 a owl:Class ;
     rdfs:label "ammonium ion derivative" ;
@@ -883,16 +835,7 @@ CHEBI:35274 a owl:Class ;
         "azanium ion derivative",
         "azanium ion derivatives" ;
     rdfs:subClassOf CHEBI:33702,
-        CHEBI:51143,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom CHEBI:35276 ] .
-
-CHEBI:35276 a owl:Class ;
-    rdfs:label "ammonium compound" ;
-    NIFRID:synonym "ammonium compounds",
-        "azanium compounds" ;
-    rdfs:subClassOf CHEBI:51143 .
+        CHEBI:51143 .
 
 CHEBI:35287 a owl:Class ;
     rdfs:label "acylcholine" ;
@@ -942,16 +885,6 @@ CHEBI:35701 a owl:Class ;
         "esters" ;
     rdfs:subClassOf CHEBI:36963 .
 
-CHEBI:36080 a owl:Class ;
-    rdfs:label "protein" ;
-    NIFRID:synonym "proteins" ;
-    rdfs:subClassOf CHEBI:33695,
-        PR:000018263,
-        PR:000050567,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom CHEBI:5291 ] .
-
 CHEBI:36357 a owl:Class ;
     rdfs:label "Polyatomic entity" ;
     NIFRID:synonym "polyatomic entities" ;
@@ -983,10 +916,7 @@ CHEBI:36916 a owl:Class ;
         "cations",
         "Kation",
         "Kationen" ;
-    rdfs:subClassOf CHEBI:24870,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom CHEBI:24866 ] .
+    rdfs:subClassOf CHEBI:24870 .
 
 CHEBI:36962 a owl:Class ;
     rdfs:label "organochalcogen compound" ;
@@ -1004,8 +934,8 @@ CHEBI:36963 a owl:Class ;
 
 CHEBI:37022 a owl:Class ;
     rdfs:label "amino-acid anion" ;
-    NIFRID:synonym "amino acid anions",
-        "amino-acid anion",
+    NIFRID:synonym "amino acid anion",
+        "amino acid anions",
         "amino-acid anions" ;
     rdfs:subClassOf CHEBI:29067,
         CHEBI:35352 .
@@ -1064,7 +994,8 @@ CHEBI:48705 a owl:Class ;
 CHEBI:50047 a owl:Class ;
     rdfs:label "organic amino compound" ;
     NIFRID:synonym "organic amino compounds" ;
-    rdfs:subClassOf CHEBI:35352 .
+    rdfs:subClassOf CHEBI:35352,
+        CHEBI:50860 .
 
 CHEBI:50860 a owl:Class ;
     rdfs:label "organic molecular entity" ;
@@ -1072,10 +1003,6 @@ CHEBI:50860 a owl:Class ;
         "organic entity",
         "organic molecular entities" ;
     rdfs:subClassOf CHEBI:33582 .
-
-CHEBI:50906 a owl:Class ;
-    rdfs:label "role" ;
-    rdfs:subClassOf BFO:0000017 .
 
 CHEBI:50994 a owl:Class ;
     rdfs:label "primary amino compound" ;
@@ -1088,22 +1015,6 @@ CHEBI:51143 a owl:Class ;
         "nitrogen molecular entities",
         "Nitrogenous compounds" ;
     rdfs:subClassOf CHEBI:33302 .
-
-CHEBI:59999 a owl:Class ;
-    rdfs:label "chemical substance" ;
-    NIFRID:synonym "Chemische Substanz" ;
-    rdfs:subClassOf CHEBI:24431 .
-
-CHEBI:60004 a owl:Class ;
-    rdfs:label "mixture" ;
-    NIFRID:synonym "Mischung" ;
-    rdfs:subClassOf CHEBI:59999 .
-
-CHEBI:60027 a owl:Class ;
-    rdfs:label "polymer" ;
-    NIFRID:synonym "Kunststoff",
-        "Polymer" ;
-    rdfs:subClassOf CHEBI:60004 .
 
 CHEBI:63534 a owl:Class ;
     rdfs:label "monoamine" ;
@@ -1187,111 +1098,166 @@ CHEBI:132943 a owl:Class ;
     rdfs:subClassOf CHEBI:33558,
         CHEBI:35693 .
 
-CL:0000000 a owl:Class ;
-    rdfs:label "cell" .
+dc:description a owl:Class ;
+    rdfs:label "Description" .
 
-CL:0000225 a owl:Class ;
-    rdfs:label "anucleate cell" .
+dc:title a owl:Class ;
+    rdfs:label "Title" .
 
-CL:0000558 a owl:Class ;
-    rdfs:label "reticulocyte" ;
-    rdfs:subClassOf CL:0000764,
-        PR:000050567 .
+FMA:5874 a owl:Class ;
+    rdfs:label "Communicating branch of spinal nerve" ;
+    NIFRID:synonym "Communicating branch of spinal nerve",
+        "Rameau communicant",
+        "Ramus communicans" ;
+    rdfs:subClassOf FMA:5985 .
 
-CL:0000764 a owl:Class ;
-    rdfs:label "erythroid lineage cell" .
+FMA:5875 a owl:Class ;
+    rdfs:label "White communicating ramus",
+        "white communicating ramus" ;
+    NIFRID:synonym "Rameau communicant blanc",
+        "Ramus communicans alba",
+        "White communicating ramus",
+        "White ramus",
+        "White ramus communicans" ;
+    rdfs:subClassOf FMA:5874 .
 
-CL:0002422 a owl:Class ;
-    rdfs:label "enucleated reticulocyte" ;
-    rdfs:subClassOf CL:0000225,
-        CL:0000558 .
+FMA:5876 a owl:Class ;
+    rdfs:label "Gray communicating ramus",
+        "gray communicating ramus" ;
+    NIFRID:synonym "Gray communicating ramus",
+        "Gray ramus",
+        "Gray ramus communicans",
+        "Grey ramus communicans of spinal nerve",
+        "Ramus communicans grisea" ;
+    rdfs:subClassOf FMA:5874 .
 
-FMA:5884 a owl:Class ;
-    rdfs:label "Ganglion" ;
-    NIFRID:synonym "Ganglio",
-        "Ganglion" ;
-    rdfs:subClassOf FMA:11195 .
+FMA:5980 a owl:Class ;
+    rdfs:label "Posterior root of spinal nerve" ;
+    NIFRID:synonym "Dorsal root of spinal nerve",
+        "Dorsal spinal nerve root",
+        "Posterior root of spinal nerve",
+        "Radix posterior (Nervus spinalis)",
+        "Radix sensoria (Nervus spinalis)",
+        "Sensory root of spinal nerve" ;
+    rdfs:subClassOf FMA:14060 .
 
-FMA:5889 a owl:Class ;
-    rdfs:label "Autonomic ganglion" ;
-    NIFRID:synonym "Autonomic ganglion",
-        "Ganglion autonomicum",
-        "Ganglion du système nerveux autonome" ;
-    rdfs:subClassOf FMA:5884 .
+FMA:5981 a owl:Class ;
+    rdfs:label "Nerve root" ;
+    NIFRID:synonym "Nerve root" ;
+    rdfs:subClassOf FMA:74941 .
 
-FMA:5890 a owl:Class ;
-    rdfs:label "Sympathetic ganglion" ;
-    NIFRID:synonym "Ganglion sympatheticum",
-        "Ganglion sympathicum",
-        "Paraganglion sympathique",
-        "Sympathetic ganglion" ;
-    rdfs:subClassOf FMA:5889 .
+FMA:5982 a owl:Class ;
+    rdfs:label "Anterior ramus of spinal nerve" ;
+    NIFRID:synonym "Anterior branch of spinal nerve",
+        "Anterior primary ramus of spinal nerve",
+        "Anterior ramus of spinal nerve",
+        "Ramus anterior",
+        "Ventral ramus of spinal nerve" ;
+    rdfs:subClassOf FMA:7052 .
 
-FMA:5891 a owl:Class ;
-    rdfs:label "Paravertebral ganglion" ;
-    NIFRID:synonym "Ganglion of sympathetic trunk",
-        "Ganglion trunci sympathetici",
-        "Ganglion trunci sympathici",
-        "Ganglions du tronc sympathique",
-        "Paravertebral ganglion",
-        "Sympathetic chain ganglion" ;
-    rdfs:subClassOf FMA:5890 .
+FMA:5983 a owl:Class ;
+    rdfs:label "Posterior ramus of spinal nerve" ;
+    NIFRID:synonym "Dorsal ramus",
+        "Dorsal ramus of spinal nerve",
+        "Posterior branch of spinal nerve",
+        "Posterior primary ramus",
+        "Posterior ramus of spinal nerve",
+        "Ramus posterior" ;
+    rdfs:subClassOf FMA:7052 .
 
-FMA:5898 a owl:Class ;
-    rdfs:label "Anatomical junction" ;
-    NIFRID:synonym "Anatomical junction",
-        "Anatomische Verzweigung",
-        "Ensambladura anatómica",
-        "Giunzione anatomica" ;
-    rdfs:subClassOf FMA:49443 .
+FMA:5985 a owl:Class ;
+    rdfs:label "Branch of anterior ramus of spinal nerve" ;
+    NIFRID:synonym "Branch of anterior ramus of spinal nerve",
+        "Branch of ventral ramus of spinal nerve" ;
+    rdfs:subClassOf FMA:10982 .
 
-FMA:5901 a owl:Class ;
-    rdfs:label "Nerve plexus" ;
-    NIFRID:synonym "Nerve plexus",
-        "Plexo del nervio" ;
-    rdfs:subClassOf FMA:5898 .
+FMA:6030 a owl:Class ;
+    rdfs:label "Anterior ramus of sacral nerve" ;
+    NIFRID:synonym "Anterior ramus of sacral nerve",
+        "Anterior ramus of sacral spinal nerve",
+        "Anterior sacral ramus",
+        "Rami anteriores, nervi sacrales",
+        "Sacral anterior ramus",
+        "Ventral ramus of sacral spinal nerve" ;
+    rdfs:subClassOf FMA:5982 .
 
-FMA:5910 a owl:Class ;
-    rdfs:label "Autonomic nerve plexus" ;
-    NIFRID:synonym "Autonomic nerve plexus",
-        "Autonomic plexus",
-        "Plexus autonomes",
-        "Plexus autonomicus",
-        "Plexus nerveux viscéral",
-        "Plexus nervosus visceralis",
-        "Plexus visceralis",
-        "Visceral nerve plexus",
-        "Visceral plexus" ;
-    rdfs:subClassOf FMA:5901 .
+FMA:6797 a owl:Class ;
+    rdfs:label "Posterior ramus of cervical nerve" ;
+    NIFRID:synonym "Cervical posterior ramus",
+        "Dorsal ramus of cervical spinal nerve",
+        "Posterior cervical ramus",
+        "Posterior ramus of cervical nerve",
+        "Posterior ramus of cervical spinal nerve",
+        "Ramus posterior, nervus cervicale" ;
+    rdfs:subClassOf FMA:5983 .
 
-FMA:6472 a owl:Class ;
-    rdfs:label "Lumbar ganglion" ;
-    NIFRID:synonym "Lumbar ganglion",
-        "Lumbar paravertebral ganglion",
-        "Lumbar sympathetic ganglion" ;
-    rdfs:subClassOf FMA:5891 .
+FMA:7052 a owl:Class ;
+    rdfs:label "Branch of peripheral segment of spinal nerve" ;
+    NIFRID:synonym "Branch of peripheral segment of spinal nerve",
+        "Spinal neural trunk branch" ;
+    rdfs:subClassOf FMA:10982 .
 
-FMA:6473 a owl:Class ;
-    rdfs:label "Sacral ganglion" ;
-    NIFRID:synonym "Sacral ganglion",
-        "Sacral sympathetic ganglion" ;
-    rdfs:subClassOf FMA:5891 .
-
-FMA:6638 a owl:Class ;
-    rdfs:label "Ovarian nerve plexus",
-        "ovarian nerve plexus" ;
-    NIFRID:synonym "Ovarian nerve plexus",
-        "Ovarian plexus",
-        "Plexus nervosus ovaricus",
-        "Plexus ovaricus",
-        "Plexus ovarique" ;
-    rdfs:subClassOf FMA:5910 .
+FMA:10982 a owl:Class ;
+    rdfs:label "Branch of spinal nerve" ;
+    NIFRID:synonym "Branch of spinal nerve",
+        "Spinal nerve tree organ part",
+        "Spinal neural branch" ;
+    rdfs:subClassOf FMA:65132 .
 
 FMA:11195 a owl:Class ;
     rdfs:label "Segment of neural tree organ" ;
     NIFRID:synonym "Neural tree organ segment",
         "Segment of neural tree organ" ;
     rdfs:subClassOf FMA:83115 .
+
+FMA:11198 a owl:Class ;
+    rdfs:label "Branch of anterior ramus of lumbar nerve" ;
+    NIFRID:synonym "Branch of anterior ramus of lumbar nerve",
+        "Branch of lumbar anterior ramus",
+        "Branch of ventral ramus of lumbar spinal nerve" ;
+    rdfs:subClassOf FMA:5985 .
+
+FMA:12908 a owl:Class ;
+    rdfs:label "Posterior root of thoracic nerve" ;
+    NIFRID:synonym "Dorsal root of thoracic nerve",
+        "Posterior root of thoracic nerve",
+        "Posterior root of thoracic spinal nerve" ;
+    rdfs:subClassOf FMA:5980 .
+
+FMA:12969 a owl:Class ;
+    rdfs:label "Posterior root of lumbar nerve" ;
+    NIFRID:synonym "Dorsal root of lumbar spinal nerve",
+        "Posterior root of lumbar nerve",
+        "Posterior root of lumbar spinal nerve" ;
+    rdfs:subClassOf FMA:5980 .
+
+FMA:14055 a owl:Class ;
+    rdfs:label "Gray communicating ramus of thoracic nerve",
+        "gray communicating ramus of thoracic nerve" ;
+    NIFRID:synonym "Gray communicating ramus of thoracic nerve",
+        "Gray communicating ramus of thoracic ventral ramus",
+        "Gray ramus communicans of thoracic anterior ramus" ;
+    rdfs:subClassOf FMA:5876 .
+
+FMA:14056 a owl:Class ;
+    rdfs:label "White communicating ramus of thoracic anterior ramus" ;
+    NIFRID:synonym "White communicating ramus of thoracic anterior ramus",
+        "White communicating ramus of thoracic ventral ramus",
+        "White ramus communicans of thoracic anterior ramus" ;
+    rdfs:subClassOf FMA:5875 .
+
+FMA:14060 a owl:Class ;
+    rdfs:label "Root of spinal nerve" ;
+    NIFRID:synonym "Root of spinal nerve",
+        "Spinal nerve root",
+        "Spinal neural root" ;
+    rdfs:subClassOf FMA:5981 .
+
+FMA:16416 a owl:Class ;
+    rdfs:label "White communicating ramus of lumbar nerve" ;
+    NIFRID:synonym "White communicating ramus of lumbar nerve",
+        "White ramus communicans of lumbar spinal nerve" ;
+    rdfs:subClassOf FMA:11198 .
 
 FMA:49443 a owl:Class ;
     rdfs:label "Anatomical cluster" ;
@@ -1314,6 +1280,18 @@ FMA:62955 a owl:Class ;
     NIFRID:synonym "Anatomical entity",
         "Entité anatomique" .
 
+FMA:65132 a owl:Class ;
+    rdfs:label "Nerve" ;
+    NIFRID:synonym "Nerf",
+        "Nerv",
+        "Nerve",
+        "Nerve trunk, each instance of which is the tract arising from some optic chiasma, consisting of fiber segments frm some ipsilateral temporal and contralateral nasal retinas, proceeding backward, around some cerebral peduncle, and dividing into a lateral and a medial root; the roots end in some superior colliculus and lateral geniculate body, respectively.",
+        "Nervio",
+        "Nervo",
+        "Nervus",
+        "Neural subtree" ;
+    rdfs:subClassOf FMA:11195 .
+
 FMA:67135 a owl:Class ;
     rdfs:label "Postnatal anatomical structure" ;
     NIFRID:synonym "Postnatal anatomical structure",
@@ -1329,6 +1307,14 @@ FMA:67165 a owl:Class ;
         "Materielles körperliches anatomisches Wesen" ;
     rdfs:subClassOf FMA:61775 .
 
+FMA:74941 a owl:Class ;
+    rdfs:label "Segment of nerve" ;
+    NIFRID:synonym "Neural segment",
+        "Region of nerve",
+        "Segment of nerve",
+        "Segmento del nervio" ;
+    rdfs:subClassOf FMA:11195 .
+
 FMA:83115 a owl:Class ;
     rdfs:label "Cell part cluster" ;
     NIFRID:synonym "Cell part cluster" ;
@@ -1343,99 +1329,6 @@ FMA:305751 a owl:Class ;
         "Structure anatomique",
         "Struttura anatomica" ;
     rdfs:subClassOf FMA:67165 .
-
-GO:0005575 a owl:Class ;
-    rdfs:label "cellular_component" ;
-    NIFRID:synonym "cell or subcellular entity",
-        "cellular component",
-        "subcellular entity" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom SAO:1813327414 ] .
-
-GO:0005622 a owl:Class ;
-    rdfs:label "intracellular anatomical structure" ;
-    NIFRID:synonym "internal to cell",
-        "intracellular",
-        "nucleocytoplasm",
-        "protoplasm",
-        "protoplast" ;
-    rdfs:subClassOf GO:0110165,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom CL:0000000 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom GO:0097653 ] .
-
-GO:0005840 a owl:Class ;
-    rdfs:label "ribosome" ;
-    NIFRID:synonym "free ribosome",
-        "membrane bound ribosome",
-        "ribosomal RNA" ;
-    rdfs:subClassOf GO:0043232,
-        PR:000050567,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom CL:0002422 ] .
-
-GO:0032991 a owl:Class ;
-    rdfs:label "macromolecular complex" ;
-    NIFRID:synonym "macromolecular complex",
-        "macromolecule complex",
-        "protein complex",
-        "protein containing complex",
-        "protein-protein complex" ;
-    rdfs:subClassOf GO:0005575,
-        PR:000050567 .
-
-GO:0032993 a owl:Class ;
-    rdfs:label "protein-DNA complex" ;
-    NIFRID:synonym "DNA-protein complex" ;
-    rdfs:subClassOf GO:0032991 .
-
-GO:0043226 a owl:Class ;
-    rdfs:label "organelle" ;
-    rdfs:subClassOf GO:0110165 .
-
-GO:0043228 a owl:Class ;
-    rdfs:label "non-membrane-bounded organelle" ;
-    NIFRID:synonym "biological condensate",
-        "non-membrane-enclosed organelle" ;
-    rdfs:subClassOf GO:0043226 .
-
-GO:0043229 a owl:Class ;
-    rdfs:label "intracellular organelle" ;
-    rdfs:subClassOf GO:0043226,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom GO:0005622 ] .
-
-GO:0043232 a owl:Class ;
-    rdfs:label "intracellular non-membrane-bounded organelle" ;
-    NIFRID:synonym "intracellular non-membrane-enclosed organelle" ;
-    rdfs:subClassOf GO:0043228,
-        GO:0043229,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom GO:0005622 ] .
-
-GO:0097653 a owl:Class ;
-    rdfs:label "unencapsulated part of cell" .
-
-GO:0110165 a owl:Class ;
-    rdfs:label "cellular anatomical entity" ;
-    rdfs:subClassOf GO:0005575,
-        UBERON:0000061 .
-
-GO:1990904 a owl:Class ;
-    rdfs:label "ribonucleoprotein complex" ;
-    NIFRID:synonym "extracellular ribonucleoprotein complex",
-        "intracellular ribonucleoprotein complex",
-        "protein-RNA complex",
-        "RNA-protein complex",
-        "RNP" ;
-    rdfs:subClassOf GO:0032991 .
 
 ILX:0100107 a owl:Class ;
     rdfs:label "Glutamate receptor" ;
@@ -1471,13 +1364,19 @@ ILX:0105486 a owl:Class ;
     rdfs:label "Inhibitory" ;
     rdfs:subClassOf PATO:0001238 .
 
-ILX:0110092 a owl:Class ;
-    rdfs:label "Rexed lamina II" ;
-    rdfs:subClassOf NLX:143975 .
+ILX:0106328 a owl:Class ;
+    rdfs:label "Local Circuit role" ;
+    NIFRID:synonym "Pathway,	Small circuit" ;
+    rdfs:subClassOf BFO:0000023 .
 
-ILX:0110100 a owl:Class ;
-    rdfs:label "Rexed lamina X" ;
-    rdfs:subClassOf NLX:143975 .
+ILX:0731969 a owl:Class ;
+    rdfs:label "least splanchnic nerve" ;
+    NIFRID:synonym "least thoracic splanchnic nerve",
+        "lowest splanchnic nerve",
+        "nervus splanchnicus imus",
+        "ramus renalis nervus splanchnici minoris",
+        "renal branch of lesser splanchnic nerve",
+        "renal nerve" .
 
 ILX:0738290 a owl:Class ;
     rdfs:label "inferior cervical ganglion - middle cervical ganglion interganglionic segment of the sympathetic chain" ;
@@ -1501,6 +1400,14 @@ ILX:0738304 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0001508 ] .
+
+ILX:0738305 a owl:Class ;
+    rdfs:label "wall of internal carotid artery" ;
+    rdfs:subClassOf UBERON:0001062 .
+
+ILX:0738306 a owl:Class ;
+    rdfs:label "Neural tissue of T1" ;
+    rdfs:subClassOf UBERON:0001062 .
 
 ILX:0738308 a owl:Class ;
     rdfs:label "External branch of inferior laryngeal nerve" ;
@@ -1549,6 +1456,18 @@ ILX:0738319 a owl:Class ;
     rdfs:label "T1-T2 intercostal muscle" ;
     rdfs:subClassOf UBERON:0001062 .
 
+ILX:0738320 a owl:Class ;
+    rdfs:label "Neural tissue of medulla" ;
+    rdfs:subClassOf UBERON:0001062 .
+
+ILX:0738321 a owl:Class ;
+    rdfs:label "Neural tissue of C4" ;
+    rdfs:subClassOf UBERON:0001062 .
+
+ILX:0738322 a owl:Class ;
+    rdfs:label "Neural tissue of C5" ;
+    rdfs:subClassOf UBERON:0001062 .
+
 ILX:0738324 a owl:Class ;
     rdfs:label "Phrenic nucleus of C4" ;
     rdfs:subClassOf UBERON:0016850,
@@ -1563,19 +1482,39 @@ ILX:0738325 a owl:Class ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0006491 ] .
 
+ILX:0738326 a owl:Class ;
+    rdfs:label "Wall of larynx" ;
+    rdfs:subClassOf UBERON:0001062,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0001737 ] .
+
+ILX:0738371 a owl:Class ;
+    rdfs:label "Rexed Lamina VII of T1" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0006457 ],
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0016578 ] .
+
 ILX:0738372 a owl:Class ;
     rdfs:label "white communicating ramus of first thoracic spinal nerve" ;
     NIFRID:synonym "T1 white ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:14056 .
 
 ILX:0738432 a owl:Class ;
-    rdfs:label "Sixth lumbar spinal cord segment" ;
-    NIFRID:synonym "L6" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:label "L6 segment of lumbar spinal cord" ;
+    NIFRID:synonym "L6",
+        "sixth lumbar spinal cord segment" ;
+    rdfs:subClassOf UBERON:0007716 .
 
 ILX:0738433 a owl:Class ;
     rdfs:label "Dome of the Bladder" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:subClassOf UBERON:0001062,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0001255 ] .
 
 ILX:0738444 a owl:Class ;
     rdfs:label "interscapular brown adipose tissue" ;
@@ -1588,28 +1527,32 @@ ILX:0739241 a owl:Class ;
     rdfs:subClassOf UBERON:0001990 .
 
 ILX:0739295 a owl:Class ;
-    rdfs:label "Thirteenth thoracic ganglion" ;
-    NIFRID:synonym "T13 sympathetic ganglion",
+    rdfs:label "T13 sympathetic chain ganglion" ;
+    NIFRID:synonym "Thirteenth thoracic ganglion",
         "thirteenth thoracic sympathetic ganglion" ;
     rdfs:subClassOf UBERON:0000961 .
 
 ILX:0739296 a owl:Class ;
-    rdfs:label "fifth lumbar sympathetic ganglion" ;
+    rdfs:label "L5 sympathetic chain ganglion" ;
     NIFRID:synonym "fifth lumbar ganglion",
         "L5 sympathetic ganglion" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:subClassOf UBERON:8600121 .
 
 ILX:0739297 a owl:Class ;
-    rdfs:label "sixth lumbar sympathetic ganglion" ;
+    rdfs:label "L6 sympathetic chain ganglion" ;
     NIFRID:synonym "L6 sympathetic ganglion",
         "sixth lumbar ganglion" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:subClassOf UBERON:8600121 .
+
+ILX:0739298 a owl:Class ;
+    rdfs:label "gray communicating ramus of twelfth thoracic nerve" ;
+    NIFRID:synonym "T12 gray ramus" .
 
 ILX:0739299 a owl:Class ;
     rdfs:label "gray communicating ramus of sixth lumbar nerve" ;
     NIFRID:synonym "L6 gray ramus",
         "L6 grey ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf ILX:0794914 .
 
 ILX:0739303 a owl:Class ;
     rdfs:label "gray communicating ramus of second thoracic nerve" ;
@@ -1621,6 +1564,47 @@ ILX:0739304 a owl:Class ;
     NIFRID:synonym "T3 gray ramus" ;
     rdfs:subClassOf UBERON:0001021 .
 
+ILX:0741757 a owl:Class ;
+    rdfs:label "superior lateral cutaneous nerve of arm" ;
+    NIFRID:synonym "n. cutaneus brachii lateralis superior",
+        "superior lateral brachial cutaneous nerve" .
+
+ILX:0741799 a owl:Class ;
+    rdfs:label "inferior lateral cutaneous nerve of arm" ;
+    NIFRID:synonym "inferior lateral brachial cutaneous nerve",
+        "n. cutaneus brachii lateralis inferior" .
+
+ILX:0744531 a owl:Class ;
+    rdfs:label "muscles (TA98)" ;
+    ilxtr:hasExistingId <https://taviewer.openanatomy.org/?id=A04.0.00.000>,
+        ILX:0744531 ;
+    ilxtr:hasExternalId <https://taviewer.openanatomy.org/?id=A04.0.00.000> ;
+    ilxtr:hasIlxId ILX:0744531 ;
+    ilxtr:hasIlxPreferredId ILX:0744531 .
+
+ILX:0746029 a owl:Class ;
+    rdfs:label "muscles of lower limb (TA98)" ;
+    NIFRID:synonym "muscles of lower limb" ;
+    rdfs:subClassOf ILX:0744531 ;
+    ilxr:type ilx.type:term ;
+    ilxtr:hasExistingId <https://taviewer.openanatomy.org/?id=A04.7.00.001>,
+        ILX:0746029 ;
+    ilxtr:hasExternalId <https://taviewer.openanatomy.org/?id=A04.7.00.001> ;
+    ilxtr:hasIlxId ILX:0746029 ;
+    ilxtr:hasIlxPreferredId ILX:0746029 .
+
+ILX:0746147 a owl:Class ;
+    rdfs:label "extensor hallucis brevis (TA98)" ;
+    NIFRID:synonym "extensor hallucis brevis",
+        "m. extensor hallucis brevis" ;
+    rdfs:subClassOf ILX:0748695 .
+
+ILX:0748695 a owl:Class ;
+    rdfs:label "muscles (TA98)" ;
+    NIFRID:synonym "muscles",
+        "muscles OF muscles of lower limb" ;
+    rdfs:subClassOf ILX:0746029 .
+
 ILX:0770759 a owl:Class ;
     rdfs:label "Lamina propria mucosae of descending colon" ;
     rdfs:subClassOf UBERON:0001062,
@@ -1630,6 +1614,9 @@ ILX:0770759 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0007177 ] .
+
+ILX:0771006 a owl:Class ;
+    rdfs:label "Wall of duodenum" .
 
 ILX:0771089 a owl:Class ;
     rdfs:label "Serosa of descending colon" ;
@@ -1641,6 +1628,22 @@ ILX:0771089 a owl:Class ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0003335 ] .
 
+ILX:0771304 a owl:Class ;
+    rdfs:label "hepatic plexus" ;
+    rdfs:subClassOf UBERON:0001062 .
+
+ILX:0773031 a owl:Class ;
+    rdfs:label "Distal part of transverse colon" .
+
+ILX:0773238 a owl:Class ;
+    rdfs:label "Muscle layer of transverse colon" .
+
+ILX:0773631 a owl:Class ;
+    rdfs:label "Inferior rectal nerve plexus" .
+
+ILX:0773722 a owl:Class ;
+    rdfs:label "spinal cord gray matter" .
+
 ILX:0773760 a owl:Class ;
     rdfs:label "Circular muscle layer of descending colon" ;
     rdfs:subClassOf UBERON:0001062,
@@ -1648,14 +1651,22 @@ ILX:0773760 a owl:Class ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0001158 ] .
 
-ILX:0774144 a owl:Class ;
-    rdfs:label "Wall of neck of urinary bladder" ;
-    rdfs:subClassOf UBERON:0001062 .
-
 ILX:0774266 a owl:Class ;
-    rdfs:label "T1 sympathetic ganglion" ;
-    NIFRID:synonym "First thoracic ganglion" ;
+    rdfs:label "T1 sympathetic chain ganglion" ;
+    NIFRID:synonym "First thoracic ganglion",
+        "T1 paravertebral ganglion" ;
     rdfs:subClassOf UBERON:0000961 .
+
+ILX:0774562 a owl:Class ;
+    rdfs:label "Proximal half of duodenum" ;
+    NIFRID:synonym "proximal duodenum" ;
+    rdfs:subClassOf UBERON:0001062,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0002114 ] .
+
+ILX:0775392 a owl:Class ;
+    rdfs:label "Wall of terminal bronchiole" .
 
 ILX:0776070 a owl:Class ;
     rdfs:label "Longitudinal muscle layer of descending colon" ;
@@ -1666,10 +1677,6 @@ ILX:0776070 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:8410061 ] .
-
-ILX:0776616 a owl:Class ;
-    rdfs:label "External carotid nerve" ;
-    rdfs:subClassOf UBERON:0001021 .
 
 ILX:0777086 a owl:Class ;
     rdfs:label "T12 - T13 interganglionic segment of the sympathetic chain" ;
@@ -1724,7 +1731,8 @@ ILX:0777098 a owl:Class ;
     rdfs:subClassOf UBERON:0001062 .
 
 ILX:0784378 a owl:Class ;
-    rdfs:label "Ninth thoracic ganglion" ;
+    rdfs:label "T9 sympathetic chain ganglion" ;
+    NIFRID:synonym "T9 paravertebral ganglion" ;
     rdfs:subClassOf UBERON:0000961 .
 
 ILX:0784439 a owl:Class ;
@@ -1732,10 +1740,29 @@ ILX:0784439 a owl:Class ;
     NIFRID:synonym "gray communicating ramus of the fifth intercostal nerve",
         "T5 gray ramus",
         "T5 grey ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:14055 .
+
+ILX:0784569 a owl:Class ;
+    rdfs:label "T10 sympathetic chain ganglion" ;
+    NIFRID:synonym "T10 paravertebral ganglion" ;
+    rdfs:subClassOf UBERON:0000961 .
+
+ILX:0784588 a owl:Class ;
+    rdfs:label "Posterior root of left ninth thoracic nerve" .
+
+ILX:0784605 a owl:Class ;
+    rdfs:label "Posterior root of seventh thoracic nerve" .
+
+ILX:0784660 a owl:Class ;
+    rdfs:label "Left first thoracic spinal ganglion" .
+
+ILX:0784694 a owl:Class ;
+    rdfs:label "Fourth intercostal nerve" ;
+    rdfs:subClassOf UBERON:0003727 .
 
 ILX:0784721 a owl:Class ;
-    rdfs:label "Eighth thoracic ganglion" ;
+    rdfs:label "T8 sympathetic chain ganglion" ;
+    NIFRID:synonym "T8 paravertebral ganglion" ;
     rdfs:subClassOf UBERON:0000961 .
 
 ILX:0784804 a owl:Class ;
@@ -1744,8 +1771,48 @@ ILX:0784804 a owl:Class ;
         "anterior root of third thoracic nerve" ;
     rdfs:subClassOf UBERON:0014617 .
 
+ILX:0784952 a owl:Class ;
+    rdfs:label "Posterior root of left second thoracic nerve" .
+
+ILX:0784992 a owl:Class ;
+    rdfs:label "Posterior root of left eighth thoracic nerve" .
+
+ILX:0785067 a owl:Class ;
+    rdfs:label "gray communicating ramus of eleventh thoracic nerve" ;
+    NIFRID:synonym "gray communicating ramus of the eleventh intercostal nerve",
+        "T11 gray ramus",
+        "T11 grey ramus" ;
+    rdfs:subClassOf FMA:14055 .
+
+ILX:0785076 a owl:Class ;
+    rdfs:label "Tenth intercostal nerve" ;
+    rdfs:subClassOf UBERON:0003727 .
+
+ILX:0785098 a owl:Class ;
+    rdfs:label "Posterior root of right twelfth thoracic nerve" .
+
+ILX:0785201 a owl:Class ;
+    rdfs:label "Posterior root of fifth lumbar nerve" .
+
 ILX:0785238 a owl:Class ;
-    rdfs:label "Anterior ramus of second sacral nerve" .
+    rdfs:label "Anterior ramus of second sacral nerve" ;
+    rdfs:subClassOf FMA:6030 .
+
+ILX:0785242 a owl:Class ;
+    rdfs:label "Anterior ramus of fourth lumbar nerve" .
+
+ILX:0785251 a owl:Class ;
+    rdfs:label "Left eighth cervical spinal ganglion" .
+
+ILX:0785338 a owl:Class ;
+    rdfs:label "Posterior root of fourth sacral nerve" .
+
+ILX:0785409 a owl:Class ;
+    rdfs:label "Left second lumbar spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002856 .
+
+ILX:0785420 a owl:Class ;
+    rdfs:label "Left second thoracic spinal ganglion" .
 
 ILX:0785421 a owl:Class ;
     rdfs:label "ventral root of the first lumbar spinal cord segment" ;
@@ -1753,30 +1820,67 @@ ILX:0785421 a owl:Class ;
         "anterior root of L1" ;
     rdfs:subClassOf UBERON:0024382 .
 
+ILX:0785435 a owl:Class ;
+    rdfs:label "Third intercostal nerve" ;
+    rdfs:subClassOf UBERON:0003727 .
+
+ILX:0785440 a owl:Class ;
+    rdfs:label "Posterior root of fifth cervical nerve" .
+
+ILX:0785477 a owl:Class ;
+    rdfs:label "Posterior root of right sixth thoracic nerve" .
+
+ILX:0785488 a owl:Class ;
+    rdfs:label "Posterior root of left tenth thoracic nerve" .
+
+ILX:0785542 a owl:Class ;
+    rdfs:label "gray communicating ramus of ninth thoracic nerve" ;
+    NIFRID:synonym "gray communicating ramus of the ninth intercostal nerve",
+        "T9 gray ramus",
+        "T9 grey ramus" ;
+    rdfs:subClassOf FMA:14055 .
+
+ILX:0785632 a owl:Class ;
+    rdfs:label "Posterior root of first thoracic nerve" .
+
+ILX:0785659 a owl:Class ;
+    rdfs:label "Right eleventh thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002854 .
+
+ILX:0785729 a owl:Class ;
+    rdfs:label "Left ninth thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002852 .
+
 ILX:0785733 a owl:Class ;
     rdfs:label "gray communicating ramus of second lumbar nerve" ;
     NIFRID:synonym "L2 gray ramus",
         "L2 grey ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf ILX:0794914 .
 
 ILX:0785825 a owl:Class ;
     rdfs:label "gray communicating ramus of first lumbar nerve" ;
     NIFRID:synonym "L1 gray ramus" ;
-    rdfs:subClassOf UBERON:0001021 .
+    rdfs:subClassOf ILX:0794914 .
+
+ILX:0785878 a owl:Class ;
+    rdfs:label "Left seventh thoracic spinal ganglion" .
 
 ILX:0785932 a owl:Class ;
     rdfs:label "gray communicating ramus of third lumbar nerve" ;
     NIFRID:synonym "L3 gray ramus",
         "L3 grey ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf ILX:0794914 .
 
-ILX:0786049 a owl:Class ;
-    rdfs:label "Fourth sacral ganglion" ;
-    rdfs:subClassOf FMA:6473 .
+ILX:0785982 a owl:Class ;
+    rdfs:label "Radial nerve component of C7 nerve" .
 
 ILX:0786141 a owl:Class ;
-    rdfs:label "Fifth thoracic ganglion" ;
+    rdfs:label "T5 sympathetic chain ganglion" ;
+    NIFRID:synonym "T5 paravertebral ganglion" ;
     rdfs:subClassOf UBERON:0000961 .
+
+ILX:0786145 a owl:Class ;
+    rdfs:label "Posterior root of third sacral nerve" .
 
 ILX:0786163 a owl:Class ;
     rdfs:label "ventral root of the eighth cervical spinal cord segment" ;
@@ -1786,30 +1890,76 @@ ILX:0786163 a owl:Class ;
     rdfs:subClassOf UBERON:0014634 .
 
 ILX:0786228 a owl:Class ;
-    rdfs:label "Second thoracic ganglion" ;
+    rdfs:label "T2 sympathetic chain ganglion" ;
+    NIFRID:synonym "T2 paravertebral ganglion" ;
     rdfs:subClassOf UBERON:0000961 .
 
 ILX:0786272 a owl:Class ;
-    rdfs:label "Fourth thoracic ganglion" ;
+    rdfs:label "T4 sympathetic chain ganglion" ;
+    NIFRID:synonym "T4 paravertebral ganglion" ;
     rdfs:subClassOf UBERON:0000961 .
+
+ILX:0786372 a owl:Class ;
+    rdfs:label "Right tenth thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002853 .
+
+ILX:0786390 a owl:Class ;
+    rdfs:label "Thoracodorsal nerve component of C7 nerve" .
+
+ILX:0786402 a owl:Class ;
+    rdfs:label "Posterior root of right eleventh thoracic nerve" .
+
+ILX:0786477 a owl:Class ;
+    rdfs:label "Left first lumbar spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002857 .
 
 ILX:0786722 a owl:Class ;
-    rdfs:label "Third thoracic ganglion" ;
+    rdfs:label "T3 sympathetic chain ganglion" ;
+    NIFRID:synonym "T3 paravertebral ganglion" ;
     rdfs:subClassOf UBERON:0000961 .
 
+ILX:0786747 a owl:Class ;
+    rdfs:label "Posterior root of fourth lumbar nerve" .
+
+ILX:0786788 a owl:Class ;
+    rdfs:label "Posterior root of left first lumbar nerve" .
+
+ILX:0786793 a owl:Class ;
+    rdfs:label "Posterior root of right eighth thoracic nerve" .
+
+ILX:0786813 a owl:Class ;
+    rdfs:label "Posterior root of right ninth thoracic nerve" .
+
 ILX:0786933 a owl:Class ;
-    rdfs:label "Second lumbar ganglion" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:label "L2 sympathetic chain ganglion" ;
+    rdfs:subClassOf UBERON:8600121 .
+
+ILX:0786989 a owl:Class ;
+    rdfs:label "Right twelfth thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002855 .
 
 ILX:0787009 a owl:Class ;
-    rdfs:label "Twelfth thoracic ganglion" ;
+    rdfs:label "T12 sympathetic chain ganglion" ;
+    NIFRID:synonym "T12 paravertebral ganglion" ;
+    rdfs:subClassOf UBERON:0000961 .
+
+ILX:0787015 a owl:Class ;
+    rdfs:label "T11 sympathetic chain ganglion" ;
+    NIFRID:synonym "T11 paravertebral ganglion" ;
     rdfs:subClassOf UBERON:0000961 .
 
 ILX:0787082 a owl:Class ;
     rdfs:label "gray communicating ramus of the first thoracic nerve" ;
     NIFRID:synonym "gray communicating ramus of the first intercostal nerve",
         "T1 gray ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:14055 .
+
+ILX:0787227 a owl:Class ;
+    rdfs:label "Posterior root of third lumbar nerve" .
+
+ILX:0787443 a owl:Class ;
+    rdfs:label "Fifth intercostal nerve" ;
+    rdfs:subClassOf UBERON:0003727 .
 
 ILX:0787520 a owl:Class ;
     rdfs:label "ventral root of the third lumbar spinal cord segment" ;
@@ -1817,12 +1967,21 @@ ILX:0787520 a owl:Class ;
         "anterior root of third lumbar nerve" ;
     rdfs:subClassOf UBERON:0024382 .
 
+ILX:0787528 a owl:Class ;
+    rdfs:label "Second sacral nerve" .
+
 ILX:0787562 a owl:Class ;
     rdfs:label "gray communicating ramus of the third thoracic nerve" ;
     NIFRID:synonym "gray communicating ramus of the third intercostal nerve",
         "T3 gray ramus",
         "T3 grey ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:14055 .
+
+ILX:0787564 a owl:Class ;
+    rdfs:label "Anterior ramus of third lumbar nerve" .
+
+ILX:0787665 a owl:Class ;
+    rdfs:label "Posterior root of twelfth thoracic nerve" .
 
 ILX:0787722 a owl:Class ;
     rdfs:label "ventral root of the first thoracic spinal cord segment" ;
@@ -1830,16 +1989,36 @@ ILX:0787722 a owl:Class ;
         "anterior root of T1" ;
     rdfs:subClassOf UBERON:0014617 .
 
+ILX:0787779 a owl:Class ;
+    rdfs:label "Posterior root of first lumbar nerve" .
+
+ILX:0787781 a owl:Class ;
+    rdfs:label "Posterior root of right seventh thoracic nerve" .
+
+ILX:0787810 a owl:Class ;
+    rdfs:label "Left twelfth thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002855 .
+
+ILX:0787870 a owl:Class ;
+    rdfs:label "Posterior root of eighth cervical nerve" .
+
 ILX:0787946 a owl:Class ;
     rdfs:label "gray communicating ramus of sixth thoracic nerve" ;
     NIFRID:synonym "gray communicating ramus of the sixth intercostal nerve",
         "T6 gray ramus",
         "T6 grey ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:14055 .
+
+ILX:0787969 a owl:Class ;
+    rdfs:label "Eighth intercostal nerve" ;
+    rdfs:subClassOf UBERON:0003727 .
 
 ILX:0788022 a owl:Class ;
-    rdfs:label "Gray communicating ramus of thoracic nerve" ;
-    rdfs:subClassOf UBERON:0001021 .
+    rdfs:label "gray communicating ramus of thoracic nerve" ;
+    rdfs:subClassOf FMA:5876 .
+
+ILX:0788023 a owl:Class ;
+    rdfs:label "Posterior root of left seventh thoracic nerve" .
 
 ILX:0788026 a owl:Class ;
     rdfs:label "ventral root of the eighth thoracic spinal cord segment" ;
@@ -1847,18 +2026,35 @@ ILX:0788026 a owl:Class ;
         "anterior root of T8" ;
     rdfs:subClassOf UBERON:0014617 .
 
+ILX:0788280 a owl:Class ;
+    rdfs:label "Posterior ramus of third cervical nerve" .
+
+ILX:0788303 a owl:Class ;
+    rdfs:label "Lateral pectoral nerve component of C6 nerve" .
+
 ILX:0788315 a owl:Class ;
-    rdfs:label "Third lumbar ganglion" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:label "L3 sympathetic chain ganglion" ;
+    rdfs:subClassOf UBERON:8600121 .
 
 ILX:0788532 a owl:Class ;
-    rdfs:label "Anterior ramus of third sacral nerve" .
+    rdfs:label "Anterior ramus of third sacral nerve" ;
+    rdfs:subClassOf FMA:6030 .
 
 ILX:0788536 a owl:Class ;
     rdfs:label "gray communicating ramus of fourth lumbar nerve" ;
     NIFRID:synonym "L4 gray ramus",
         "L4 grey ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf ILX:0794914 .
+
+ILX:0788647 a owl:Class ;
+    rdfs:label "Right seventh thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002850 .
+
+ILX:0788670 a owl:Class ;
+    rdfs:label "ventral root of the tenth thoracic spinal cord segment" ;
+    NIFRID:synonym "anterior root of T10",
+        "anterior root of tenth thoracic nerve" ;
+    rdfs:subClassOf UBERON:0014617 .
 
 ILX:0788675 a owl:Class ;
     rdfs:label "ventral root of the second lumbar spinal cord segment" ;
@@ -1866,19 +2062,53 @@ ILX:0788675 a owl:Class ;
         "anterior root of second lumbar nerve" ;
     rdfs:subClassOf UBERON:0024382 .
 
+ILX:0788711 a owl:Class ;
+    rdfs:label "Right ninth thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002852 .
+
+ILX:0788723 a owl:Class ;
+    rdfs:label "Posterior root of second sacral nerve" .
+
+ILX:0788771 a owl:Class ;
+    rdfs:label "gray communicating ramus of seventh thoracic nerve" ;
+    NIFRID:synonym "gray communicating ramus of the seventh intercostal nerve",
+        "T7 gray ramus",
+        "T7 grey ramus" ;
+    rdfs:subClassOf FMA:14055 .
+
 ILX:0788777 a owl:Class ;
-    rdfs:label "Anterior ramus of fourth sacral nerve" .
+    rdfs:label "Anterior ramus of fourth sacral nerve" ;
+    rdfs:subClassOf FMA:6030 .
+
+ILX:0788815 a owl:Class ;
+    rdfs:label "Posterior root of left third thoracic nerve" .
 
 ILX:0788945 a owl:Class ;
     rdfs:label "gray communicating ramus of the fourth thoracic nerve" ;
     NIFRID:synonym "gray communicating ramus of the fourth intercostal nerve",
         "T4 gray ramus",
         "T4 grey ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:14055 .
+
+ILX:0788972 a owl:Class ;
+    rdfs:label "First lumbar nerve" .
+
+ILX:0788975 a owl:Class ;
+    rdfs:label "Long thoracic nerve component of C5 nerve" .
+
+ILX:0789105 a owl:Class ;
+    rdfs:label "Posterior root of seventh cervical nerve" .
 
 ILX:0789109 a owl:Class ;
-    rdfs:label "First sacral ganglion" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:label "S1 sympathetic chain ganglion" ;
+    rdfs:subClassOf UBERON:8600122 .
+
+ILX:0789143 a owl:Class ;
+    rdfs:label "Lateral pectoral nerve component of C5 nerve" .
+
+ILX:0789287 a owl:Class ;
+    rdfs:label "Sixth intercostal nerve" ;
+    rdfs:subClassOf UBERON:0003727 .
 
 ILX:0789339 a owl:Class ;
     rdfs:label "Pharyngeal branch of glossopharyngeal nerve" ;
@@ -1887,10 +2117,30 @@ ILX:0789339 a owl:Class ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0001649 ] .
 
+ILX:0789482 a owl:Class ;
+    rdfs:label "Second intercostal nerve" ;
+    rdfs:subClassOf UBERON:0003727 .
+
+ILX:0789580 a owl:Class ;
+    rdfs:label "Celiac branch of posterior vagal trunk" .
+
+ILX:0789655 a owl:Class ;
+    rdfs:label "S2 sympathetic chain ganglion" ;
+    rdfs:subClassOf UBERON:8600122 .
+
+ILX:0789741 a owl:Class ;
+    rdfs:label "Posterior root of ninth thoracic nerve" .
+
+ILX:0789839 a owl:Class ;
+    rdfs:label "Posterior root of left eleventh thoracic nerve" .
+
 ILX:0789862 a owl:Class ;
-    rdfs:label "First lumbar ganglion" ;
+    rdfs:label "L1 sympathetic chain ganglion" ;
     NIFRID:synonym "L1 sympathetic ganglion" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:subClassOf UBERON:8600121 .
+
+ILX:0789892 a owl:Class ;
+    rdfs:label "Posterior root of tenth thoracic nerve" .
 
 ILX:0789894 a owl:Class ;
     rdfs:label "ventral root of the second thoracic spinal cord segment" ;
@@ -1899,7 +2149,8 @@ ILX:0789894 a owl:Class ;
     rdfs:subClassOf UBERON:0014617 .
 
 ILX:0789947 a owl:Class ;
-    rdfs:label "Sixth thoracic ganglion" ;
+    rdfs:label "T6 sympathetic chain ganglion" ;
+    NIFRID:synonym "T6 paravertebral ganglion" ;
     rdfs:subClassOf UBERON:0000961 .
 
 ILX:0789966 a owl:Class ;
@@ -1914,23 +2165,69 @@ ILX:0789968 a owl:Class ;
         "anterior root of L4" ;
     rdfs:subClassOf UBERON:0024382 .
 
+ILX:0790142 a owl:Class ;
+    rdfs:label "Radial nerve component of C8 nerve" .
+
 ILX:0790146 a owl:Class ;
     rdfs:label "ventral root of the fifth thoracic spinal cord segment" ;
     NIFRID:synonym "anterior root of fifth thoracic nerve",
         "anterior root of T5" ;
     rdfs:subClassOf UBERON:0014617 .
 
+ILX:0790316 a owl:Class ;
+    rdfs:label "left nodose ganglion" ;
+    rdfs:subClassOf UBERON:0000045 .
+
+ILX:0790338 a owl:Class ;
+    rdfs:label "Posterior root of eleventh thoracic nerve" .
+
+ILX:0790352 a owl:Class ;
+    rdfs:label "Posterior root of left first thoracic nerve" .
+
+ILX:0790394 a owl:Class ;
+    rdfs:label "S3 sympathetic chain ganglion" ;
+    rdfs:subClassOf UBERON:8600122 .
+
+ILX:0790414 a owl:Class ;
+    rdfs:label "Posterior root of left twelfth thoracic nerve" .
+
+ILX:0790443 a owl:Class ;
+    rdfs:label "Anterior ramus of second lumbar nerve" .
+
 ILX:0790472 a owl:Class ;
-    rdfs:label "Fourth lumbar ganglion" ;
-    rdfs:subClassOf FMA:6472 .
+    rdfs:label "L4 sympathetic chain ganglion" ;
+    rdfs:subClassOf UBERON:8600121 .
 
 ILX:0790482 a owl:Class ;
-    rdfs:label "Seventh thoracic ganglion" ;
+    rdfs:label "T7 sympathetic chain ganglion" ;
+    NIFRID:synonym "T7 paravertebral ganglion" ;
     rdfs:subClassOf UBERON:0000961 .
+
+ILX:0790494 a owl:Class ;
+    rdfs:label "Left eighth thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002851 .
 
 ILX:0790497 a owl:Class ;
     rdfs:label "Gray communicating ramus of cervicothoracic ganglion to first thoracic spinal nerve" ;
     rdfs:subClassOf UBERON:0001021 .
+
+ILX:0790504 a owl:Class ;
+    rdfs:label "First sacral nerve" .
+
+ILX:0790553 a owl:Class ;
+    rdfs:label "Hepatic branch of left vagus nerve" .
+
+ILX:0790602 a owl:Class ;
+    rdfs:label "ventral root of the eleventh thoracic spinal cord segment" ;
+    NIFRID:synonym "anterior root of eleventh thoracic nerve",
+        "anterior root of T11" ;
+    rdfs:subClassOf UBERON:0014617 .
+
+ILX:0790949 a owl:Class ;
+    rdfs:label "Lateral pectoral nerve component of C7 nerve" .
+
+ILX:0791046 a owl:Class ;
+    rdfs:label "Twelfth thoracic nerve" .
 
 ILX:0791062 a owl:Class ;
     rdfs:label "ventral root of the sixth thoracic spinal cord segment" ;
@@ -1938,11 +2235,14 @@ ILX:0791062 a owl:Class ;
         "anterior root of T6" ;
     rdfs:subClassOf UBERON:0014617 .
 
+ILX:0791100 a owl:Class ;
+    rdfs:label "Left third thoracic spinal ganglion" .
+
 ILX:0791105 a owl:Class ;
     rdfs:label "gray communicating ramus of the second thoracic nerve" ;
     NIFRID:synonym "gray communicating ramus of the second intercostal nerve",
         "T2 gray ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:14055 .
 
 ILX:0791148 a owl:Class ;
     rdfs:label "ventral root of the fifth lumbar spinal cord segment" ;
@@ -1950,15 +2250,98 @@ ILX:0791148 a owl:Class ;
         "anterior root of L5" ;
     rdfs:subClassOf UBERON:0024382 .
 
+ILX:0791153 a owl:Class ;
+    rdfs:label "Right eighth thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002851 .
+
+ILX:0791390 a owl:Class ;
+    rdfs:label "Anterior ramus of first lumbar nerve" .
+
+ILX:0791512 a owl:Class ;
+    rdfs:label "Posterior ramus of fourth cervical nerve" .
+
+ILX:0791527 a owl:Class ;
+    rdfs:label "Right sixth thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002849 .
+
+ILX:0791560 a owl:Class ;
+    rdfs:label "gray communicating ramus of eighth thoracic nerve" ;
+    NIFRID:synonym "gray communicating ramus of the eighth intercostal nerve",
+        "T8 gray ramus",
+        "T8 grey ramus" ;
+    rdfs:subClassOf FMA:14055 .
+
+ILX:0791633 a owl:Class ;
+    rdfs:label "Posterior root of first sacral nerve" .
+
+ILX:0791808 a owl:Class ;
+    rdfs:label "Seventh intercostal nerve" ;
+    rdfs:subClassOf UBERON:0003727 .
+
 ILX:0791932 a owl:Class ;
     rdfs:label "ventral root of the ninth thoracic spinal cord segment" ;
     NIFRID:synonym "anterior root of ninth thoracic nerve",
         "anterior root of T9" ;
     rdfs:subClassOf UBERON:0014617 .
 
+ILX:0792048 a owl:Class ;
+    rdfs:label "ventral root of the twelveth thoracic spinal cord segment" ;
+    NIFRID:synonym "anterior root of T12",
+        "anterior root of twelveth thoracic nerve" ;
+    rdfs:subClassOf UBERON:0014617 .
+
+ILX:0792057 a owl:Class ;
+    rdfs:label "Left eleventh thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002854 .
+
+ILX:0792058 a owl:Class ;
+    rdfs:label "Posterior root of second lumbar nerve" .
+
+ILX:0792093 a owl:Class ;
+    rdfs:label "Posterior root of left eighth cervical nerve" .
+
+ILX:0792132 a owl:Class ;
+    rdfs:label "Eleventh intercostal nerve" ;
+    rdfs:subClassOf UBERON:0003727 .
+
+ILX:0792193 a owl:Class ;
+    rdfs:label "First intercostal nerve" ;
+    rdfs:subClassOf UBERON:0003727 .
+
+ILX:0792327 a owl:Class ;
+    rdfs:label "Fourth sacral nerve" .
+
+ILX:0792342 a owl:Class ;
+    rdfs:label "Posterior root of left second lumbar nerve" .
+
+ILX:0792409 a owl:Class ;
+    rdfs:label "gray communicating ramus of tenth thoracic nerve" ;
+    NIFRID:synonym "gray communicating ramus of the tenth intercostal nerve",
+        "T10 gray ramus",
+        "T10 grey ramus" ;
+    rdfs:subClassOf FMA:14055 .
+
+ILX:0792433 a owl:Class ;
+    rdfs:label "right nodose ganglion" ;
+    rdfs:subClassOf UBERON:0000045 .
+
+ILX:0792508 a owl:Class ;
+    rdfs:label "Left tenth thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002853 .
+
+ILX:0792543 a owl:Class ;
+    rdfs:label "Ninth intercostal nerve" ;
+    rdfs:subClassOf UBERON:0003727 .
+
+ILX:0792624 a owl:Class ;
+    rdfs:label "Posterior root of eighth thoracic nerve" .
+
 ILX:0792627 a owl:Class ;
     rdfs:label "White communicating ramus of thoracic anterior ramus" ;
-    rdfs:subClassOf UBERON:0001021 .
+    rdfs:subClassOf FMA:5875 .
+
+ILX:0792748 a owl:Class ;
+    rdfs:label "Posterior root of sixth cervical nerve" .
 
 ILX:0792838 a owl:Class ;
     rdfs:label "ventral root of the fourth thoracic spinal cord segment" ;
@@ -1971,6 +2354,9 @@ ILX:0792853 a owl:Class ;
     NIFRID:synonym "anterior root of first sacral nerve",
         "anterior root of S1" ;
     rdfs:subClassOf UBERON:0023623 .
+
+ILX:0792995 a owl:Class ;
+    rdfs:label "Posterior root of right tenth thoracic nerve" .
 
 ILX:0793082 a owl:Class ;
     rdfs:label "celiac ganglion- superior mesenteric ganglion complex" ;
@@ -1992,46 +2378,94 @@ ILX:0793178 a owl:Class ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0001264 ] .
 
+ILX:0793207 a owl:Class ;
+    rdfs:label "ventral root of the thirteenth thoracic spinal cord segment" ;
+    NIFRID:synonym "anterior root of T13",
+        "Anterior root of thirteenth thoracic nerve" ;
+    rdfs:subClassOf UBERON:0014617 .
+
 ILX:0793208 a owl:Class ;
     rdfs:label "white communicating ramus of second thoracic spinal nerve" ;
     NIFRID:synonym "T2 white ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:14056 .
 
 ILX:0793209 a owl:Class ;
     rdfs:label "white communicating ramus of third thoracic spinal nerve" ;
     NIFRID:synonym "T3 white ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:14056 .
 
 ILX:0793210 a owl:Class ;
     rdfs:label "white communicating ramus of fourth thoracic spinal nerve" ;
     NIFRID:synonym "T4 white ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:14056 .
 
 ILX:0793211 a owl:Class ;
     rdfs:label "white communicating ramus of fifth thoracic spinal nerve" ;
     NIFRID:synonym "T5 white ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:14056 .
 
 ILX:0793212 a owl:Class ;
     rdfs:label "white communicating ramus of sixth thoracic spinal nerve" ;
     NIFRID:synonym "T6 white ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:14056 .
+
+ILX:0793213 a owl:Class ;
+    rdfs:label "white communicating ramus of seventh thoracic spinal nerve" ;
+    NIFRID:synonym "T7 white ramus" ;
+    rdfs:subClassOf FMA:14056 .
+
+ILX:0793214 a owl:Class ;
+    rdfs:label "white communicating ramus of eighth thoracic spinal nerve" ;
+    NIFRID:synonym "T8 white ramus" ;
+    rdfs:subClassOf FMA:14056 .
+
+ILX:0793215 a owl:Class ;
+    rdfs:label "white communicating ramus of ninth thoracic spinal nerve" ;
+    NIFRID:synonym "T9 white ramus" ;
+    rdfs:subClassOf FMA:14056 .
+
+ILX:0793216 a owl:Class ;
+    rdfs:label "white communicating ramus of tenth thoracic spinal nerve" ;
+    NIFRID:synonym "T10 white ramus" ;
+    rdfs:subClassOf FMA:14056 .
+
+ILX:0793217 a owl:Class ;
+    rdfs:label "white communicating ramus of eleventh thoracic spinal nerve" ;
+    NIFRID:synonym "T11 white ramus" ;
+    rdfs:subClassOf FMA:14056 .
+
+ILX:0793218 a owl:Class ;
+    rdfs:label "white communicating ramus of twelfth thoracic spinal nerve" ;
+    NIFRID:synonym "T12 white ramus" ;
+    rdfs:subClassOf FMA:14056 .
+
+ILX:0793219 a owl:Class ;
+    rdfs:label "white communicating ramus of thirteenth thoracic spinal nerve" ;
+    NIFRID:synonym "T13 white ramus" ;
+    rdfs:subClassOf FMA:14056 .
 
 ILX:0793220 a owl:Class ;
     rdfs:label "white communicating ramus of first lumbar spinal nerve" ;
     NIFRID:synonym "L1 white ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:16416 .
 
 ILX:0793221 a owl:Class ;
     rdfs:label "white communicating ramus of second lumbar spinal nerve" ;
     NIFRID:synonym "L2 white ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:16416 .
+
+ILX:0793227 a owl:Class ;
+    rdfs:label "gray communicating ramus of thirteenth thoracic nerve" ;
+    NIFRID:synonym "gray communicating ramus of the thirteenth intercostal nerve",
+        "T13 gray ramus",
+        "T13 grey ramus" ;
+    rdfs:subClassOf FMA:14055 .
 
 ILX:0793228 a owl:Class ;
     rdfs:label "gray communicating ramus of first sacral nerve" ;
     NIFRID:synonym "S1 gray ramus",
         "S1 grey ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf ILX:0794913 .
 
 ILX:0793335 a owl:Class ;
     rdfs:label "T5 sympathetic chain" ;
@@ -2047,15 +2481,11 @@ ILX:0793336 a owl:Class ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0000407 ] .
 
-ILX:0793350 a owl:Class ;
-    rdfs:label "S1 sympathetic chain" ;
-    rdfs:subClassOf ILX:0793766 .
-
 ILX:0793357 a owl:Class ;
-    rdfs:label "Thirteenth thoracic spinal cord segment" ;
+    rdfs:label "T13 segment of thoracic spinal cord" ;
     NIFRID:synonym "T13 segment",
         "T13 spinal cord segment" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:subClassOf UBERON:0007715 .
 
 ILX:0793359 a owl:Class ;
     rdfs:label "thirteenth thoracic dorsal root ganglion" ;
@@ -2073,7 +2503,7 @@ ILX:0793360 a owl:Class ;
 ILX:0793361 a owl:Class ;
     rdfs:label "white communicating ramus of third lumbar spinal nerve" ;
     NIFRID:synonym "L3 white ramus" ;
-    rdfs:subClassOf UBERON:0017642 .
+    rdfs:subClassOf FMA:16416 .
 
 ILX:0793362 a owl:Class ;
     rdfs:label "White communicating ramus of fourth lumbar anterior ramus" ;
@@ -2082,12 +2512,12 @@ ILX:0793362 a owl:Class ;
 
 ILX:0793550 a owl:Class ;
     rdfs:label "mediastinal ganglion" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:subClassOf UBERON:0001805 .
 
 ILX:0793555 a owl:Class ;
     rdfs:label "Atrial intrinsic cardiac ganglion" ;
     NIFRID:synonym "atrial ganglionated plexus" ;
-    rdfs:subClassOf UBERON:0001062,
+    rdfs:subClassOf UBERON:0014463,
         [ a owl:Restriction ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0035814 ] .
@@ -2095,10 +2525,16 @@ ILX:0793555 a owl:Class ;
 ILX:0793556 a owl:Class ;
     rdfs:label "ventricular intrinsic cardiac ganglion" ;
     NIFRID:synonym "Ventricular ganglionated plexus" ;
-    rdfs:subClassOf UBERON:0001062,
+    rdfs:subClassOf UBERON:0014463,
         [ a owl:Restriction ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0035814 ] .
+
+ILX:0793558 a owl:Class ;
+    rdfs:label "distal stomach" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0000945 ] .
 
 ILX:0793559 a owl:Class ;
     rdfs:label "bladder nerve" ;
@@ -2238,7 +2674,7 @@ ILX:0793646 a owl:Class ;
 
 ILX:0793656 a owl:Class ;
     rdfs:label "myenteric nerve plexus of stomach" ;
-    rdfs:subClassOf UBERON:0001062,
+    rdfs:subClassOf UBERON:0002439,
         [ a owl:Restriction ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0000945 ],
@@ -2255,6 +2691,13 @@ ILX:0793657 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:8410058 ] .
+
+ILX:0793658 a owl:Class ;
+    rdfs:label "proximal stomach" ;
+    rdfs:subClassOf UBERON:0001062,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0000945 ] .
 
 ILX:0793659 a owl:Class ;
     rdfs:label "Submucosal nerve plexus of descending colon" ;
@@ -2283,14 +2726,14 @@ ILX:0793664 a owl:Class ;
 
 ILX:0793667 a owl:Class ;
     rdfs:label "myenteric plexus of gastric antrum" ;
-    rdfs:subClassOf ILX:0793656,
+    rdfs:subClassOf UBERON:0002439,
         [ a owl:Restriction ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0001165 ] .
 
 ILX:0793668 a owl:Class ;
     rdfs:label "myenteric plexus of proximal duodenum" ;
-    rdfs:subClassOf UBERON:0001062,
+    rdfs:subClassOf UBERON:0002439,
         [ a owl:Restriction ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:8410063 ] .
@@ -2354,6 +2797,9 @@ ILX:0793681 a owl:Class ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0002106 ] .
 
+ILX:0793684 a owl:Class ;
+    rdfs:label "Wall of trachea" .
+
 ILX:0793697 a owl:Class ;
     rdfs:label "Intermediolateral nucleus of second thoracic segment" ;
     NIFRID:synonym "T2 intermediolateral cell column",
@@ -2400,6 +2846,14 @@ ILX:0793701 a owl:Class ;
 ILX:0793702 a owl:Class ;
     rdfs:label "Greater petrosal nerve" ;
     rdfs:subClassOf UBERON:0001021 .
+
+ILX:0793704 a owl:Class ;
+    rdfs:label "Esophageal nerve plexus" ;
+    NIFRID:synonym "oesophageal plexus" ;
+    rdfs:subClassOf UBERON:0001810,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0001759 ] .
 
 ILX:0793711 a owl:Class ;
     rdfs:label "Communicating branch of zygomatic nerve" ;
@@ -2456,25 +2910,37 @@ ILX:0793739 a owl:Class ;
     rdfs:label "Nerve fiber from submandibular ganglion to sublingual gland" ;
     rdfs:subClassOf UBERON:0011929 .
 
-ILX:0793766 a owl:Class ;
-    rdfs:label "sympathetic chain segment" ;
+ILX:0793764 a owl:Class ;
+    rdfs:label "Wall of bronchus" ;
+    NIFRID:synonym "Bronchial wall",
+        "Wall of bronchus" ;
     rdfs:subClassOf UBERON:0001062 .
+
+ILX:0793765 a owl:Class ;
+    rdfs:label "Wall of bronchiole" ;
+    NIFRID:synonym "Bronchiolar wall",
+        "Bronchiole wall",
+        "Wall of bronchiole" ;
+    rdfs:subClassOf UBERON:0000060 .
+
+ILX:0793769 a owl:Class ;
+    rdfs:label "smooth muscle" .
 
 ILX:0793800 a owl:Class ;
     rdfs:label "S2 sacral parasympathetic nucleus" ;
-    rdfs:subClassOf PAXSPN:80 .
+    rdfs:subClassOf UBERON:0011777 .
 
 ILX:0793801 a owl:Class ;
     rdfs:label "S3 sacral parasympathetic nucleus" ;
-    rdfs:subClassOf PAXSPN:80 .
+    rdfs:subClassOf UBERON:0011777 .
 
 ILX:0793802 a owl:Class ;
     rdfs:label "S4 sacral parasympathetic nucleus" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:subClassOf UBERON:0011777 .
 
 ILX:0793803 a owl:Class ;
     rdfs:label "inferior hypogastric nerve plexus ganglion" ;
-    rdfs:subClassOf UBERON:0001062,
+    rdfs:subClassOf UBERON:0001805,
         [ a owl:Restriction ;
             owl:onProperty ilx.partOf: ;
             owl:someValuesFrom UBERON:0002014 ] .
@@ -2482,11 +2948,11 @@ ILX:0793803 a owl:Class ;
 ILX:0793804 a owl:Class ;
     rdfs:label "L6 parasympathetic nucleus" ;
     NIFRID:synonym "parasympathetic nucleus of sixth lumbar segment" ;
-    rdfs:subClassOf ILX:0793897 .
+    rdfs:subClassOf UBERON:0011777 .
 
 ILX:0793805 a owl:Class ;
     rdfs:label "S1 sacral parasympathetic nucleus" ;
-    rdfs:subClassOf PAXSPN:80 .
+    rdfs:subClassOf UBERON:0011777 .
 
 ILX:0793806 a owl:Class ;
     rdfs:label "prostatic nerve plexus" ;
@@ -2530,7 +2996,7 @@ ILX:0793812 a owl:Class ;
 ILX:0793813 a owl:Class ;
     rdfs:label "Intermediolateral nucleus of ninth thoracic segment" ;
     NIFRID:synonym "T9 Intermediolateral nucleus" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:subClassOf UBERON:0002175 .
 
 ILX:0793814 a owl:Class ;
     rdfs:label "Intermediolateral nucleus of tenth thoracic segment" ;
@@ -2550,12 +3016,12 @@ ILX:0793815 a owl:Class ;
 
 ILX:0793816 a owl:Class ;
     rdfs:label "Intermediolateral nucleus of twelfth thoracic segment" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:subClassOf UBERON:0002175 .
 
 ILX:0793817 a owl:Class ;
     rdfs:label "Intermediolateral nucleus of thirteenth thoracic segment" ;
     NIFRID:synonym "T13 intermediolateral nucleus" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:subClassOf UBERON:0002175 .
 
 ILX:0793818 a owl:Class ;
     rdfs:label "Intermediolateral nucleus of first lumbar segment" ;
@@ -2574,7 +3040,7 @@ ILX:0793819 a owl:Class ;
 ILX:0793821 a owl:Class ;
     rdfs:label "prevertebral sympathetic ganglion in abdominal aortic plexus" ;
     NIFRID:synonym "abdominal aortic plexus prevertebral sympathetic ganglion" ;
-    rdfs:subClassOf UBERON:0001062 .
+    rdfs:subClassOf UBERON:0003964 .
 
 ILX:0793822 a owl:Class ;
     rdfs:label "Superior ovarian nerve" ;
@@ -2587,17 +3053,27 @@ ILX:0793823 a owl:Class ;
         "pelvic ganglion" ;
     rdfs:subClassOf UBERON:0000045 .
 
+ILX:0793826 a owl:Class ;
+    rdfs:label "anterior abdominal vagal trunk" ;
+    rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0001759 ] .
+
+ILX:0793827 a owl:Class ;
+    rdfs:label "posterior abdominal vagal trunk" ;
+    rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0001759 ] .
+
 ILX:0793832 a owl:Class ;
     rdfs:label "ovarian nerve plexus" ;
     rdfs:subClassOf UBERON:0001810 .
 
-ILX:0793833 a owl:Class ;
-    rdfs:label "ovarian nerve plexus parasympathetic ganglion" ;
-    rdfs:subClassOf UBERON:0000045 .
-
 ILX:0793834 a owl:Class ;
     rdfs:label "accessory pelvic ganglion" ;
-    rdfs:subClassOf UBERON:0000045 .
+    rdfs:subClassOf UBERON:0003964 .
 
 ILX:0793877 a owl:Class ;
     rdfs:label "Intermediolateral nucleus of sixth lumbar segment" ;
@@ -2664,45 +3140,64 @@ ILX:0793884 a owl:Class ;
     rdfs:label "first accessory pelvic ganglion" ;
     rdfs:subClassOf ILX:0793834 .
 
-ILX:0793897 a owl:Class ;
-    rdfs:label "lumbar parasympathetic nucleus" ;
-    rdfs:subClassOf UBERON:0001062 .
+ILX:0794141 a owl:Class ;
+    rdfs:label "right cervical vagus nerve" .
+
+ILX:0794142 a owl:Class ;
+    rdfs:label "left cervical vagus nerve" ;
+    rdfs:subClassOf UBERON:0001021 .
+
+ILX:0794473 a owl:Class ;
+    rdfs:label "abdominal branch of vagus nerve" ;
+    rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0001759 ] .
+
+ILX:0794476 a owl:Class ;
+    rdfs:label "abdominal branch of vagus nerve" ;
+    rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0001759 ] .
+
+ILX:0794506 a owl:Class ;
+    rdfs:label "posterior hepatic branch of vagus nerve" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0001759 ] .
 
 ILX:0794730 a owl:Class ;
     rdfs:label "aorticorenal ganglion" ;
-    rdfs:subClassOf UBERON:0001805 .
+    rdfs:subClassOf UBERON:0000045 .
 
 ILX:0794731 a owl:Class ;
     rdfs:label "smooth muscle of the cervix" ;
-    rdfs:subClassOf UBERON:0000002 .
+    rdfs:subClassOf ILX:0793769 .
 
 ILX:0794732 a owl:Class ;
     rdfs:label "intermesenteric plexus" ;
     rdfs:subClassOf UBERON:0001810 .
 
-ILX:0794733 a owl:Class ;
-    rdfs:label "ovarian nerve plexus sympathetic ganglion" ;
-    rdfs:subClassOf FMA:6638 .
-
 ILX:0794734 a owl:Class ;
     rdfs:label "blood vessel of the vagina" ;
-    rdfs:subClassOf UBERON:0000996 .
+    rdfs:subClassOf UBERON:0001981 .
 
 ILX:0794735 a owl:Class ;
     rdfs:label "smooth muscle of the isthmus of the Fallopian tube" ;
-    rdfs:subClassOf UBERON:0016632 .
+    rdfs:subClassOf ILX:0793769 .
 
 ILX:0794736 a owl:Class ;
     rdfs:label "blood vessel of the isthmus of the Fallopian tube" ;
-    rdfs:subClassOf UBERON:0016632 .
+    rdfs:subClassOf UBERON:0001981 .
 
 ILX:0794737 a owl:Class ;
     rdfs:label "blood vessel of the uterus" ;
-    rdfs:subClassOf UBERON:0000995 .
+    rdfs:subClassOf UBERON:0001981 .
 
 ILX:0794738 a owl:Class ;
     rdfs:label "blood vessel of the cervix" ;
-    rdfs:subClassOf UBERON:0000002 .
+    rdfs:subClassOf UBERON:0001981 .
 
 ILX:0794764 a owl:Class ;
     rdfs:label "suprarenal ganglion" ;
@@ -2718,19 +3213,667 @@ ILX:0794766 a owl:Class ;
 
 ILX:0794767 a owl:Class ;
     rdfs:label "smooth muscle of the upper uterus" ;
-    rdfs:subClassOf UBERON:0001296 .
+    rdfs:subClassOf ILX:0793769 .
 
 ILX:0794768 a owl:Class ;
     rdfs:label "smooth muscle of the lower uterus" ;
-    rdfs:subClassOf UBERON:0000995 .
+    rdfs:subClassOf ILX:0793769 .
 
 ILX:0794769 a owl:Class ;
     rdfs:label "upper uterine segment" ;
-    rdfs:subClassOf UBERON:0000995 .
+    rdfs:subClassOf UBERON:0005156,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0000995 ] .
 
 ILX:0794770 a owl:Class ;
     rdfs:label "lower uterine segment" ;
-    rdfs:subClassOf UBERON:0000995 .
+    rdfs:subClassOf UBERON:0005156,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0000995 ] .
+
+ILX:0794853 a owl:Class ;
+    rdfs:label "esophageal vagus trunk" ;
+    rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0001759 ] .
+
+ILX:0794910 a owl:Class ;
+    rdfs:label "ovarian ganglion" ;
+    rdfs:subClassOf UBERON:0000045 .
+
+ILX:0794913 a owl:Class ;
+    rdfs:label "sacral gray ramus" ;
+    rdfs:subClassOf FMA:5876 .
+
+ILX:0794914 a owl:Class ;
+    rdfs:label "lumbar gray ramus" ;
+    rdfs:subClassOf FMA:5876 .
+
+ILX:0794916 a owl:Class ;
+    rdfs:label "white ramus communicans" ;
+    rdfs:subClassOf UBERON:0017642 .
+
+ILX:0794948 a owl:Class ;
+    rdfs:label "medial portion of the brachialis muscle" ;
+    rdfs:subClassOf UBERON:0001506 .
+
+ILX:0794949 a owl:Class ;
+    rdfs:label "recurrent branch of the median nerve" ;
+    NIFRID:synonym "thenar branch of the median nerve" ;
+    rdfs:subClassOf UBERON:0001148 .
+
+ILX:0794950 a owl:Class ;
+    rdfs:label "articular branch of lateral pectoral nerve" .
+
+ILX:0794951 a owl:Class ;
+    rdfs:label "lateral cutaneous nerve of the forearm" ;
+    NIFRID:synonym "lateral antebrachial cutaneous nerve" ;
+    rdfs:subClassOf UBERON:0002386 .
+
+ILX:0794952 a owl:Class ;
+    rdfs:label "medial cutaneous nerve of the arm" ;
+    NIFRID:synonym "lesser internal cutaneous nerve",
+        "medial brachial cutaneous nerve" ;
+    rdfs:subClassOf UBERON:0001814 .
+
+ILX:0794953 a owl:Class ;
+    rdfs:label "medial cutaneous nerve of the forearm" ;
+    NIFRID:synonym "medial antebrachial cutaneous nerve" ;
+    rdfs:subClassOf UBERON:0001814 .
+
+ILX:0794954 a owl:Class ;
+    rdfs:label "dorsum of the hand" ;
+    rdfs:subClassOf UBERON:0002398 .
+
+ILX:0794955 a owl:Class ;
+    rdfs:label "dorsum of ulnar 11/2 fingers" ;
+    rdfs:subClassOf UBERON:0002398 .
+
+ILX:0794956 a owl:Class ;
+    rdfs:label "obliquus capitis superior muscle" ;
+    rdfs:subClassOf UBERON:0002377 .
+
+ILX:0794957 a owl:Class ;
+    rdfs:label "obliquus capitis inferior muscle" ;
+    rdfs:subClassOf UBERON:0002377 .
+
+ILX:0794958 a owl:Class ;
+    rdfs:label "Flexor digiti minimi brevis of the foot" ;
+    rdfs:subClassOf UBERON:0014377 .
+
+ILX:0794959 a owl:Class ;
+    rdfs:label "posterior rami lower cervical nerves" ;
+    rdfs:subClassOf FMA:6797 .
+
+ILX:0794960 a owl:Class ;
+    rdfs:label "flexor surface of ulnar 11/2 finger" ;
+    rdfs:subClassOf UBERON:0002398 .
+
+ILX:0794961 a owl:Class ;
+    rdfs:label "periosteum of the forearm" ;
+    rdfs:subClassOf UBERON:0002515 .
+
+ILX:0794962 a owl:Class ;
+    rdfs:label "Interosseous membrane of arm" ;
+    rdfs:subClassOf UBERON:0002384 .
+
+ILX:0794963 a owl:Class ;
+    rdfs:label "pronator quadratus muscle" ;
+    NIFRID:synonym "Pronator quadratus" ;
+    rdfs:subClassOf UBERON:0004254 .
+
+ILX:0794964 a owl:Class ;
+    rdfs:label "opponens pollicis muscle" ;
+    NIFRID:synonym "Opponens pollicis" ;
+    rdfs:subClassOf UBERON:0014376 .
+
+ILX:0794965 a owl:Class ;
+    rdfs:label "subacromial bursa" ;
+    rdfs:subClassOf UBERON:0001467 .
+
+ILX:0794966 a owl:Class ;
+    rdfs:label "suprascapular nerve" ;
+    rdfs:subClassOf UBERON:0001814 .
+
+ILX:0794967 a owl:Class ;
+    rdfs:label "posterior interosseous nerve" ;
+    NIFRID:synonym "Deep branch of radial nerve" ;
+    rdfs:subClassOf UBERON:0003433 .
+
+ILX:0794969 a owl:Class ;
+    rdfs:label "deep branch of ulnar nerve" ;
+    NIFRID:synonym "Deep terminal branch of ulnar nerve",
+        "Ramus profundus (Nervus ulnaris)" ;
+    rdfs:subClassOf UBERON:0001494 .
+
+ILX:0794970 a owl:Class ;
+    rdfs:label "medial head of median nerve" ;
+    NIFRID:synonym "C8-T1 root of median nerve",
+        "Medial head of median nerve" .
+
+ILX:0794971 a owl:Class ;
+    rdfs:label "ulnar collateral ligament" ;
+    NIFRID:synonym "Collateral carpal ulnar ligament",
+        "Ligamentum collaterale carpi ulnare (Articulatio radiocarpalis)",
+        "Ulnar collateral ligament of wrist joint" ;
+    rdfs:subClassOf UBERON:0001461 .
+
+ILX:0794972 a owl:Class ;
+    rdfs:label "inferior subscapular nerve" ;
+    NIFRID:synonym "Lower subscapular nerve" .
+
+ILX:0794973 a owl:Class ;
+    rdfs:label "upper subscapular nerve" ;
+    NIFRID:synonym "Superior subscapular nerve" ;
+    rdfs:subClassOf UBERON:0001814 .
+
+ILX:0794975 a owl:Class ;
+    rdfs:label "medial pectoral nerve" ;
+    rdfs:subClassOf UBERON:0001814 .
+
+ILX:0794976 a owl:Class ;
+    rdfs:label "long head of triceps brachii muscle" ;
+    NIFRID:synonym "Caput longum (Musculus triceps brachii)",
+        "Long head of triceps brachii muscle" ;
+    rdfs:subClassOf UBERON:0001499 .
+
+ILX:0794977 a owl:Class ;
+    rdfs:label "deep branch of radial nerve" ;
+    NIFRID:synonym "Posterior interosseous nerve" ;
+    rdfs:subClassOf UBERON:0001492 .
+
+ILX:0794978 a owl:Class ;
+    rdfs:label "extensor indicis muscle" ;
+    NIFRID:synonym "Extensor indicis" ;
+    rdfs:subClassOf UBERON:0004254 .
+
+ILX:0794979 a owl:Class ;
+    rdfs:label "dorsal scapular nerve" ;
+    rdfs:subClassOf UBERON:0001814 .
+
+ILX:0794980 a owl:Class ;
+    rdfs:label "rhomboid major muscle" ;
+    NIFRID:synonym "Rhomboid major" ;
+    rdfs:subClassOf UBERON:0002324 .
+
+ILX:0794981 a owl:Class ;
+    rdfs:label "rhomboid minor muscle" ;
+    NIFRID:synonym "Rhomboid minor" ;
+    rdfs:subClassOf UBERON:0002324 .
+
+ILX:0794982 a owl:Class ;
+    rdfs:label "Subclavian nerve" ;
+    NIFRID:synonym "Nerve to subclavius" .
+
+ILX:0794983 a owl:Class ;
+    rdfs:label "serratus anterior muscle" ;
+    NIFRID:synonym """Boxer's muscle\r
+Serratus anterior""" ;
+    rdfs:subClassOf UBERON:0002426 .
+
+ILX:0794984 a owl:Class ;
+    rdfs:label "deep part of external anal sphincter" ;
+    NIFRID:synonym "Pars profunda (Musculus sphincter ani externus)" ;
+    rdfs:subClassOf UBERON:0001367 .
+
+ILX:0794985 a owl:Class ;
+    rdfs:label "superficial part of external anal sphincter" ;
+    NIFRID:synonym "Pars superficialis (Musculus sphincter ani externus)" ;
+    rdfs:subClassOf UBERON:0001367 .
+
+ILX:0794986 a owl:Class ;
+    rdfs:label "subcutaneous part of external anal sphincter" ;
+    NIFRID:synonym "Pars subcutanea (Musculus sphincter ani externus)" ;
+    rdfs:subClassOf UBERON:0001367 .
+
+ILX:0794987 a owl:Class ;
+    rdfs:label "skin of the perineum" ;
+    NIFRID:synonym "Perineum skin" ;
+    rdfs:subClassOf UBERON:0002356 .
+
+ILX:0794988 a owl:Class ;
+    rdfs:label "nerve to obturator internus" ;
+    rdfs:subClassOf UBERON:0034986 .
+
+ILX:0794989 a owl:Class ;
+    rdfs:label "serratus posterior superior muscle" ;
+    NIFRID:synonym "Serratus posterior superior",
+        "Superior serratus posterior",
+        "Superior serratus posterior muscle" ;
+    rdfs:subClassOf UBERON:0002324 .
+
+ILX:0794990 a owl:Class ;
+    rdfs:label "superior gluteal nerve" ;
+    rdfs:subClassOf UBERON:0034986 .
+
+ILX:0794991 a owl:Class ;
+    rdfs:label "inferior gluteal nerve" ;
+    rdfs:subClassOf UBERON:0034986 .
+
+ILX:0794992 a owl:Class ;
+    rdfs:label "extensor hallucis longus muscle" ;
+    NIFRID:synonym "Extensor hallucis longus" ;
+    rdfs:subClassOf UBERON:0001498 .
+
+ILX:0794993 a owl:Class ;
+    rdfs:label "Abductor digiti minimi muscle of foot" ;
+    NIFRID:synonym "Abductor digiti minimi",
+        "Abductor digiti minimi of foot" ;
+    rdfs:subClassOf UBERON:0001498 .
+
+ILX:0794994 a owl:Class ;
+    rdfs:label "Abductor digiti minimi muscle of hand" ;
+    NIFRID:synonym "Abductor digiti minimi of hand" ;
+    rdfs:subClassOf UBERON:0001500 .
+
+ILX:0794995 a owl:Class ;
+    rdfs:label "quadratus plantae muscle" ;
+    NIFRID:synonym "Flexor accessorius",
+        "Flexor accessorius muscle",
+        "Flexor digitorum accessorius",
+        "Quadratus plantae" ;
+    rdfs:subClassOf UBERON:0001498 .
+
+ILX:0794996 a owl:Class ;
+    rdfs:label "Ilioinguinal nerve" ;
+    NIFRID:synonym """Ilio-inguinal nerve\r
+Nervus ilio-inguinalis""" .
+
+ILX:0794997 a owl:Class ;
+    rdfs:label "femoral branch of genitofemoral nerve" ;
+    NIFRID:synonym "Genitofemoral nerve femoral branch",
+        "Ramus femoralis (Nervus genitofemoralis)" ;
+    rdfs:subClassOf UBERON:0034987 .
+
+ILX:0794998 a owl:Class ;
+    rdfs:label "Genital branch of genitofemoral nerve" ;
+    NIFRID:synonym "Genitofemoral nerve genital branch",
+        "Ramus genitalis (Nervus genitofemoralis)" ;
+    rdfs:subClassOf UBERON:0034987 .
+
+ILX:0794999 a owl:Class ;
+    rdfs:label "Lateral cutaneous nerve of thigh" ;
+    NIFRID:synonym "Lateral femoral cutaneous nerve" ;
+    rdfs:subClassOf UBERON:0034987 .
+
+ILX:0795000 a owl:Class ;
+    rdfs:label "posterior cutaneous nerve of thigh" ;
+    NIFRID:synonym "Posterior femoral cutaneous nerve" ;
+    rdfs:subClassOf UBERON:0034986 .
+
+ILX:0795001 a owl:Class ;
+    rdfs:label "perforating cutaneous nerve" ;
+    rdfs:subClassOf UBERON:0034986 .
+
+ILX:0795002 a owl:Class ;
+    rdfs:label "iliohypogastric nerve" ;
+    NIFRID:synonym "Iliopubic nerve" ;
+    rdfs:subClassOf UBERON:0034987 .
+
+ILX:0795003 a owl:Class ;
+    rdfs:label "Skin of buttock" ;
+    NIFRID:synonym "Buttock skin",
+        "Skin of gluteal region" ;
+    rdfs:subClassOf UBERON:0013691 .
+
+ILX:0795004 a owl:Class ;
+    rdfs:label "Skin of lower abdomen" ;
+    rdfs:subClassOf UBERON:0000916 .
+
+ILX:0795005 a owl:Class ;
+    rdfs:label "Posterior cutaneous nerve of arm" ;
+    NIFRID:synonym "Posterior brachial cutaneous nerve" ;
+    rdfs:subClassOf UBERON:0001492 .
+
+ILX:0795006 a owl:Class ;
+    rdfs:label "Suboccipital nerve" ;
+    rdfs:subClassOf UBERON:0006839 .
+
+ILX:0795008 a owl:Class ;
+    rdfs:label "anterior hepatic neural plexus" .
+
+ILX:0795009 a owl:Class ;
+    rdfs:label "posterior hepatic neural plexus" .
+
+ILX:0795010 a owl:Class ;
+    rdfs:label "parasympathetic ganglia of the liver" ;
+    rdfs:subClassOf UBERON:0001808 .
+
+ILX:0795011 a owl:Class ;
+    rdfs:label "periarterial neural plexus of the common hepatic artery" .
+
+ILX:0795013 a owl:Class ;
+    rdfs:label "smooth muscle of hepatic artery" ;
+    rdfs:subClassOf ILX:0793769,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0001193 ] .
+
+ILX:0795015 a owl:Class ;
+    rdfs:label "smooth muscle of portal vein" ;
+    rdfs:subClassOf ILX:0793769 .
+
+ILX:0795016 a owl:Class ;
+    rdfs:label "peribiliary gland" ;
+    rdfs:subClassOf UBERON:0002530 .
+
+ILX:0795018 a owl:Class ;
+    rdfs:label "palmar digital nerve" ;
+    NIFRID:synonym "Proper Palmar Digital Branches of Median Nerve" .
+
+ILX:0795019 a owl:Class ;
+    rdfs:label "superficial transverse perineal muscle" ;
+    NIFRID:synonym "Thiele's muscle",
+        "Transversus perinei superficialis" ;
+    rdfs:subClassOf UBERON:0004486 .
+
+ILX:0795020 a owl:Class ;
+    rdfs:label "deep transverse perineal muscle" ;
+    NIFRID:synonym "Transversus perinei profundus" ;
+    rdfs:subClassOf UBERON:0004486 .
+
+ILX:0795023 a owl:Class ;
+    rdfs:label "dorsal grey horn of T7" .
+
+ILX:0795024 a owl:Class ;
+    rdfs:label "dorsal grey horn of T8" .
+
+ILX:0795025 a owl:Class ;
+    rdfs:label "dorsal grey horn of T9" .
+
+ILX:0795026 a owl:Class ;
+    rdfs:label "dorsal grey horn of T10" .
+
+ILX:0795027 a owl:Class ;
+    rdfs:label "dorsal grey horn of T11" .
+
+ILX:0795028 a owl:Class ;
+    rdfs:label "dorsal grey horn of T12" .
+
+ILX:0795029 a owl:Class ;
+    rdfs:label "dorsal grey horn of L1" .
+
+ILX:0795030 a owl:Class ;
+    rdfs:label "dorsal grey horn of L2" .
+
+ILX:0795031 a owl:Class ;
+    rdfs:label "dorsal grey horn of L3" .
+
+ILX:0795032 a owl:Class ;
+    rdfs:label "dorsal grey horn of left T8" .
+
+ILX:0795033 a owl:Class ;
+    rdfs:label "dorsal grey horn of left T9" .
+
+ILX:0795034 a owl:Class ;
+    rdfs:label "dorsal grey horn of left T10" .
+
+ILX:0795035 a owl:Class ;
+    rdfs:label "dorsal grey horn of left T11" .
+
+ILX:0795036 a owl:Class ;
+    rdfs:label "dorsal grey horn of left T12" .
+
+ILX:0795037 a owl:Class ;
+    rdfs:label "dorsal grey horn of left T13" .
+
+ILX:0795038 a owl:Class ;
+    rdfs:label "dorsal grey horn of left L1" .
+
+ILX:0795039 a owl:Class ;
+    rdfs:label "dorsal grey horn of left L2" .
+
+ILX:0795040 a owl:Class ;
+    rdfs:label "dorsal grey horn of right T6" .
+
+ILX:0795041 a owl:Class ;
+    rdfs:label "dorsal grey horn of right T7" .
+
+ILX:0795042 a owl:Class ;
+    rdfs:label "dorsal grey horn of right T8" .
+
+ILX:0795043 a owl:Class ;
+    rdfs:label "dorsal grey horn of right T9" .
+
+ILX:0795044 a owl:Class ;
+    rdfs:label "dorsal grey horn of right T10" .
+
+ILX:0795045 a owl:Class ;
+    rdfs:label "dorsal grey horn of right T11" .
+
+ILX:0795046 a owl:Class ;
+    rdfs:label "dorsal grey horn of right T12" .
+
+ILX:0795047 a owl:Class ;
+    rdfs:label "dorsal grey horn of right T13" .
+
+ILX:0795049 a owl:Class ;
+    rdfs:label "Posterior root of right thirteenth thoracic nerve" .
+
+ILX:0795050 a owl:Class ;
+    rdfs:label "Posterior root of left thirteenth thoracic nerve" .
+
+ILX:0795051 a owl:Class ;
+    rdfs:label "Right thirteenth thoracic spinal ganglion" ;
+    rdfs:subClassOf ILX:0793359 .
+
+ILX:0795052 a owl:Class ;
+    rdfs:label "Left thirteenth thoracic spinal ganglion" ;
+    rdfs:subClassOf ILX:0793359 .
+
+ILX:0795053 a owl:Class ;
+    rdfs:label "tunica adventitia of the renal artery" ;
+    rdfs:subClassOf UBERON:0007240,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0001184 ] .
+
+ILX:0795054 a owl:Class ;
+    rdfs:label "upper ureter" ;
+    rdfs:subClassOf UBERON:0001062,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0000056 ] .
+
+ILX:0795055 a owl:Class ;
+    rdfs:label "lower ureter" ;
+    rdfs:subClassOf UBERON:0001062,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0000056 ] .
+
+ILX:0795056 a owl:Class ;
+    rdfs:label "intramural ganglion of the kidney" ;
+    rdfs:subClassOf UBERON:0000045 .
+
+ILX:0795057 a owl:Class ;
+    rdfs:label "renal nerve plexus ganglion" ;
+    rdfs:subClassOf UBERON:0001805 .
+
+ILX:0795058 a owl:Class ;
+    rdfs:label "segmental renal artery" ;
+    rdfs:subClassOf UBERON:0001637,
+        [ a owl:Restriction ;
+            owl:onProperty ilx.partOf: ;
+            owl:someValuesFrom UBERON:0001184 ] .
+
+ILX:0795059 a owl:Class ;
+    rdfs:label "eccrine sweat gland of the upper limb" ;
+    rdfs:subClassOf UBERON:0000423 .
+
+ILX:0795060 a owl:Class ;
+    rdfs:label "eccrine sweat gland of the face" ;
+    rdfs:subClassOf UBERON:0000423 .
+
+ILX:0795061 a owl:Class ;
+    rdfs:label "eccrine sweat gland of the trunk" ;
+    rdfs:subClassOf UBERON:0000423 .
+
+ILX:0795062 a owl:Class ;
+    rdfs:label "eccrine sweat gland of the lower limb" ;
+    rdfs:subClassOf UBERON:0000423 .
+
+ILX:0795064 a owl:Class ;
+    rdfs:label "first lumbrical muscle of the hand" ;
+    rdfs:subClassOf UBERON:0001501 .
+
+ILX:0795065 a owl:Class ;
+    rdfs:label "second lumbrical muscle of the hand" ;
+    rdfs:subClassOf UBERON:0001501 .
+
+ILX:0795340 a owl:Class ;
+    rdfs:label "celiac periarterial nerve plexus" ;
+    rdfs:subClassOf UBERON:0001810 .
+
+ILX:0795341 a owl:Class ;
+    rdfs:label "muscle layer of proximal colon" ;
+    rdfs:subClassOf UBERON:0012367 .
+
+ILX:0795342 a owl:Class ;
+    rdfs:label "upper part of the anal canal" ;
+    rdfs:subClassOf UBERON:0001062 .
+
+ILX:0795343 a owl:Class ;
+    rdfs:label "myenteric nerve plexus ganglion of esophagus" ;
+    rdfs:subClassOf UBERON:0001809 .
+
+ILX:0795344 a owl:Class ;
+    rdfs:label "myenteric nerve plexus ganglion of stomach" ;
+    rdfs:subClassOf UBERON:0001809 .
+
+ILX:0795345 a owl:Class ;
+    rdfs:label "myenteric nerve plexus ganglion of large intestine" ;
+    rdfs:subClassOf UBERON:0001809 .
+
+ILX:0795346 a owl:Class ;
+    rdfs:label "myenteric nerve plexus ganglion of rectum" ;
+    rdfs:subClassOf UBERON:0001809 .
+
+ILX:0795347 a owl:Class ;
+    rdfs:label "myenteric nerve plexus ganglion of anus" ;
+    rdfs:subClassOf UBERON:0001809 .
+
+ILX:0795348 a owl:Class ;
+    rdfs:label "submucosal nerve plexus ganglion of small intestine" ;
+    rdfs:subClassOf UBERON:0001809 .
+
+ILX:0795349 a owl:Class ;
+    rdfs:label "submucosal nerve plexus ganglion of large intestine" ;
+    rdfs:subClassOf UBERON:0001809 .
+
+ILX:0795350 a owl:Class ;
+    rdfs:label "submucosal nerve plexus ganglion of rectum" ;
+    rdfs:subClassOf UBERON:0001809 .
+
+ILX:0795351 a owl:Class ;
+    rdfs:label "submucosal nerve plexus ganglion of anus" ;
+    rdfs:subClassOf UBERON:0001809 .
+
+ILX:0795491 a owl:Class ;
+    rdfs:label "Posterior root of sixth lumbar nerve" ;
+    rdfs:subClassOf FMA:12969 .
+
+ILX:0795492 a owl:Class ;
+    rdfs:label "Posterior root of thirteenth thoracic nerve" ;
+    rdfs:subClassOf FMA:12908 .
+
+ILX:0795493 a owl:Class ;
+    rdfs:label "Intermediolateral nucleus of first thoracic segment" ;
+    rdfs:subClassOf ILX:0773722 .
+
+ILX:0795494 a owl:Class ;
+    rdfs:label "dorsal grey horn of T13" ;
+    rdfs:subClassOf UBERON:0014609 .
+
+ILX:0795507 a owl:Class ;
+    rdfs:label "vagosympthetic trunk" ;
+    rdfs:subClassOf UBERON:0001021 .
+
+ILX:0795513 a owl:Class ;
+    rdfs:label "right celiac ganglion" ;
+    rdfs:subClassOf UBERON:0001805 .
+
+ILX:0795514 a owl:Class ;
+    rdfs:label "right superior mesenteric ganglion" ;
+    rdfs:subClassOf UBERON:0001805 .
+
+ILX:0795515 a owl:Class ;
+    rdfs:label "left celiac ganglion" ;
+    rdfs:subClassOf UBERON:0001805 .
+
+ILX:0795516 a owl:Class ;
+    rdfs:label "left superior mesenteric ganglion" ;
+    rdfs:subClassOf UBERON:0001805 .
+
+ILX:0796487 a owl:Class ;
+    rdfs:label "third lumbrical muscle of the hand" ;
+    rdfs:subClassOf UBERON:0001501 .
+
+ILX:0796488 a owl:Class ;
+    rdfs:label "fourth lumbrical muscle of the hand" ;
+    rdfs:subClassOf UBERON:0001501 .
+
+ILX:0796498 a owl:Class ;
+    rdfs:label "dorsal grey horn of left T7" ;
+    rdfs:subClassOf UBERON:0001062 .
+
+ILX:0796510 a owl:Class ;
+    rdfs:label "type A nerve fiber" ;
+    rdfs:subClassOf UBERON:0006135 .
+
+ILX:0796514 a owl:Class ;
+    rdfs:label "type Aδ (delta) nerve fiber" ;
+    rdfs:subClassOf ILX:0796510 .
+
+ILX:0796516 a owl:Class ;
+    rdfs:label "type C nerve fiber" ;
+    rdfs:subClassOf UBERON:0006136 .
+
+ILX:0796530 a owl:Class ;
+    rdfs:label "nociceptive circuit" ;
+    rdfs:subClassOf ILX:0106328 .
+
+ILX:0796679 a owl:Class ;
+    rdfs:label "cardiac interganglionic nerve" ;
+    rdfs:subClassOf UBERON:0001021 .
+
+ILX:0796950 a owl:Class ;
+    rdfs:label "Left greater splanchnic nerve" .
+
+ILX:0796952 a owl:Class ;
+    rdfs:label "Left lesser splanchnic nerve" .
+
+ILX:0797391 a owl:Class ;
+    rdfs:label "superficial branch of radial nerve" ;
+    rdfs:subClassOf UBERON:0001021 .
+
+ILX:0797430 a owl:Class ;
+    rdfs:label "nerve plexus along the left precaval vein" .
+
+ILX:0797431 a owl:Class ;
+    rdfs:label "dorsal grey horn of left C8" ;
+    rdfs:subClassOf UBERON:0001062 .
+
+ILX:0797432 a owl:Class ;
+    rdfs:label "dorsal grey horn of left T1" ;
+    rdfs:subClassOf UBERON:0001062 .
+
+ILX:0797433 a owl:Class ;
+    rdfs:label "dorsal grey horn of left T2" ;
+    rdfs:subClassOf UBERON:0001062 .
+
+ILX:0797434 a owl:Class ;
+    rdfs:label "dorsal grey horn of left T3" ;
+    rdfs:subClassOf UBERON:0001062 .
+
+ILX:0797451 a owl:Class ;
+    rdfs:label "subcostal nerve" ;
+    rdfs:subClassOf UBERON:0003726 .
+
+ilxcr:hasComposerURI a owl:Class .
 
 ilxtr:GABAReceptor a owl:Class ;
     owl:equivalentClass [ a owl:Restriction ;
@@ -3031,6 +4174,7 @@ NCBIGene:14394 a owl:Class ;
         "GABAA alpha 1",
         "GABAA-alpha1",
         "GABAAR alpha1",
+        "GABAAR subunit alpha-1",
         "GABAAR-alpha1",
         "Gabra-1",
         "gamma-aminobutyric acid (GABA) A receptor, subunit alpha 1",
@@ -3041,6 +4185,7 @@ NCBIGene:14394 a owl:Class ;
 NCBIGene:14397 a owl:Class ;
     rdfs:label "Gabra4" ;
     NIFRID:synonym "GABA(A) receptor subunit alpha-4",
+        "GABAAR subunit alpha-4",
         "Gabra-4",
         "gamma-aminobutyric acid (GABA) A receptor, subunit alpha 4",
         "gamma-aminobutyric acid receptor subunit alpha-4",
@@ -3050,6 +4195,7 @@ NCBIGene:14397 a owl:Class ;
 NCBIGene:14403 a owl:Class ;
     rdfs:label "Gabrd" ;
     NIFRID:synonym "GABA(A) receptor subunit delta",
+        "GABAAR subunit delta",
         "gamma-aminobutyric acid (GABA) A receptor, subunit delta",
         "gamma-aminobutyric acid receptor subunit delta" ;
     rdfs:subClassOf SO:0000110 .
@@ -3268,7 +4414,7 @@ NCBIGene:18573 a owl:Class ;
 
 NCBIGene:18578 a owl:Class ;
     rdfs:label "Pde4b" ;
-    NIFRID:synonym "cAMP-specific 3',5'-cyclic phosphodiesterase 4B",
+    NIFRID:synonym "3',5'-cyclic-AMP phosphodiesterase 4B",
         "Dpde4",
         "dunce",
         "phosphodiesterase 4B, cAMP specific" ;
@@ -3373,7 +4519,9 @@ NCBIGene:19242 a owl:Class ;
 
 NCBIGene:19293 a owl:Class ;
     rdfs:label "Pvalb" ;
-    NIFRID:synonym "Parv",
+    NIFRID:synonym "alpha-parvalbumin",
+        "alpha-PV",
+        "Parv",
         "parvalbumin",
         "parvalbumin alpha",
         "PV",
@@ -3628,7 +4776,8 @@ NCBIGene:22354 a owl:Class ;
         "VIP receptor subtype 1",
         "VIP-R1",
         "VIP-R-1",
-        "VPAC1" ;
+        "VPAC1",
+        "VPAC1 receptor" ;
     rdfs:subClassOf SO:0000110 .
 
 NCBIGene:22355 a owl:Class ;
@@ -3701,7 +4850,9 @@ NCBIGene:26381 a owl:Class ;
 
 NCBIGene:29863 a owl:Class ;
     rdfs:label "Pde7b" ;
-    NIFRID:synonym "cAMP-specific 3',5'-cyclic phosphodiesterase 7B",
+    NIFRID:synonym "3',5'-cyclic-AMP phosphodiesterase 7B",
+        "cAMP-specific 3',5'-cyclic phosphodiesterase 7B",
+        "cAMP-specific phosphodiesterase 7B",
         "phosphodiesterase 7B" ;
     rdfs:subClassOf SO:0000110 .
 
@@ -3813,7 +4964,8 @@ NCBIGene:60596 a owl:Class ;
 
 NCBIGene:64378 a owl:Class ;
     rdfs:label "Gpr88" ;
-    NIFRID:synonym "G-protein coupled receptor 88",
+    NIFRID:synonym "G protein-coupled receptor 88",
+        "G-protein coupled receptor 88",
         "probable G-protein coupled receptor 88",
         "Strg",
         "striatum-specific G-protein coupled receptor" ;
@@ -4118,7 +5270,8 @@ NCBIGene:628779 a owl:Class ;
 
 NCBITaxon:1 a owl:Class ;
     rdfs:label "root" ;
-    NIFRID:synonym "all" ;
+    NIFRID:synonym "all",
+        "root" ;
     rdfs:subClassOf OBI:0100026 .
 
 NCBITaxon:2759 a owl:Class ;
@@ -4127,40 +5280,46 @@ NCBITaxon:2759 a owl:Class ;
         "Eucaryotae",
         "eucaryotes",
         "Eukarya",
+        "Eukaryota",
         "Eukaryotae",
         "eukaryote",
         "eukaryotes" ;
-    rdfs:subClassOf NCBITaxon:131567,
-        NLXORG:110506 .
+    rdfs:subClassOf NCBITaxon:131567 .
 
 NCBITaxon:6072 a owl:Class ;
     rdfs:label "Eumetazoa" ;
+    NIFRID:synonym "Eumetazoa" ;
     rdfs:subClassOf NCBITaxon:33208 .
 
 NCBITaxon:7711 a owl:Class ;
     rdfs:label "Chordata" ;
-    NIFRID:synonym "chordates" ;
+    NIFRID:synonym "Chordata",
+        "chordates" ;
     rdfs:subClassOf NCBITaxon:33511 .
 
 NCBITaxon:7742 a owl:Class ;
     rdfs:label "Vertebrata" ;
     NIFRID:synonym "Vertebrata",
+        "Vertebrata <vertebrates>",
         "vertebrates" ;
     rdfs:subClassOf NCBITaxon:89593 .
 
 NCBITaxon:7776 a owl:Class ;
     rdfs:label "Gnathostomata" ;
     NIFRID:synonym "Gnathostomata",
+        "Gnathostomata <vertebrates>",
         "jawed vertebrates" ;
     rdfs:subClassOf NCBITaxon:7742 .
 
 NCBITaxon:8287 a owl:Class ;
     rdfs:label "Sarcopterygii" ;
+    NIFRID:synonym "Sarcopterygii" ;
     rdfs:subClassOf NCBITaxon:117571 .
 
 NCBITaxon:9347 a owl:Class ;
     rdfs:label "Eutheria" ;
-    NIFRID:synonym "eutherian mammals",
+    NIFRID:synonym "Eutheria",
+        "eutherian mammals",
         "placental mammals",
         "Placentalia",
         "placentals" ;
@@ -4170,30 +5329,34 @@ NCBITaxon:9443 a owl:Class ;
     rdfs:label "Primates" ;
     NIFRID:synonym "Primata",
         "primate",
+        "Primates",
         "primates" ;
     rdfs:subClassOf NCBITaxon:314146 .
 
 NCBITaxon:9526 a owl:Class ;
     rdfs:label "Catarrhini" ;
+    NIFRID:synonym "Catarrhini" ;
     rdfs:subClassOf NCBITaxon:314293 .
 
 NCBITaxon:9604 a owl:Class ;
     rdfs:label "Hominidae" ;
     NIFRID:synonym "great apes",
+        "Hominidae",
         "Pongidae" ;
     rdfs:subClassOf NCBITaxon:314295 .
 
 NCBITaxon:9605 a owl:Class ;
     rdfs:label "Homo" ;
-    NIFRID:synonym "humans" ;
+    NIFRID:synonym "Homo",
+        "humans" ;
     rdfs:subClassOf NCBITaxon:207598 .
 
 NCBITaxon:9606 a owl:Class ;
     rdfs:label "Homo sapiens" ;
-    NIFRID:synonym "h",
-        "human",
-        "man" ;
-    rdfs:subClassOf NCBITaxon:9605 .
+    NIFRID:synonym "Homo sapiens",
+        "human" ;
+    rdfs:subClassOf NCBITaxon:9605,
+        OBI:0100026 .
 
 NCBITaxon:9608 a owl:Class ;
     rdfs:label "Canidae" ;
@@ -4207,17 +5370,20 @@ NCBITaxon:9611 a owl:Class ;
 NCBITaxon:9612 a owl:Class ;
     rdfs:label "Canis lupus" ;
     NIFRID:synonym "gray wolf",
-        "grey wolf" ;
+        "wolf" ;
     rdfs:subClassOf NCBITaxon:9611 .
 
 NCBITaxon:9615 a owl:Class ;
     rdfs:label "Canis familiaris" ;
-    NIFRID:synonym "Canis canis",
+    NIFRID:synonym "Canis borealis",
+        "Canis canis",
         "Canis domesticus",
         "Canis familiaris",
+        "Canis lupus borealis",
         "dog",
         "dogs" ;
-    rdfs:subClassOf NCBITaxon:9612 .
+    rdfs:subClassOf NCBITaxon:9612,
+        OBI:0100026 .
 
 NCBITaxon:9681 a owl:Class ;
     rdfs:label "Felidae" ;
@@ -4254,7 +5420,8 @@ NCBITaxon:9823 a owl:Class ;
         "Sus scrofa",
         "swine",
         "wild boar" ;
-    rdfs:subClassOf NCBITaxon:9822 .
+    rdfs:subClassOf NCBITaxon:9822,
+        OBI:0100026 .
 
 NCBITaxon:9825 a owl:Class ;
     rdfs:label "Domestic Pig" ;
@@ -4267,26 +5434,30 @@ NCBITaxon:9825 a owl:Class ;
 NCBITaxon:9989 a owl:Class ;
     rdfs:label "Rodentia" ;
     NIFRID:synonym "rodent",
+        "Rodentia",
         "rodents" ;
     rdfs:subClassOf NCBITaxon:314147 .
 
 NCBITaxon:10066 a owl:Class ;
     rdfs:label "Muridae" ;
+    NIFRID:synonym "Muridae" ;
     rdfs:subClassOf NCBITaxon:337687 .
 
 NCBITaxon:10088 a owl:Class ;
     rdfs:label "Mus <genus>" ;
     NIFRID:synonym "mice",
         "mouse",
-        "Mus" ;
+        "Mus",
+        "Mus <genus>" ;
     rdfs:subClassOf NCBITaxon:39107 .
 
 NCBITaxon:10090 a owl:Class ;
     rdfs:label "Mus musculus" ;
     NIFRID:synonym "house mouse",
-        "m",
-        "mouse" ;
-    rdfs:subClassOf NCBITaxon:862507 .
+        "mouse",
+        "Mus musculus" ;
+    rdfs:subClassOf NCBITaxon:862507,
+        OBI:0100026 .
 
 NCBITaxon:10114 a owl:Class ;
     rdfs:label "Rattus" ;
@@ -4301,7 +5472,8 @@ NCBITaxon:10116 a owl:Class ;
         "Norway rat",
         "rat",
         "rats" ;
-    rdfs:subClassOf NCBITaxon:10114 .
+    rdfs:subClassOf NCBITaxon:10114,
+        OBI:0100026 .
 
 NCBITaxon:10139 a owl:Class ;
     rdfs:label "Caviidae" ;
@@ -4325,22 +5497,27 @@ NCBITaxon:10141 a owl:Class ;
 
 NCBITaxon:32523 a owl:Class ;
     rdfs:label "Tetrapoda" ;
-    NIFRID:synonym "tetrapods" ;
-    rdfs:subClassOf NCBITaxon:1338369 .
+    NIFRID:synonym "Tetrapoda",
+        "tetrapods" ;
+    rdfs:subClassOf NCBITaxon:8287,
+        NCBITaxon:1338369 .
 
 NCBITaxon:32524 a owl:Class ;
     rdfs:label "Amniota" ;
-    NIFRID:synonym "amniotes" ;
+    NIFRID:synonym "Amniota",
+        "amniotes" ;
     rdfs:subClassOf NCBITaxon:32523 .
 
 NCBITaxon:32525 a owl:Class ;
     rdfs:label "Theria" ;
-    NIFRID:synonym "Theria" ;
+    NIFRID:synonym "Theria",
+        "Theria <mammals>" ;
     rdfs:subClassOf NCBITaxon:40674 .
 
 NCBITaxon:33154 a owl:Class ;
     rdfs:label "Opisthokonta" ;
     NIFRID:synonym "Fungi/Metazoa group",
+        "Opisthokonta",
         "opisthokonts" ;
     rdfs:subClassOf NCBITaxon:2759 .
 
@@ -4348,12 +5525,15 @@ NCBITaxon:33208 a owl:Class ;
     rdfs:label "Metazoa" ;
     NIFRID:synonym "Animalia",
         "animals",
+        "Metazoa",
         "metazoans",
         "multicellular animals" ;
-    rdfs:subClassOf NCBITaxon:33154 .
+    rdfs:subClassOf NCBITaxon:2759,
+        NCBITaxon:33154 .
 
 NCBITaxon:33213 a owl:Class ;
     rdfs:label "Bilateria" ;
+    NIFRID:synonym "Bilateria" ;
     rdfs:subClassOf NCBITaxon:6072 .
 
 NCBITaxon:33316 a owl:Class ;
@@ -4362,8 +5542,10 @@ NCBITaxon:33316 a owl:Class ;
 
 NCBITaxon:33511 a owl:Class ;
     rdfs:label "Deuterostomia" ;
-    NIFRID:synonym "deuterostomes" ;
-    rdfs:subClassOf NCBITaxon:33316 .
+    NIFRID:synonym "deuterostomes",
+        "Deuterostomia" ;
+    rdfs:subClassOf NCBITaxon:33213,
+        NCBITaxon:33316 .
 
 NCBITaxon:33550 a owl:Class ;
     rdfs:label "Hystricomorpha" ;
@@ -4384,6 +5566,7 @@ NCBITaxon:35497 a owl:Class ;
 
 NCBITaxon:39107 a owl:Class ;
     rdfs:label "Murinae" ;
+    NIFRID:synonym "Murinae" ;
     rdfs:subClassOf NCBITaxon:10066 .
 
 NCBITaxon:40674 a owl:Class ;
@@ -4394,69 +5577,81 @@ NCBITaxon:40674 a owl:Class ;
 
 NCBITaxon:89593 a owl:Class ;
     rdfs:label "Craniata" ;
-    NIFRID:synonym "Craniata" ;
+    NIFRID:synonym "Craniata",
+        "Craniata <chordates>" ;
     rdfs:subClassOf NCBITaxon:7711 .
 
 NCBITaxon:91561 a owl:Class ;
     rdfs:label "Artiodactyla" ;
     NIFRID:synonym "Cetartiodactyla",
-        "even-toed ungulates",
-        "whales, hippos, ruminants, pigs, camels etc." ;
+        "even-toed ungulates & whales" ;
     rdfs:subClassOf NCBITaxon:314145 .
 
 NCBITaxon:117570 a owl:Class ;
     rdfs:label "Teleostomi" ;
+    NIFRID:synonym "Teleostomi" ;
     rdfs:subClassOf NCBITaxon:7776 .
 
 NCBITaxon:117571 a owl:Class ;
     rdfs:label "Euteleostomi" ;
-    NIFRID:synonym "bony vertebrates" ;
+    NIFRID:synonym "bony vertebrates",
+        "Euteleostomi" ;
     rdfs:subClassOf NCBITaxon:117570 .
 
 NCBITaxon:131567 a owl:Class ;
     rdfs:label "cellular organisms" ;
-    NIFRID:synonym "biota" ;
+    NIFRID:synonym "biota",
+        "cellular organisms" ;
     rdfs:subClassOf NCBITaxon:1 .
 
 NCBITaxon:207598 a owl:Class ;
     rdfs:label "Homininae" ;
-    NIFRID:synonym "Homo/Pan/Gorilla group" ;
+    NIFRID:synonym "Homininae",
+        "Homo/Pan/Gorilla group" ;
     rdfs:subClassOf NCBITaxon:9604 .
 
 NCBITaxon:314145 a owl:Class ;
     rdfs:label "Laurasiatheria" ;
-    rdfs:subClassOf NCBITaxon:1437010 .
+    rdfs:subClassOf NCBITaxon:9347,
+        NCBITaxon:1437010 .
 
 NCBITaxon:314146 a owl:Class ;
     rdfs:label "Euarchontoglires" ;
+    NIFRID:synonym "Euarchontoglires" ;
     rdfs:subClassOf NCBITaxon:1437010 .
 
 NCBITaxon:314147 a owl:Class ;
     rdfs:label "Glires" ;
-    NIFRID:synonym "Rodents and rabbits" ;
+    NIFRID:synonym "Glires",
+        "Rodents and rabbits" ;
     rdfs:subClassOf NCBITaxon:314146 .
 
 NCBITaxon:314293 a owl:Class ;
     rdfs:label "Simiiformes" ;
-    NIFRID:synonym "Anthropoidea" ;
+    NIFRID:synonym "Anthropoidea",
+        "Simiiformes" ;
     rdfs:subClassOf NCBITaxon:376913 .
 
 NCBITaxon:314295 a owl:Class ;
     rdfs:label "Hominoidea" ;
     NIFRID:synonym "ape",
-        "apes" ;
+        "apes",
+        "Hominoidea" ;
     rdfs:subClassOf NCBITaxon:9526 .
 
 NCBITaxon:337687 a owl:Class ;
     rdfs:label "Muroidea" ;
+    NIFRID:synonym "Muroidea" ;
     rdfs:subClassOf NCBITaxon:1963758 .
 
 NCBITaxon:338152 a owl:Class ;
     rdfs:label "Felinae" ;
+    NIFRID:synonym "Acinonychinae" ;
     rdfs:subClassOf NCBITaxon:9681 .
 
 NCBITaxon:376913 a owl:Class ;
     rdfs:label "Haplorrhini" ;
+    NIFRID:synonym "Haplorrhini" ;
     rdfs:subClassOf NCBITaxon:9443 .
 
 NCBITaxon:379583 a owl:Class ;
@@ -4469,21 +5664,25 @@ NCBITaxon:379584 a owl:Class ;
 
 NCBITaxon:862507 a owl:Class ;
     rdfs:label "Mus <subgenus>" ;
-    NIFRID:synonym "Mus" ;
+    NIFRID:synonym "Mus",
+        "Mus <subgenus>" ;
     rdfs:subClassOf NCBITaxon:10088 .
 
 NCBITaxon:1338369 a owl:Class ;
     rdfs:label "Dipnotetrapodomorpha" ;
+    NIFRID:synonym "Dipnotetrapodomorpha" ;
     rdfs:subClassOf NCBITaxon:8287 .
 
 NCBITaxon:1437010 a owl:Class ;
     rdfs:label "Boreoeutheria" ;
-    NIFRID:synonym "Boreotheria" ;
+    NIFRID:synonym "Boreoeutheria",
+        "Boreotheria" ;
     rdfs:subClassOf NCBITaxon:9347 .
 
 NCBITaxon:1963758 a owl:Class ;
     rdfs:label "Myomorpha" ;
     NIFRID:synonym "mice and others",
+        "Myomorpha",
         "Sciurognathi" ;
     rdfs:subClassOf NCBITaxon:9989 .
 
@@ -4500,14 +5699,17 @@ NIFEXT:123 a owl:Class ;
         "Olfactory bulb main granule cell",
         "Olfactory Granule cell",
         "Olfactory granule neuron" ;
-    rdfs:subClassOf npokb:7 .
+    rdfs:subClassOf SAO:1417703748 .
 
 NIFEXT:2502 a owl:Class ;
     rdfs:label "Multimeric ion channel" ;
     NIFRID:synonym "Multimeric ion channel" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf SAO:26622963 .
+
+NIFEXT:2505 a owl:Class ;
+    rdfs:label "Tetrameric ion channel" ;
+    NIFRID:synonym "Tetrameric ion channel" ;
+    rdfs:subClassOf NIFEXT:2502 .
 
 NIFEXT:2506 a owl:Class ;
     rdfs:label "Multimeric Voltage-gated ion channel" ;
@@ -4531,28 +5733,18 @@ NIFEXT:3061 a owl:Class ;
     NIFRID:synonym "BCNG1",
         "HAC2",
         "HCN1" ;
-    rdfs:subClassOf NIFEXT:2516,
-        PR:000000676 .
+    rdfs:subClassOf NIFEXT:2516 .
 
 NIFEXT:5000 a owl:Class ;
     rdfs:label "Peptide" ;
     NIFRID:synonym "Peptide" ;
     rdfs:subClassOf CHEBI:33243 .
 
-NIFEXT:5092 a owl:Class ;
-    rdfs:label "Neurotensin" ;
-    NIFRID:synonym "Neurotensin" ;
-    rdfs:subClassOf NIFEXT:5000 .
-
 NIFEXT:5124 a owl:Class ;
     rdfs:label "Vasopressin" ;
     NIFRID:synonym "Vasopressin" ;
-    rdfs:subClassOf TEMPIND:Avp .
-
-NIFEXT:5137 a owl:Class ;
-    rdfs:label "Corticotropin releasing factor" ;
-    NIFRID:synonym "Corticotropin releasing factor" ;
-    rdfs:subClassOf TEMPIND:Crh .
+    rdfs:subClassOf NIFEXT:5000,
+        TEMPIND:Avp .
 
 NIFEXT:5236 a owl:Class ;
     rdfs:label "Pentameric ion channel" ;
@@ -4569,7 +5761,8 @@ NIFEXT:5239 a owl:Class ;
     NIFRID:synonym "GluR",
         "Glutamate receptor",
         "Glutamate-gated cationic channel" ;
-    rdfs:subClassOf TEMPIND:GluR .
+    rdfs:subClassOf NIFEXT:2505,
+        TEMPIND:GluR .
 
 NIFEXT:5240 a owl:Class ;
     rdfs:label "Anionic cys-loop ligand-gated ion channel" ;
@@ -4615,7 +5808,7 @@ NIFEXT:5250 a owl:Class ;
         "NMDA receptor",
         "NMDA-type glutamate-gated cationic channel",
         "NMDAR" ;
-    rdfs:subClassOf NIFEXT:5239 .
+    rdfs:subClassOf NLXMOL:100305 .
 
 NIFEXT:5251 a owl:Class ;
     rdfs:label "AMPA-type glutamate-gated cationic channel" ;
@@ -4646,21 +5839,6 @@ NLX:96 a owl:Class ;
     ilxtr:hasExternalId NLX:96 ;
     ilxtr:hasIlxId ILX:0107937 ;
     ilxtr:hasIlxPreferredId NLX:96 .
-
-NLX:462 a owl:Class ;
-    rdfs:label "Calcium calmodulin protein kinase II" ;
-    NIFRID:synonym "Ca2+/calmodulin-dependent protein kinase II",
-        "calcium/calmodulin-dependent protein kinase type II",
-        "CAMKII" ;
-    definition: "The 'calcium calmodulin protein kinase II' is a protein with a core domain architecture consisting of a Protein kinase domain and a C-terminal Calcium/calmodulin dependent protein kinase II Association domain." ;
-    rdfs:subClassOf BIRNLEX:1 ;
-    ilx.hasDbXref: NLXWIKI:nlx_462 ;
-    ilxr:type ilx.type:term ;
-    ilxtr:hasExistingId ILX:0101561,
-        NLX:462 ;
-    ilxtr:hasExternalId NLX:462 ;
-    ilxtr:hasIlxId ILX:0101561 ;
-    ilxtr:hasIlxPreferredId NLX:462 .
 
 NLX:12056 a owl:Class ;
     rdfs:label "Anterior piriform cortex" ;
@@ -4756,26 +5934,6 @@ NLX:69833 a owl:Class ;
     ilxtr:hasExternalId NLX:69833 ;
     ilxtr:hasIlxId ILX:0104674 ;
     ilxtr:hasIlxPreferredId NLX:69833 .
-
-NLX:70371 a owl:Class ;
-    rdfs:label "Basal pons" ;
-    rdfs:subClassOf NLX:62707,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000988 ] ;
-    ilx.hasDbXref: NLXWIKI:nlx_70371 ;
-    ilx.partOf: UBERON:0000988 ;
-    ILX:0381449 "PMID:8978476",
-        "PMID:20886621" ;
-    ilxr:type ilx.type:term ;
-    ilxtr:hasExistingId ILX:0101112,
-        NLX:70371 ;
-    ilxtr:hasExternalId NLX:70371 ;
-    ilxtr:hasIlxId ILX:0101112 ;
-    ilxtr:hasIlxPreferredId NLX:70371 .
-
-NLX:143975 a owl:Class ;
-    rdfs:label "Rexed spinal cord parcellation scheme region" .
 
 NLX:149264 a owl:Class ;
     rdfs:label "Superior paraolivary nucleus" ;
@@ -4887,21 +6045,15 @@ NLXMOL:1006006 a owl:Class ;
         "Calbindin",
         "calbindin 1",
         "calbindin D28K" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf SAO:26622963 .
 
 NLXMOL:1006008 a owl:Class ;
     rdfs:label "Vesicular acetylcholine transporter" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf SAO:26622963 .
 
 NLXMOL:1006009 a owl:Class ;
     rdfs:label "Vesicular glutamate transporter 2" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf SAO:26622963 .
 
 NLXMOL:20090303 a owl:Class ;
     rdfs:label "Molecule role" ;
@@ -4911,25 +6063,9 @@ NLXMOL:20090405 a owl:Class ;
     rdfs:label "Enzyme" ;
     rdfs:subClassOf NLXMOL:20090303 .
 
-NLXMOL:20090503 a owl:Class ;
-    rdfs:label "Metabotropic Glutamate Receptor" ;
-    NIFRID:synonym "Glutamate metabotropic",
-        "GRM",
-        "Metabotropic glutamate",
-        "mGluRs" ;
-    rdfs:subClassOf SAO:1164727693 .
-
-NLXMOL:20090504 a owl:Class ;
-    rdfs:label "MGluR1" ;
-    NIFRID:synonym "GRM1",
-        "Metabotropic glutamate receptor 1" ;
-    rdfs:subClassOf NLXMOL:20090503 .
-
 NLXMOL:20090513 a owl:Class ;
     rdfs:label "Doublecortin" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf SAO:26622963 .
 
 NLXMOL:20090515 a owl:Class ;
     rdfs:label "Neurotransmitter role" ;
@@ -4938,9 +6074,6 @@ NLXMOL:20090515 a owl:Class ;
 NLXMOL:20090604 a owl:Class ;
     rdfs:label "GABA-gated anionic channel" ;
     NIFRID:synonym "GABA receptor" .
-
-NLXORG:110506 a owl:Class ;
-    rdfs:subClassOf BFO:0000040 .
 
 OBI:0100026 a owl:Class ;
     rdfs:label "organism" ;
@@ -4951,6 +6084,10 @@ owl:Class a owl:Class .
 PATO:0000001 a owl:Class ;
     rdfs:label "quality" ;
     rdfs:subClassOf BFO:0000020 .
+
+PATO:0000039 a owl:Class ;
+    rdfs:label "direction" ;
+    rdfs:subClassOf PATO:0001018 .
 
 PATO:0000047 a owl:Class ;
     rdfs:label "biological sex" ;
@@ -4971,6 +6108,21 @@ PATO:0000060 a owl:Class ;
         "pattern" ;
     rdfs:subClassOf PATO:0000051 .
 
+PATO:0000140 a owl:Class ;
+    rdfs:label "position" ;
+    NIFRID:synonym "location",
+        "placement",
+        "relational spatial quality" ;
+    rdfs:subClassOf PATO:0001018 .
+
+PATO:0000366 a owl:Class ;
+    rdfs:label "Left" ;
+    rdfs:subClassOf PATO:0000039 .
+
+PATO:0000367 a owl:Class ;
+    rdfs:label "right" ;
+    rdfs:subClassOf PATO:0000039 .
+
 PATO:0000383 a owl:Class ;
     rdfs:label "female" ;
     rdfs:subClassOf PATO:0001894 .
@@ -4979,10 +6131,19 @@ PATO:0000384 a owl:Class ;
     rdfs:label "male" ;
     rdfs:subClassOf PATO:0001894 .
 
+PATO:0000618 a owl:Class ;
+    rdfs:label "bilateral" ;
+    rdfs:subClassOf PATO:0000140 .
+
 PATO:0000936 a owl:Class ;
     rdfs:label "truncated" ;
     NIFRID:synonym "truncate" ;
     rdfs:subClassOf PATO:0000052 .
+
+PATO:0001018 a owl:Class ;
+    rdfs:label "physical quality" ;
+    NIFRID:synonym "relational physical quality" ;
+    rdfs:subClassOf PATO:0001241 .
 
 PATO:0001238 a owl:Class ;
     rdfs:label "Quality of related physical entities" .
@@ -4997,7 +6158,7 @@ PATO:0001241 a owl:Class ;
         "quality of a single physical entity",
         "quality of an object",
         "quality of continuant" ;
-    rdfs:subClassOf BFO:0000019 .
+    rdfs:subClassOf PATO:0000001 .
 
 PATO:0001609 a owl:Class ;
     rdfs:label "sparse" ;
@@ -5013,8 +6174,7 @@ PATO:0001995 a owl:Class ;
 
 PAXRAT: a owl:Class ;
     rdfs:label "Paxinos rat parcellation label root" ;
-    rdfs:subClassOf atom:Label,
-        ilxtr:parcellationLabel .
+    rdfs:subClassOf ilxtr:parcellationLabel .
 
 PAXRAT:794 a owl:Class ;
     rdfs:label "primary somatosensory cortex (paxrat)" ;
@@ -5025,46 +6185,21 @@ PAXRAT:794 a owl:Class ;
             owl:onProperty ilxtr:delineates ;
             owl:someValuesFrom UBERON:0008933 ] .
 
-PAXSPN:80 a owl:Class ;
-    rdfs:label "sacral parasympathetic nucleus" .
-
 PR:000000001 a owl:Class ;
     rdfs:label "protein" ;
     NIFRID:synonym "native protein",
         "natural protein" ;
     rdfs:subClassOf CHEBI:33695,
         PR:000018263,
-        PR:000050567,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom GO:0005840 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom GO:0032991 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom GO:0032993 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom GO:1990904 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom PR:000050567 ] .
-
-PR:000000676 a owl:Class ;
-    rdfs:label "potassium/sodium hyperpolarization-activated cyclic nucleotide-gated channel protein" ;
-    NIFRID:synonym "f-channel",
-        "HCN" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+        PR:000064867 .
 
 PR:000001094 a owl:Class ;
     rdfs:label "rhodopsin-like G-protein coupled receptor" ;
     NIFRID:synonym "class 1 G-protein coupled receptor",
         "class A G-protein coupled receptor",
         "fam:rhodopsin" ;
-    rdfs:subClassOf PR:000030035 .
+    rdfs:subClassOf PR:000000001,
+        PR:000030035 .
 
 PR:000001125 a owl:Class ;
     rdfs:label "cannabinoid receptor 1" ;
@@ -5092,8 +6227,7 @@ PR:000001217 a owl:Class ;
 
 PR:000001488 a owl:Class ;
     rdfs:label "muscarinic acetylcholine receptor" ;
-    rdfs:subClassOf PR:000001094,
-        SAO:1700719022 .
+    rdfs:subClassOf PR:000001094 .
 
 PR:000001562 a owl:Class ;
     rdfs:label "vasopressin/oxytocin receptor" ;
@@ -5105,8 +6239,7 @@ PR:000001614 a owl:Class ;
     NIFRID:synonym "CHRM2",
         "Chrm-2",
         "muscarinic acetylcholine receptor 2" ;
-    rdfs:subClassOf PR:000001488,
-        SAO:2062447305 .
+    rdfs:subClassOf PR:000001488 .
 
 PR:000001635 a owl:Class ;
     rdfs:label "oxytocin receptor" ;
@@ -5118,9 +6251,7 @@ PR:000003781 a owl:Class ;
     rdfs:label "ADM" ;
     NIFRID:synonym "ADM",
         "AM" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000004967 a owl:Class ;
     rdfs:label "calbindin" ;
@@ -5131,9 +6262,7 @@ PR:000004967 a owl:Class ;
         "PCD-29",
         "spot 35 protein",
         "vitamin D-dependent calcium-binding protein, avian-type" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000004968 a owl:Class ;
     rdfs:label "calretinin" ;
@@ -5141,16 +6270,12 @@ PR:000004968 a owl:Class ;
         "CAB29",
         "CALB2",
         "CR" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000005110 a owl:Class ;
     rdfs:label "cholecystokinin" ;
     NIFRID:synonym "CCK" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000005404 a owl:Class ;
     rdfs:label "choline O-acetyltransferase" ;
@@ -5158,16 +6283,12 @@ PR:000005404 a owl:Class ;
         "ChAT",
         "CHOACTase",
         "choline acetylase" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000005767 a owl:Class ;
     rdfs:label "cortistatin" ;
     NIFRID:synonym "CORT" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000005867 a owl:Class ;
     rdfs:label "corticoliberin" ;
@@ -5176,9 +6297,7 @@ PR:000005867 a owl:Class ;
         "CRF",
         "CRH",
         "Gm1347" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000006899 a owl:Class ;
     rdfs:label "endothelin-3" ;
@@ -5186,9 +6305,7 @@ PR:000006899 a owl:Class ;
         "ET-3",
         "PPET3",
         "preproendothelin-3" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000007786 a owl:Class ;
     rdfs:label "glutamate decarboxylase 2" ;
@@ -5197,24 +6314,7 @@ PR:000007786 a owl:Class ;
         "GAD65",
         "GAD-65",
         "glutamate decarboxylase 65 kDa isoform" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
-
-PR:000008235 a owl:Class ;
-    rdfs:label "glutamate receptor 3" ;
-    NIFRID:synonym "AMPA-selective glutamate receptor 3",
-        "GLUR3",
-        "GluR-3",
-        "GluR-C",
-        "GluR-K3",
-        "GLURC",
-        "glutamate receptor ionotropic, AMPA 3",
-        "GRIA3",
-        "Kiaa4184" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000008476 a owl:Class ;
     rdfs:label "orexin" ;
@@ -5224,9 +6324,7 @@ PR:000008476 a owl:Class ;
         "OX",
         "PPORX",
         "PPOX" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000008833 a owl:Class ;
     rdfs:label "5-hydroxytryptamine receptor 3A" ;
@@ -5241,9 +6339,7 @@ PR:000008833 a owl:Class ;
         "HTR3A",
         "serotonin receptor 3A",
         "serotonin-gated ion channel receptor" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000009182 a owl:Class ;
     rdfs:label "insulin-like growth factor I" ;
@@ -5251,46 +6347,38 @@ PR:000009182 a owl:Class ;
         "Igf-1",
         "IGF-I",
         "somatomedin" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000011326 a owl:Class ;
-    rdfs:label "nitric oxide synthase, brain" ;
+    rdfs:label "nitric oxide synthase 1" ;
     NIFRID:synonym "bNOS",
         "constitutive NOS",
         "N-NOS",
         "NC-NOS",
         "neuronal NOS",
+        "nitric oxide synthase, brain",
         "nNOS",
         "NOS1",
-        "NOS type I" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+        "NOS type I",
+        "peptidyl-cysteine S-nitrosylase NOS1" ;
+    rdfs:subClassOf PR:000000001 .
 
 PR:000011387 a owl:Class ;
     rdfs:label "neuropeptide Y" ;
     NIFRID:synonym "NPY" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000012544 a owl:Class ;
     rdfs:label "proenkephalin-A" ;
     NIFRID:synonym "PENK",
         "Penk1" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000013502 a owl:Class ;
     rdfs:label "parvalbumin alpha" ;
     NIFRID:synonym "Pva",
         "PVALB" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000014962 a owl:Class ;
     rdfs:label "vesicular glutamate transporter 2" ;
@@ -5299,28 +6387,24 @@ PR:000014962 a owl:Class ;
         "DNPI",
         "SLC17A6",
         "solute carrier family 17 member 6",
+        "VGLUT2",
         "VGluT2" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000014968 a owl:Class ;
     rdfs:label "vesicular acetylcholine transporter" ;
     NIFRID:synonym "SLC18A3",
         "solute carrier family 18 member 3",
+        "VACHT",
         "VAChT" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000015040 a owl:Class ;
     rdfs:label "prestin" ;
     NIFRID:synonym "PRES",
         "SLC26A5",
         "solute carrier family 26 member 5" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000015084 a owl:Class ;
     rdfs:label "vesicular inhibitory amino acid transporter" ;
@@ -5333,9 +6417,7 @@ PR:000015084 a owl:Class ;
         "vesicular GABA transporter",
         "VGAT",
         "VIAAT" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000015189 a owl:Class ;
     rdfs:label "sodium-dependent serotonin transporter" ;
@@ -5345,27 +6427,21 @@ PR:000015189 a owl:Class ;
         "SERT",
         "SLC6A4",
         "solute carrier family 6 member 4" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000015665 a owl:Class ;
     rdfs:label "somatostatin" ;
     NIFRID:synonym "growth hormone release-inhibiting factor",
         "Smst",
         "SST" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000016301 a owl:Class ;
     rdfs:label "tyrosine 3-monooxygenase" ;
     NIFRID:synonym "TH",
         "TYH",
         "tyrosine 3-hydroxylase" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000017299 a owl:Class ;
     rdfs:label "VIP peptides" ;
@@ -5373,9 +6449,7 @@ PR:000017299 a owl:Class ;
         "vasoactive intestinal polypeptides",
         "vasoactive intestinal polypeptides precursor",
         "VIP" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000017300 a owl:Class ;
     rdfs:label "vasoactive intestinal polypeptide receptor 1" ;
@@ -5386,9 +6460,7 @@ PR:000017300 a owl:Class ;
         "VIP-R-1",
         "VIPR1",
         "VPAC1" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000017301 a owl:Class ;
     rdfs:label "vasoactive intestinal polypeptide receptor 2" ;
@@ -5400,9 +6472,7 @@ PR:000017301 a owl:Class ;
         "VIP2R",
         "VIP-R-2",
         "VIPR2" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000018263 a owl:Class ;
     rdfs:label "amino acid chain" ;
@@ -5414,43 +6484,34 @@ PR:000027222 a owl:Class ;
     rdfs:label "CALCA gene translation product" ;
     NIFRID:synonym "CALC",
         "CALCA" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0003092 ] .
+    rdfs:subClassOf PR:000000001 .
 
 PR:000030035 a owl:Class ;
     rdfs:label "G-protein coupled receptor" ;
     NIFRID:synonym "7TM receptor",
         "fam:GPCR",
         "seven-transmembrane receptor" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf PR:000000001 .
 
-PR:000050567 a owl:Class ;
-    rdfs:label "protein-containing material entity" ;
+PR:000064867 a owl:Class ;
+    rdfs:label "protein-containing molecular entity" ;
     NIFRID:synonym "protein",
         "protein aggregate",
         "protein complex",
         "protein-containing complex" ;
-    rdfs:subClassOf BFO:0000040 .
+    rdfs:subClassOf CHEBI:23367 .
 
 PTHR:10558 a owl:Class .
 
 PTHR:11653 a owl:Class .
 
-RO:0000081 a owl:Class ;
-    rdfs:label "role of" .
+RO:0002577 a owl:Class ;
+    rdfs:label "system" ;
+    rdfs:subClassOf BFO:0000040 .
 
 SAO:26622963 a owl:Class ;
     rdfs:label "Protein" ;
-    NIFRID:synonym "Protein" ;
-    rdfs:subClassOf CHEBI:33695,
-        PR:000018263,
-        PR:000050567 .
+    NIFRID:synonym "Protein" .
 
 SAO:83745184 a owl:Class ;
     rdfs:label "Nucleic Acid" ;
@@ -5530,9 +6591,7 @@ SAO:1103104164 a owl:Class ;
 SAO:1164727693 a owl:Class ;
     rdfs:label "Glutamate Receptor" ;
     NIFRID:synonym "Glutamate Receptor" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf SAO:26622963 .
 
 SAO:1224657022 a owl:Class ;
     rdfs:label "Nervous System Cell" .
@@ -5579,18 +6638,7 @@ SAO:1511566913 a owl:Class ;
 SAO:1593305396 a owl:Class ;
     rdfs:label "Cytoskeletal Protein" ;
     NIFRID:synonym "Cytoskeletal Protein" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
-
-SAO:1700719022 a owl:Class ;
-    rdfs:label "Acetylcholine Receptor" ;
-    NIFRID:synonym "Acetylcholine Receptor",
-        "AChR",
-        "cholinergic receptor" ;
-    rdfs:subClassOf CHEBI:36080,
-        PR:000000001,
-        SAO:26622963 .
+    rdfs:subClassOf SAO:26622963 .
 
 SAO:1744435799 a owl:Class ;
     rdfs:label "Glutamate" ;
@@ -5599,9 +6647,6 @@ SAO:1744435799 a owl:Class ;
     rdfs:subClassOf NLXMOL:100306,
         SAO:1511566913 .
 
-SAO:1813327414 a owl:Class ;
-    rdfs:label "Cell" .
-
 SAO:1843715402 a owl:Class ;
     rdfs:label "RNA" ;
     NIFRID:synonym "RNA" ;
@@ -5609,13 +6654,6 @@ SAO:1843715402 a owl:Class ;
 
 SAO:2046464388 a owl:Class ;
     rdfs:label "Hair Cell" .
-
-SAO:2062447305 a owl:Class ;
-    rdfs:label "Muscarinic Acetylcholine Receptor" ;
-    NIFRID:synonym "Muscarinic Acetylcholine Receptor",
-        "Muscarinic cholinergic receptor" ;
-    rdfs:subClassOf PR:000001094,
-        SAO:1700719022 .
 
 SAO:9271919883 a owl:Class ;
     rdfs:label "Stellate" ;
@@ -5677,15 +6715,11 @@ UBERON:0000004 a owl:Class ;
         "olfactory apparatus",
         "peripheral olfactory organ",
         "proboscis" ;
-    rdfs:subClassOf UBERON:0000475,
-        UBERON:0002268,
+    rdfs:subClassOf UBERON:0002268,
         UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001456 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001557 ],
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001004 ],
@@ -5697,11 +6731,11 @@ UBERON:0000006 a owl:Class ;
     rdfs:label "islet of Langerhans" ;
     NIFRID:synonym "island of Langerhans",
         "island of pancreas",
+        "islet of Langerhans",
         "islets of Langerhans",
         "pancreatic insula",
         "pancreatic islet" ;
-    rdfs:subClassOf UBERON:0004119,
-        UBERON:0034922,
+    rdfs:subClassOf UBERON:0034922,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000016 ],
@@ -5709,41 +6743,22 @@ UBERON:0000006 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000016 ] .
 
-UBERON:0000007 a owl:Class ;
-    rdfs:label "pituitary gland" ;
-    NIFRID:synonym "glandula pituitaria",
-        "Hp",
-        "hypophysis",
-        "hypophysis cerebri",
-        "pituitary",
-        "pituitary body" ;
-    rdfs:subClassOf UBERON:0003296,
-        UBERON:0010133,
-        UBERON:0010314,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001894 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0001894 ] .
-
 UBERON:0000009 a owl:Class ;
     rdfs:label "submucosa" ;
     NIFRID:synonym "organ submucosa",
         "region of submucosa",
+        "submucosa",
         "submucosa of organ",
         "submucosa of region of organ",
         "submucous layer",
         "tela submucosa",
         "tunica submucosa" ;
-    rdfs:subClassOf UBERON:0004923,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0012125 ] .
+    rdfs:subClassOf UBERON:0004923 .
 
 UBERON:0000010 a owl:Class ;
     rdfs:label "peripheral nervous system" ;
     NIFRID:synonym "pars peripherica",
+        "peripheral nervous system",
         "PNS",
         "systema nervosum periphericum" ;
     rdfs:subClassOf UBERON:0011216,
@@ -5753,7 +6768,8 @@ UBERON:0000010 a owl:Class ;
 
 UBERON:0000011 a owl:Class ;
     rdfs:label "parasympathetic nervous system" ;
-    NIFRID:synonym "parasympathetic part of autonomic division of nervous system",
+    NIFRID:synonym "parasympathetic nervous system",
+        "parasympathetic part of autonomic division of nervous system",
         "pars parasympathica divisionis autonomici systematis nervosi",
         "PNS - parasympathetic" ;
     rdfs:subClassOf UBERON:0010314,
@@ -5768,6 +6784,7 @@ UBERON:0000011 a owl:Class ;
 UBERON:0000012 a owl:Class ;
     rdfs:label "somatic nervous system" ;
     NIFRID:synonym "PNS - somatic",
+        "somatic nervous system",
         "somatic nervous system, somatic division",
         "somatic part of peripheral nervous system",
         "somatic peripheral nervous system" ;
@@ -5792,6 +6809,20 @@ UBERON:0000013 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0002410 ] .
 
+UBERON:0000014 a owl:Class ;
+    rdfs:label "zone of skin" ;
+    NIFRID:synonym "portion of skin",
+        "region of skin",
+        "skin",
+        "skin region",
+        "skin zone",
+        "zone of skin" ;
+    rdfs:subClassOf UBERON:0010314,
+        UBERON:0034944,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002097 ] .
+
 UBERON:0000016 a owl:Class ;
     rdfs:label "endocrine pancreas" ;
     NIFRID:synonym "endocrine pancreas",
@@ -5800,6 +6831,9 @@ UBERON:0000016 a owl:Class ;
         "pars endocrina pancreatis" ;
     rdfs:subClassOf UBERON:0000471,
         UBERON:0004119,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom NCBITaxon:6072 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000949 ],
@@ -5819,6 +6853,10 @@ UBERON:0000017 a owl:Class ;
     rdfs:subClassOf UBERON:0000409,
         UBERON:0004119,
         UBERON:0005177,
+        UBERON:0013765,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001007 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001264 ],
@@ -5831,7 +6869,8 @@ UBERON:0000017 a owl:Class ;
 
 UBERON:0000019 a owl:Class ;
     rdfs:label "camera-type eye" ;
-    NIFRID:synonym "camera-type eye plus associated structures",
+    NIFRID:synonym "camera-type eye",
+        "camera-type eye plus associated structures",
         "eye",
         "eyes",
         "orbital part of face",
@@ -5851,6 +6890,7 @@ UBERON:0000020 a owl:Class ;
     NIFRID:synonym "organ of sense organ system",
         "organ of sensory organ system",
         "organ of sensory system",
+        "sense organ",
         "sense organ system organ",
         "sensillum",
         "sensor",
@@ -5866,12 +6906,14 @@ UBERON:0000020 a owl:Class ;
 UBERON:0000025 a owl:Class ;
     rdfs:label "tube" ;
     NIFRID:synonym "anatomical tube",
-        "duct" ;
+        "duct",
+        "tube" ;
     rdfs:subClassOf UBERON:0004111 .
 
 UBERON:0000026 a owl:Class ;
     rdfs:label "appendage" ;
-    NIFRID:synonym "appendages",
+    NIFRID:synonym "appendage",
+        "appendages",
         "extremitaet",
         "extremity",
         "limbs/digits/tail" ;
@@ -5881,15 +6923,15 @@ UBERON:0000029 a owl:Class ;
     rdfs:label "lymph node" ;
     NIFRID:synonym "lymph gland",
         "nodus lymphaticus" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0005057,
+    rdfs:subClassOf UBERON:0005057,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002465 ] .
 
 UBERON:0000030 a owl:Class ;
     rdfs:label "lamina propria" ;
-    NIFRID:synonym "lamina propria mucosa",
+    NIFRID:synonym "lamina propria",
+        "lamina propria mucosa",
         "lamina propria mucosae",
         "tunica propria" ;
     rdfs:subClassOf UBERON:0004923,
@@ -5901,6 +6943,7 @@ UBERON:0000033 a owl:Class ;
     rdfs:label "head" ;
     NIFRID:synonym "adult head",
         "cephalic area",
+        "head",
         "head (volume)" ;
     rdfs:subClassOf UBERON:0011676,
         [ a owl:Restriction ;
@@ -5913,17 +6956,17 @@ UBERON:0000033 a owl:Class ;
 UBERON:0000042 a owl:Class ;
     rdfs:label "serous membrane" ;
     NIFRID:synonym "serosa",
+        "serous membrane",
         "tunica serosa",
         "wall of serous sac" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000481,
+    rdfs:subClassOf UBERON:0000481,
         UBERON:0004120,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000060 ],
+            owl:someValuesFrom NCBITaxon:6072 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005906 ] .
+            owl:someValuesFrom UBERON:0000060 ] .
 
 UBERON:0000044 a owl:Class ;
     rdfs:label "dorsal root ganglion" ;
@@ -5937,12 +6980,12 @@ UBERON:0000044 a owl:Class ;
         "posterior root ganglion",
         "spinal ganglion",
         "spinal ganglion part of peripheral nervous system" ;
-    rdfs:subClassOf UBERON:0001800,
-        UBERON:0010313 .
+    rdfs:subClassOf UBERON:0001800 .
 
 UBERON:0000045 a owl:Class ;
     rdfs:label "ganglion" ;
     NIFRID:synonym "ganglia",
+        "ganglion",
         "neural ganglion" ;
     rdfs:subClassOf UBERON:0000061,
         [ a owl:Restriction ;
@@ -5951,10 +6994,12 @@ UBERON:0000045 a owl:Class ;
 
 UBERON:0000047 a owl:Class ;
     rdfs:label "simple eye" ;
+    NIFRID:synonym "simple eye" ;
     rdfs:subClassOf UBERON:0000970 .
 
 UBERON:0000055 a owl:Class ;
     rdfs:label "vessel" ;
+    NIFRID:synonym "vessel" ;
     rdfs:subClassOf UBERON:0004111 .
 
 UBERON:0000056 a owl:Class ;
@@ -5986,18 +7031,16 @@ UBERON:0000057 a owl:Class ;
 UBERON:0000058 a owl:Class ;
     rdfs:label "duct" ;
     NIFRID:synonym "anatomical duct",
+        "duct",
         "ducts",
         "exocrine duct",
         "exocrine gland duct" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000063,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002365 ] .
+    rdfs:subClassOf UBERON:0000063 .
 
 UBERON:0000059 a owl:Class ;
     rdfs:label "large intestine" ;
-    NIFRID:synonym "intestinum crassum" ;
+    NIFRID:synonym "intestinum crassum",
+        "large intestine" ;
     rdfs:subClassOf UBERON:0004921,
         UBERON:0013765,
         [ a owl:Restriction ;
@@ -6012,17 +7055,16 @@ UBERON:0000059 a owl:Class ;
 
 UBERON:0000060 a owl:Class ;
     rdfs:label "anatomical wall" ;
-    NIFRID:synonym "organ wall",
+    NIFRID:synonym "anatomical wall",
+        "organ wall",
         "wall",
         "wall of organ" ;
-    rdfs:subClassOf UBERON:0000064,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0013522 ] .
+    rdfs:subClassOf UBERON:0000064 .
 
 UBERON:0000061 a owl:Class ;
     rdfs:label "anatomical structure" ;
-    NIFRID:synonym "biological structure",
+    NIFRID:synonym "anatomical structure",
+        "biological structure",
         "connected biological structure" ;
     rdfs:subClassOf UBERON:0000465 .
 
@@ -6030,7 +7072,8 @@ UBERON:0000062 a owl:Class ;
     rdfs:label "organ" ;
     NIFRID:synonym "anatomical unit",
         "body organ",
-        "element" ;
+        "element",
+        "organ" ;
     rdfs:subClassOf UBERON:0010000,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -6040,12 +7083,14 @@ UBERON:0000063 a owl:Class ;
     rdfs:label "organ subunit" ;
     NIFRID:synonym "organ region with fixed fiat boundary",
         "organ segment",
+        "organ subunit",
         "segment of organ" ;
     rdfs:subClassOf UBERON:0000064 .
 
 UBERON:0000064 a owl:Class ;
     rdfs:label "organ part" ;
     NIFRID:synonym "cardinal organ part",
+        "organ part",
         "regional part of organ" ;
     rdfs:subClassOf UBERON:0010000,
         [ a owl:Restriction ;
@@ -6054,26 +7099,30 @@ UBERON:0000064 a owl:Class ;
 
 UBERON:0000065 a owl:Class ;
     rdfs:label "respiratory tract" ;
+    NIFRID:synonym "respiratory tract" ;
     rdfs:subClassOf UBERON:0001005,
-        UBERON:0004119,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001004 ] .
 
 UBERON:0000072 a owl:Class ;
     rdfs:label "proximo-distal subdivision of respiratory tract" ;
-    NIFRID:synonym "respiratory tract",
+    NIFRID:synonym "proximo-distal subdivision of respiratory tract",
+        "respiratory tract",
         "subdivision of respiratory tract" ;
-    rdfs:subClassOf UBERON:0004119,
-        UBERON:0013522,
+    rdfs:subClassOf UBERON:0013522,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000065 ] .
 
 UBERON:0000073 a owl:Class ;
     rdfs:label "Regional part of nervous system" ;
-    NIFRID:synonym "part of nervous system" ;
+    NIFRID:synonym "part of nervous system",
+        "regional part of nervous system" ;
     rdfs:subClassOf UBERON:0000481,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom NCBITaxon:6072 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001016 ] .
@@ -6081,16 +7130,12 @@ UBERON:0000073 a owl:Class ;
 UBERON:0000075 a owl:Class ;
     rdfs:label "subdivision of skeletal system" ;
     NIFRID:synonym "skeletal system part",
-        "skeletal system subdivision" ;
+        "skeletal system subdivision",
+        "subdivision of skeletal system" ;
     rdfs:subClassOf UBERON:0011216,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001434 ] .
-
-UBERON:0000077 a owl:Class ;
-    rdfs:label "mixed endoderm/mesoderm-derived structure" ;
-    rdfs:subClassOf UBERON:0004119,
-        UBERON:0004120 .
 
 UBERON:0000079 a owl:Class ;
     rdfs:label "male reproductive system" ;
@@ -6110,13 +7155,20 @@ UBERON:0000079 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0003101 ] .
 
+UBERON:0000094 a owl:Class ;
+    rdfs:label "membrane organ" ;
+    NIFRID:synonym "membrane",
+        "membrane of organ",
+        "membrane organ" ;
+    rdfs:subClassOf UBERON:0000062 .
+
 UBERON:0000101 a owl:Class ;
     rdfs:label "lobe of lung" ;
-    NIFRID:synonym "lung lobe",
+    NIFRID:synonym "lobe of lung",
+        "lung lobe",
         "pulminory lobe",
         "pulmonary lobe" ;
-    rdfs:subClassOf UBERON:0004119,
-        UBERON:0009912,
+    rdfs:subClassOf UBERON:0009912,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002048 ],
@@ -6128,29 +7180,22 @@ UBERON:0000117 a owl:Class ;
     rdfs:label "respiratory tube" ;
     NIFRID:synonym "airway",
         "respiratory conducting tube",
+        "respiratory tube",
         "segment of tracheobronchial tree",
         "tracheobronchial tree segment" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000025,
-        UBERON:0004119,
+    rdfs:subClassOf UBERON:0000025,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000065 ] .
-
-UBERON:0000119 a owl:Class ;
-    rdfs:label "cell layer" ;
-    NIFRID:synonym "cell sheath",
-        "layer",
-        "layer of cells",
-        "sheath of cells" ;
-    rdfs:subClassOf UBERON:0000957 .
 
 UBERON:0000122 a owl:Class ;
     rdfs:label "neuron projection bundle" ;
     NIFRID:synonym "funiculus",
         "nerve fiber bundle",
-        "neural fiber bundle" ;
-    rdfs:subClassOf UBERON:0005162,
+        "neural fiber bundle",
+        "neuron projection bundle" ;
+    rdfs:subClassOf UBERON:0000061,
+        UBERON:0005162,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001016 ] .
@@ -6158,6 +7203,7 @@ UBERON:0000122 a owl:Class ;
 UBERON:0000125 a owl:Class ;
     rdfs:label "neural nucleus" ;
     NIFRID:synonym "nervous system nucleus",
+        "neural nucleus",
         "neuraxis nucleus",
         "neuronal nucleus",
         "nucleus",
@@ -6170,18 +7216,24 @@ UBERON:0000125 a owl:Class ;
 
 UBERON:0000126 a owl:Class ;
     rdfs:label "cranial nerve nucleus" ;
-    NIFRID:synonym "cranial neural nucleus",
+    NIFRID:synonym "cranial nerve nucleus",
+        "cranial neural nucleus",
         "nucleus nervi cranialis",
         "nucleus of cranial nerve" ;
-    rdfs:subClassOf UBERON:0002308 .
+    rdfs:subClassOf UBERON:0002308,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
 
 UBERON:0000127 a owl:Class ;
     rdfs:label "facial nucleus" ;
     NIFRID:synonym "facial nerve nucleus",
+        "facial nucleus",
         "facial VII motor nucleus",
         "facial VII nucleus",
         "nucleus of facial nerve" ;
     rdfs:subClassOf UBERON:0000126,
+        UBERON:0004121,
         UBERON:0006331,
         UBERON:0009662,
         [ a owl:Restriction ;
@@ -6193,18 +7245,46 @@ UBERON:0000127 a owl:Class ;
 
 UBERON:0000153 a owl:Class ;
     rdfs:label "anterior region of body" ;
+    NIFRID:synonym "anterior region of body" ;
+    rdfs:subClassOf UBERON:0000475 .
+
+UBERON:0000154 a owl:Class ;
+    rdfs:label "posterior region of body" ;
+    NIFRID:synonym "posterior region of body" ;
     rdfs:subClassOf UBERON:0000475 .
 
 UBERON:0000158 a owl:Class ;
     rdfs:label "membranous layer" ;
     NIFRID:synonym "membrane",
+        "membranous layer",
         "membranous organ component" ;
     rdfs:subClassOf UBERON:0004923 .
+
+UBERON:0000159 a owl:Class ;
+    rdfs:label "anal canal" ;
+    NIFRID:synonym "anal canal",
+        "anal canal viewed anatomically",
+        "anal pad",
+        "anatomical anal canal",
+        "anus",
+        "canalis analis",
+        "cloaca",
+        "cloacal chamber",
+        "mesenteron",
+        "pars analis recti" ;
+    rdfs:subClassOf UBERON:0004111,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000059 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001353 ] .
 
 UBERON:0000160 a owl:Class ;
     rdfs:label "intestine" ;
     NIFRID:synonym "bowel",
-        "intestinal tract" ;
+        "intestinal tract",
+        "intestine" ;
     rdfs:subClassOf UBERON:0004921,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -6219,6 +7299,7 @@ UBERON:0000165 a owl:Class ;
         "cavital oralis",
         "cavitas oris",
         "cavum oris",
+        "mouth",
         "mouth cavity",
         "oral region",
         "oral vestibule",
@@ -6229,17 +7310,26 @@ UBERON:0000165 a owl:Class ;
         "trophic apparatus",
         "vestibule of mouth",
         "vestibulum oris" ;
-    rdfs:subClassOf UBERON:0004921,
+    rdfs:subClassOf UBERON:0004921 .
+
+UBERON:0000167 a owl:Class ;
+    rdfs:label "oral cavity" ;
+    NIFRID:synonym "bucca",
+        "buccal cavity",
+        "cavity of mouth",
+        "oral cavity" ;
+    rdfs:subClassOf UBERON:0002553,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000033 ],
+            owl:someValuesFrom UBERON:0000165 ],
         [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001456 ] .
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0000165 ] .
 
 UBERON:0000168 a owl:Class ;
     rdfs:label "proximal-distal subdivision of colon" ;
-    NIFRID:synonym "segment of colon" ;
+    NIFRID:synonym "proximal-distal subdivision of colon",
+        "segment of colon" ;
     rdfs:subClassOf UBERON:0004921,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -6249,6 +7339,7 @@ UBERON:0000170 a owl:Class ;
     rdfs:label "pair of lungs" ;
     NIFRID:synonym "lungs",
         "lungs pair",
+        "pair of lungs",
         "pulmones",
         "set of lungs" ;
     rdfs:subClassOf UBERON:0034925,
@@ -6263,6 +7354,7 @@ UBERON:0000171 a owl:Class ;
         "gas exchange organ",
         "organ of apparatus respiratorius",
         "organ of respiratory system",
+        "respiration organ",
         "respiratory organ",
         "respiratory system organ" ;
     rdfs:subClassOf UBERON:0000062,
@@ -6278,12 +7370,12 @@ UBERON:0000200 a owl:Class ;
         "folium of brain",
         "gyri",
         "gyri of cerebrum",
+        "gyrus",
         "gyrus of cerebral hemisphere",
         "gyrus of cerebrum",
         "gyrus of neuraxis",
         "neuraxis gyrus" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0034768,
+    rdfs:subClassOf UBERON:0034768,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000956 ],
@@ -6296,7 +7388,8 @@ UBERON:0000203 a owl:Class ;
     NIFRID:synonym "area dorsalis telencephali",
         "dorsal part of telencephalon",
         "dorsal telencephalic area",
-        "dorsal telencephalon" ;
+        "dorsal telencephalon",
+        "pallium" ;
     rdfs:subClassOf UBERON:0002616,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -6306,6 +7399,7 @@ UBERON:0000204 a owl:Class ;
     rdfs:label "ventral part of telencephalon" ;
     NIFRID:synonym "area ventralis telencephali",
         "subpallium",
+        "ventral part of telencephalon",
         "ventral telencephalon" ;
     rdfs:subClassOf UBERON:0002616,
         [ a owl:Restriction ;
@@ -6316,6 +7410,25 @@ UBERON:0000211 a owl:Class ;
     rdfs:label "ligament" ;
     NIFRID:synonym "ligament organ" ;
     rdfs:subClassOf UBERON:0000062 .
+
+UBERON:0000303 a owl:Class ;
+    rdfs:label "adductor longus" ;
+    NIFRID:synonym "adductor longus muscle",
+        "long adductor muscle",
+        "musculus adductor longus" ;
+    rdfs:subClassOf UBERON:0004252,
+        UBERON:0011144,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000376 ] .
+
+UBERON:0000311 a owl:Class ;
+    rdfs:label "extensor muscle" ;
+    NIFRID:synonym "extensor" ;
+    rdfs:subClassOf UBERON:0014892,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000026 ] .
 
 UBERON:0000317 a owl:Class ;
     rdfs:label "colonic mucosa" ;
@@ -6334,6 +7447,7 @@ UBERON:0000317 a owl:Class ;
 UBERON:0000328 a owl:Class ;
     rdfs:label "gut wall" ;
     NIFRID:synonym "digestive tract wall",
+        "gut wall",
         "wall of alimentary tract",
         "wall of digestive tract",
         "wall of gut" ;
@@ -6344,43 +7458,207 @@ UBERON:0000328 a owl:Class ;
 
 UBERON:0000344 a owl:Class ;
     rdfs:label "mucosa" ;
-    NIFRID:synonym "mucosa of organ",
+    NIFRID:synonym "mucosa",
+        "mucosa of organ",
         "mucosa of organ part",
         "mucosal region",
         "mucous membrane",
         "organ mucosa",
         "region of mucosa",
         "tunica mucosa" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0004923,
+    rdfs:subClassOf UBERON:0004923 .
+
+UBERON:0000348 a owl:Class ;
+    rdfs:label "ophthalmic nerve" ;
+    NIFRID:synonym "ciliary nerve",
+        "cranial nerve V, branch V1",
+        "ethmoidal nerve",
+        "first branch of fifth cranial nerve",
+        "first division of fifth cranial nerve",
+        "first division of trigeminal nerve",
+        "nervus ophthalmicus (V1)",
+        "nervus ophthalmicus (Va)",
+        "nervus ophthalmicus [v1]",
+        "nervus ophthalmicus [va]",
+        "ophthalmic division",
+        "ophthalmic division [V1]",
+        "ophthalmic division [Va]",
+        "ophthalmic division of fifth cranial nerve",
+        "ophthalmic division of trigeminal nerve (V1)",
+        "ophthalmic division of trigeminal nerve (Va)",
+        "ophthalmic nerve [V1]",
+        "ophthalmic nerve [Va]",
+        "opthalmic nerve",
+        "profundal nerve",
+        "profundus",
+        "profundus nerve",
+        "ramus opthalmicus profundus (ramus V1)",
+        "rostral branch of trigeminal nerve",
+        "trigeminal nerve ophthalmic division",
+        "trigeminal V nerve ophthalmic division" ;
+    rdfs:subClassOf UBERON:0004121,
+        UBERON:0011779,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0011374 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0012125 ] .
+            owl:someValuesFrom UBERON:0001645 ] .
 
 UBERON:0000349 a owl:Class ;
     rdfs:label "limbic system" ;
-    NIFRID:synonym "visceral brain" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0011216,
+    NIFRID:synonym "limbic system",
+        "visceral brain" ;
+    rdfs:subClassOf UBERON:0011216,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001890 ] .
 
 UBERON:0000353 a owl:Class ;
     rdfs:label "parenchyma" ;
+    NIFRID:synonym "parenchyma" ;
     rdfs:subClassOf UBERON:0000064 .
+
+UBERON:0000355 a owl:Class ;
+    rdfs:label "pharyngeal mucosa" ;
+    NIFRID:synonym "mucosa of organ of pharynx",
+        "mucosa of pharynx",
+        "mucous membrane of pharynx",
+        "mucous membrane of the pharynx",
+        "organ mucosa of pharynx",
+        "pharyngeal mucosa",
+        "pharynx mucosa",
+        "pharynx mucosa of organ",
+        "pharynx mucous membrane",
+        "pharynx organ mucosa",
+        "tunica mucosa pharyngea",
+        "tunica mucosa pharyngis" ;
+    rdfs:subClassOf UBERON:0004785,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001042 ] .
+
+UBERON:0000366 a owl:Class ;
+    rdfs:label "flexor muscle" ;
+    NIFRID:synonym "flexor" ;
+    rdfs:subClassOf UBERON:0014892,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000026 ] .
+
+UBERON:0000368 a owl:Class ;
+    rdfs:label "adductor brevis" ;
+    NIFRID:synonym "adductor brevis muscle",
+        "musculus adductos brevis" ;
+    rdfs:subClassOf UBERON:0004252,
+        UBERON:0011144,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000376 ] .
 
 UBERON:0000369 a owl:Class ;
     rdfs:label "corpus striatum" ;
-    NIFRID:synonym "striate body",
+    NIFRID:synonym "corpus striatum",
+        "striate body",
         "striated body" ;
     rdfs:subClassOf UBERON:0002616,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002420 ] .
+
+UBERON:0000370 a owl:Class ;
+    rdfs:label "adductor magnus" ;
+    NIFRID:synonym "adductor magnus muscle",
+        "musculus adductor magnus" ;
+    rdfs:subClassOf UBERON:0004252,
+        UBERON:0011144,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000376 ] .
+
+UBERON:0000372 a owl:Class ;
+    rdfs:label "extensor digitorum brevis pes" ;
+    NIFRID:synonym "extensor digitorum brevis",
+        "extensor digitorum brevis muscle",
+        "musculus extensor digitorum brevis" ;
+    rdfs:subClassOf UBERON:0000311,
+        UBERON:0001498,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002387 ] .
+
+UBERON:0000375 a owl:Class ;
+    rdfs:label "mandibular nerve" ;
+    NIFRID:synonym "inferior maxillary nerve",
+        "mandibular division [V3]",
+        "mandibular division [Vc]",
+        "mandibular division of fifth cranial nerve",
+        "mandibular division of trigeminal nerve [Vc; V3]",
+        "mandibular nerve",
+        "mandibular nerve [V3]",
+        "mandibular nerve [Vc]",
+        "n. mandibularis",
+        "nervus mandibularis",
+        "nervus mandibularis [v3]",
+        "nervus mandibularis [Vc; V3]",
+        "nervus mandibularis [vc]",
+        "ramus mandibularis (ramus V3)",
+        "third division of fifth cranial nerve",
+        "third division of trigeminal nerve",
+        "trigeminal nerve mandibular division",
+        "trigeminal V nerve mandibular division" ;
+    rdfs:subClassOf UBERON:0011779,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001645 ] .
+
+UBERON:0000376 a owl:Class ;
+    rdfs:label "hindlimb stylopod" ;
+    NIFRID:synonym "femur",
+        "hind limb stylopod",
+        "hind limb stylopodium",
+        "hind propodium",
+        "hindlimb propodium",
+        "hindlimb stylopod",
+        "hindlimb stylopodium",
+        "proximal segment of free lower limb",
+        "stylopod of hind limb",
+        "stylopod of hindlimb",
+        "stylopod of lower limb",
+        "thigh",
+        "upper leg" ;
+    rdfs:subClassOf UBERON:0002472,
+        UBERON:0008784,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000978 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002103 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002103 ] .
+
+UBERON:0000377 a owl:Class ;
+    rdfs:label "maxillary nerve" ;
+    NIFRID:synonym "maxillary division [V2]",
+        "maxillary division [Vb]",
+        "maxillary division of fifth cranial nerve",
+        "maxillary division of trigeminal nerve (Vb; V2)",
+        "maxillary nerve",
+        "maxillary nerve [V2]",
+        "maxillary nerve [Vb]",
+        "n. maxillaris",
+        "nervus maxillaris",
+        "nervus maxillaris (Vb; V2)",
+        "nervus maxillaris [v2]",
+        "nervus maxillaris [vb]",
+        "ramus maxillaris (ramus V2)",
+        "second division of fifth cranial nerve",
+        "second division of trigeminal nerve",
+        "trigeminal nerve maxillary division",
+        "trigeminal V nerve maxillary division" ;
+    rdfs:subClassOf UBERON:0011779,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001645 ] .
 
 UBERON:0000379 a owl:Class ;
     rdfs:label "tracheal mucosa" ;
@@ -6396,6 +7674,7 @@ UBERON:0000379 a owl:Class ;
         "trachea mucosa of organ",
         "trachea mucous membrane",
         "trachea organ mucosa",
+        "tracheal mucosa",
         "tracheal mucous membrane",
         "tunica mucosa (tracheae)",
         "tunica mucosa tracheae",
@@ -6406,40 +7685,30 @@ UBERON:0000379 a owl:Class ;
     rdfs:subClassOf UBERON:0004785,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001005 ] .
+            owl:someValuesFrom UBERON:0001005 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003126 ] .
 
 UBERON:0000383 a owl:Class ;
     rdfs:label "musculature of body" ;
     NIFRID:synonym "muscle system",
         "muscle system of body",
         "muscular system",
+        "musculature of body",
         "musculature system",
         "muskelsystem",
         "set of all muscles",
         "set of muscles of body",
         "vertebrate muscular system" ;
-    rdfs:subClassOf UBERON:0011216,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002204 ] .
+    rdfs:subClassOf UBERON:0011216 .
 
 UBERON:0000388 a owl:Class ;
-    rdfs:label "Epiglottis",
-        "epiglottis" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0013522,
+    rdfs:label "epiglottis" ;
+    rdfs:subClassOf UBERON:0013522,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001051 ] .
-
-UBERON:0000403 a owl:Class ;
-    rdfs:label "scalp" ;
-    NIFRID:synonym "scalpus" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0034921,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000033 ] .
 
 UBERON:0000407 a owl:Class ;
     rdfs:label "sympathetic trunk" ;
@@ -6455,16 +7724,40 @@ UBERON:0000407 a owl:Class ;
 
 UBERON:0000409 a owl:Class ;
     rdfs:label "serous gland" ;
+    NIFRID:synonym "serous gland" ;
     rdfs:subClassOf UBERON:0002365 .
 
 UBERON:0000414 a owl:Class ;
     rdfs:label "mucous gland" ;
     NIFRID:synonym "glandula mucosa",
         "muciparous gland",
+        "mucous gland",
         "mucous secreting gland",
         "mucus gland",
         "mucus-secreting gland" ;
     rdfs:subClassOf UBERON:0002365 .
+
+UBERON:0000415 a owl:Class ;
+    rdfs:label "artery wall" ;
+    NIFRID:synonym "arterial wall",
+        "artery wall",
+        "wall of artery" ;
+    rdfs:subClassOf UBERON:0035965,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001637 ] .
+
+UBERON:0000423 a owl:Class ;
+    rdfs:label "eccrine sweat gland" ;
+    NIFRID:synonym "eccrine gland",
+        "glandula sudorifera eccrina",
+        "glandula sudorifera merocrina",
+        "merocrine sweat gland" ;
+    rdfs:subClassOf UBERON:0001820,
+        UBERON:0010243,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001003 ] .
 
 UBERON:0000428 a owl:Class ;
     rdfs:label "prostate epithelium" ;
@@ -6478,11 +7771,9 @@ UBERON:0000428 a owl:Class ;
         "prostate gland epithelium",
         "prostatic epithelium",
         "prostatic gland epithelium" ;
-    rdfs:subClassOf UBERON:0000077,
-        UBERON:0000485,
+    rdfs:subClassOf UBERON:0000485,
         UBERON:0005156,
         UBERON:0005911,
-        UBERON:0012275,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002367 ] .
@@ -6495,15 +7786,9 @@ UBERON:0000429 a owl:Class ;
         "plexus nervosus entericus",
         "sympathetic enteric nerve plexus" ;
     rdfs:subClassOf UBERON:0001816,
-        UBERON:0010313,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002005 ] .
-
-UBERON:0000440 a owl:Class ;
-    rdfs:label "trabecula" ;
-    NIFRID:synonym "trabeculae" ;
-    rdfs:subClassOf UBERON:0000064 .
 
 UBERON:0000446 a owl:Class ;
     rdfs:label "septum of telencephalon" ;
@@ -6514,6 +7799,7 @@ UBERON:0000446 a owl:Class ;
         "septal region",
         "septum",
         "septum (NN)",
+        "septum of telencephalon",
         "septum pellucidum (BNA,PNA)",
         "septum telencephali",
         "telencephalon septum" ;
@@ -6525,18 +7811,12 @@ UBERON:0000446 a owl:Class ;
 UBERON:0000454 a owl:Class ;
     rdfs:label "cerebral subcortex" ;
     NIFRID:synonym "cerebral medulla",
+        "cerebral subcortex",
         "subcortex" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000955 ] .
-
-UBERON:0000458 a owl:Class ;
-    rdfs:label "endocervix" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000064,
-        UBERON:0005156 .
 
 UBERON:0000459 a owl:Class ;
     rdfs:label "uterine wall" ;
@@ -6550,13 +7830,30 @@ UBERON:0000459 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000995 ] .
 
+UBERON:0000464 a owl:Class ;
+    rdfs:label "anatomical space" ;
+    NIFRID:synonym "anatomical space",
+        "anatomical spaces",
+        "lumen",
+        "lumen space",
+        "space" ;
+    rdfs:subClassOf UBERON:0000466 .
+
 UBERON:0000465 a owl:Class ;
     rdfs:label "material anatomical entity" ;
-    rdfs:subClassOf BFO:0000040 .
+    NIFRID:synonym "material anatomical entity" ;
+    rdfs:subClassOf UBERON:0001062 .
+
+UBERON:0000466 a owl:Class ;
+    rdfs:label "immaterial anatomical entity" ;
+    NIFRID:synonym "immaterial anatomical entity",
+        "immaterial physical anatomical entity" ;
+    rdfs:subClassOf UBERON:0001062 .
 
 UBERON:0000467 a owl:Class ;
     rdfs:label "anatomical system" ;
-    NIFRID:synonym "anatomical systems",
+    NIFRID:synonym "anatomical system",
+        "anatomical systems",
         "body system",
         "connected anatomical system",
         "organ system",
@@ -6568,10 +7865,10 @@ UBERON:0000467 a owl:Class ;
 
 UBERON:0000468 a owl:Class ;
     rdfs:label "multicellular organism" ;
-    NIFRID:synonym "animal",
-        "body",
+    NIFRID:synonym "body",
         "Koerper",
         "multi-cellular organism",
+        "multicellular organism",
         "organism",
         "whole body",
         "whole organism" ;
@@ -6579,7 +7876,8 @@ UBERON:0000468 a owl:Class ;
 
 UBERON:0000471 a owl:Class ;
     rdfs:label "compound organ component" ;
-    NIFRID:synonym "compound organ components" ;
+    NIFRID:synonym "compound organ component",
+        "compound organ components" ;
     rdfs:subClassOf UBERON:0000481,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -6598,10 +7896,7 @@ UBERON:0000473 a owl:Class ;
         UBERON:0003135,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000079 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0010899 ] .
+            owl:someValuesFrom UBERON:0000079 ] .
 
 UBERON:0000474 a owl:Class ;
     rdfs:label "female reproductive system" ;
@@ -6611,6 +7906,7 @@ UBERON:0000474 a owl:Class ;
         "female genitals",
         "female organism genitalia",
         "female organism reproductive system",
+        "female reproductive system",
         "female reproductive tract",
         "genitalia of female organism",
         "gynaecological tissue",
@@ -6626,7 +7922,8 @@ UBERON:0000475 a owl:Class ;
     NIFRID:synonym "anatomic region",
         "body part",
         "body region",
-        "cardinal body part" ;
+        "cardinal body part",
+        "organism subdivision" ;
     rdfs:subClassOf UBERON:0010000,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -6634,44 +7931,42 @@ UBERON:0000475 a owl:Class ;
 
 UBERON:0000476 a owl:Class ;
     rdfs:label "acellular anatomical structure" ;
-    NIFRID:synonym "acellular anatomical structures" ;
+    NIFRID:synonym "acellular anatomical structure",
+        "acellular anatomical structures" ;
     rdfs:subClassOf UBERON:0000061 .
 
 UBERON:0000477 a owl:Class ;
     rdfs:label "anatomical cluster" ;
+    NIFRID:synonym "anatomical cluster" ;
     rdfs:subClassOf UBERON:0034923 .
 
 UBERON:0000479 a owl:Class ;
     rdfs:label "tissue" ;
     NIFRID:synonym "portion of tissue",
         "simple tissue",
+        "tissue",
         "tissue portion" ;
-    rdfs:subClassOf UBERON:0010000,
+    rdfs:subClassOf UBERON:0000465,
+        UBERON:0010000,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000468 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000481 ] .
+            owl:someValuesFrom UBERON:0000468 ] .
 
 UBERON:0000481 a owl:Class ;
     rdfs:label "multi-tissue structure" ;
-    NIFRID:synonym "multi-tissue structures" ;
-    rdfs:subClassOf UBERON:0010000 .
+    NIFRID:synonym "multi-tissue structure",
+        "multi-tissue structures" ;
+    rdfs:subClassOf UBERON:0010000,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom NCBITaxon:6072 ] .
 
 UBERON:0000483 a owl:Class ;
-    rdfs:label "Epithelium",
-        "epithelium" ;
+    rdfs:label "epithelium" ;
     NIFRID:synonym "epithelial tissue",
+        "epithelium",
         "portion of epithelium" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000479,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000117 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000344 ] .
+    rdfs:subClassOf UBERON:0000479 .
 
 UBERON:0000485 a owl:Class ;
     rdfs:label "simple columnar epithelium" ;
@@ -6681,38 +7976,58 @@ UBERON:0000485 a owl:Class ;
         "simple columnar epithelia",
         "simple columnar epithelium" ;
     rdfs:subClassOf UBERON:0000490,
-        UBERON:0012274,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000458 ] .
+        UBERON:0012274 .
 
 UBERON:0000486 a owl:Class ;
     rdfs:label "multilaminar epithelium" ;
     NIFRID:synonym "laminated epithelium",
+        "multilaminar epithelium",
         "stratified epithelium" ;
     rdfs:subClassOf UBERON:0000483 .
+
+UBERON:0000487 a owl:Class ;
+    rdfs:label "simple squamous epithelium" ;
+    NIFRID:synonym "epithelium simplex squamosum",
+        "simple squamous epithelia",
+        "simple squamous epithelium" ;
+    rdfs:subClassOf UBERON:0000490,
+        UBERON:0006914 .
 
 UBERON:0000488 a owl:Class ;
     rdfs:label "atypical epithelium" ;
     NIFRID:synonym "atypical epithelia",
+        "atypical epithelium",
         "heterogenous epithelium" ;
     rdfs:subClassOf UBERON:0000483 .
 
 UBERON:0000489 a owl:Class ;
     rdfs:label "cavitated compound organ" ;
-    NIFRID:synonym "cavitated compound organs",
+    NIFRID:synonym "cavitated compound organ",
+        "cavitated compound organs",
         "cavitated organ" ;
     rdfs:subClassOf UBERON:0003103 .
 
 UBERON:0000490 a owl:Class ;
     rdfs:label "unilaminar epithelium" ;
     NIFRID:synonym "simple epithelium",
-        "unilaminar epithelia" ;
+        "unilaminar epithelia",
+        "unilaminar epithelium" ;
     rdfs:subClassOf UBERON:0000483 .
+
+UBERON:0000711 a owl:Class ;
+    rdfs:label "splenius capitis" ;
+    NIFRID:synonym "musculus splenius capitis",
+        "splenius capitis muscle" ;
+    rdfs:subClassOf UBERON:0002252,
+        UBERON:0002377,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012477 ] .
 
 UBERON:0000915 a owl:Class ;
     rdfs:label "thoracic segment of trunk" ;
     NIFRID:synonym "anterior subdivision of trunk",
+        "thoracic segment of trunk",
         "thorax",
         "upper body",
         "upper trunk" ;
@@ -6721,7 +8036,8 @@ UBERON:0000915 a owl:Class ;
 
 UBERON:0000916 a owl:Class ;
     rdfs:label "abdomen" ;
-    NIFRID:synonym "abdominopelvic region",
+    NIFRID:synonym "abdomen",
+        "abdominopelvic region",
         "abdominopelvis",
         "adult abdomen",
         "belly",
@@ -6731,21 +8047,21 @@ UBERON:0000916 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002417 ] .
 
-UBERON:0000922 a owl:Class ;
-    rdfs:label "embryo" ;
-    NIFRID:synonym "developing organism",
-        "developmental tissue",
-        "embryonic organism" ;
-    rdfs:subClassOf UBERON:0000468,
+UBERON:0000942 a owl:Class ;
+    rdfs:label "frontal nerve (branch of ophthalmic)" ;
+    NIFRID:synonym "frontal nerve",
+        "nervus frontalis" ;
+    rdfs:subClassOf UBERON:0011779,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0009097 ] .
+            owl:someValuesFrom UBERON:0000348 ] .
 
 UBERON:0000945 a owl:Class ;
     rdfs:label "stomach" ;
     NIFRID:synonym "anterior intestine",
         "gaster",
         "mesenteron",
+        "stomach",
         "stomach chamber",
         "ventriculus" ;
     rdfs:subClassOf UBERON:0004921,
@@ -6759,13 +8075,17 @@ UBERON:0000945 a owl:Class ;
 
 UBERON:0000947 a owl:Class ;
     rdfs:label "aorta" ;
-    NIFRID:synonym "arteria maxima",
+    NIFRID:synonym "aorta",
+        "arteria maxima",
         "dorsal aorta",
         "trunk of aortic tree",
         "trunk of systemic arterial tree" ;
     rdfs:subClassOf UBERON:0003509,
         UBERON:0003519,
         UBERON:0013768,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0010191 ] .
@@ -6775,14 +8095,12 @@ UBERON:0000948 a owl:Class ;
     NIFRID:synonym "branchial heart",
         "cardium",
         "chambered heart",
+        "heart",
         "vertebrate heart" ;
     rdfs:subClassOf UBERON:0004120,
         UBERON:0005181,
         UBERON:0007100,
         UBERON:0010314,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004535 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0015410 ],
@@ -6797,14 +8115,26 @@ UBERON:0000949 a owl:Class ;
         "systema endocrinum" ;
     rdfs:subClassOf UBERON:0015204 .
 
+UBERON:0000950 a owl:Class ;
+    rdfs:label "gracilis" ;
+    NIFRID:synonym "gracilis muscle",
+        "musculus gracilis" ;
+    rdfs:subClassOf UBERON:0004252,
+        UBERON:0011144,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000376 ] .
+
 UBERON:0000955 a owl:Class ;
     rdfs:label "brain" ;
-    NIFRID:synonym "encephalon",
+    NIFRID:synonym "brain",
+        "encephalon",
         "suprasegmental levels of nervous system",
         "suprasegmental structures",
         "synganglion",
         "the brain" ;
     rdfs:subClassOf UBERON:0000062,
+        UBERON:0000465,
         UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -6816,6 +8146,7 @@ UBERON:0000955 a owl:Class ;
 UBERON:0000956 a owl:Class ;
     rdfs:label "cerebral cortex" ;
     NIFRID:synonym "brain cortex",
+        "cerebral cortex",
         "cortex cerebralis",
         "cortex cerebri",
         "cortex of cerebral hemisphere",
@@ -6834,15 +8165,13 @@ UBERON:0000956 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001893 ] .
 
-UBERON:0000957 a owl:Class ;
-    rdfs:label "lamina" ;
-    NIFRID:synonym "laminar tissue" ;
-    rdfs:subClassOf UBERON:0000479 .
-
 UBERON:0000958 a owl:Class ;
     rdfs:label "medulla of organ" ;
     NIFRID:synonym "medulla" ;
-    rdfs:subClassOf UBERON:0000471 .
+    rdfs:subClassOf UBERON:0000471,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom NCBITaxon:6072 ] .
 
 UBERON:0000961 a owl:Class ;
     rdfs:label "thoracic ganglion" ;
@@ -6857,19 +8186,26 @@ UBERON:0000961 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004863 ] .
 
+UBERON:0000962 a owl:Class ;
+    rdfs:label "nerve of cervical vertebra" ;
+    NIFRID:synonym "cervical nerve",
+        "cervical nerve tree",
+        "cervical spinal nerve",
+        "nerve of cervical vertebra",
+        "nervus cervicalis" ;
+    rdfs:subClassOf UBERON:0001780 .
+
 UBERON:0000966 a owl:Class ;
     rdfs:label "Retina",
         "retina" ;
     NIFRID:synonym "inner layer of eyeball",
         "Netzhaut",
+        "retina",
         "retina of camera-type eye",
         "retinas",
         "tunica interna of eyeball" ;
     rdfs:subClassOf UBERON:0004121,
         UBERON:0005388,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000019 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001802 ],
@@ -6888,7 +8224,8 @@ UBERON:0000966 a owl:Class ;
 
 UBERON:0000970 a owl:Class ;
     rdfs:label "eye" ;
-    NIFRID:synonym "light-detecting organ",
+    NIFRID:synonym "eye",
+        "light-detecting organ",
         "visual apparatus" ;
     rdfs:subClassOf UBERON:0000020,
         [ a owl:Restriction ;
@@ -6898,39 +8235,45 @@ UBERON:0000970 a owl:Class ;
 UBERON:0000974 a owl:Class ;
     rdfs:label "neck" ;
     NIFRID:synonym "collum",
+        "neck",
         "neck (volume)" ;
     rdfs:subClassOf UBERON:0000475,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000153 ],
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007811 ] .
+            owl:someValuesFrom UBERON:0000153 ] .
+
+UBERON:0000978 a owl:Class ;
+    rdfs:label "leg" ;
+    NIFRID:synonym "lower extremity",
+        "tetrapod leg" ;
+    rdfs:subClassOf UBERON:0006058,
+        UBERON:0008784,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002103 ] .
 
 UBERON:0000982 a owl:Class ;
     rdfs:label "skeletal joint" ;
     NIFRID:synonym "articular joint",
         "articulation",
         "joint",
-        "joints" ;
+        "joints",
+        "skeletal joint" ;
     rdfs:subClassOf UBERON:0004905,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004770 ],
         [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0011137 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0011249 ],
-        [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001434 ] .
 
 UBERON:0000988 a owl:Class ;
-    rdfs:label "Pons",
-        "pons" ;
-    NIFRID:synonym "pons cerebri",
+    rdfs:label "pons" ;
+    NIFRID:synonym "pons",
+        "pons cerebri",
         "pons of Varolius",
         "pons Varolii" ;
     rdfs:subClassOf UBERON:0002616,
@@ -6945,16 +8288,7 @@ UBERON:0000988 a owl:Class ;
             owl:someValuesFrom UBERON:0001895 ],
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0002298 ] ;
-    ilxtr:hasExistingId BIRNLEX:733,
-        FMA:67943,
-        ILX:0109019,
-        UBERON:0000988 ;
-    ilxtr:hasExternalId BIRNLEX:733,
-        FMA:67943,
-        UBERON:0000988 ;
-    ilxtr:hasIlxId ILX:0109019 ;
-    ilxtr:hasIlxPreferredId UBERON:0000988 .
+            owl:someValuesFrom UBERON:0002298 ] .
 
 UBERON:0000989 a owl:Class ;
     rdfs:label "penis" ;
@@ -6971,17 +8305,16 @@ UBERON:0000990 a owl:Class ;
         "genitalia",
         "Geschlechtsorgan",
         "organa genitalia",
+        "reproductive system",
         "reproductive tissue",
         "reproductive tract",
         "systemata genitalia" ;
-    rdfs:subClassOf UBERON:0000467,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004122 ] .
+    rdfs:subClassOf UBERON:0000467 .
 
 UBERON:0000991 a owl:Class ;
     rdfs:label "gonad" ;
-    NIFRID:synonym "gonada",
+    NIFRID:synonym "gonad",
+        "gonada",
         "gonads" ;
     rdfs:subClassOf UBERON:0003133,
         [ a owl:Restriction ;
@@ -7012,6 +8345,7 @@ UBERON:0000992 a owl:Class ;
         "gonada of reproductive system of female organism",
         "ovaries",
         "ovarium",
+        "ovary",
         "ovum-producing ovary",
         "reproductive system of female organism gonad",
         "reproductive system of female organism gonada" ;
@@ -7019,10 +8353,7 @@ UBERON:0000992 a owl:Class ;
         UBERON:0003134,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000474 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0010899 ] .
+            owl:someValuesFrom UBERON:0000474 ] .
 
 UBERON:0000993 a owl:Class ;
     rdfs:label "oviduct" ;
@@ -7098,6 +8429,18 @@ UBERON:0000998 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0004054 ] .
 
+UBERON:0001003 a owl:Class ;
+    rdfs:label "skin epidermis" ;
+    NIFRID:synonym "epidermis",
+        "skin",
+        "skin epidermis",
+        "vertebrate epidermis" ;
+    rdfs:subClassOf UBERON:0007376,
+        UBERON:3000961,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002097 ] .
+
 UBERON:0001004 a owl:Class ;
     rdfs:label "respiratory system" ;
     NIFRID:synonym "apparatus respiratorius",
@@ -7109,7 +8452,8 @@ UBERON:0001004 a owl:Class ;
 UBERON:0001005 a owl:Class ;
     rdfs:label "respiratory airway" ;
     NIFRID:synonym "airway",
-        "airways" ;
+        "airways",
+        "respiratory airway" ;
     rdfs:subClassOf UBERON:0003103,
         UBERON:0004111,
         [ a owl:Restriction ;
@@ -7120,6 +8464,7 @@ UBERON:0001007 a owl:Class ;
     rdfs:label "digestive system" ;
     NIFRID:synonym "alimentary system",
         "alimentary tract",
+        "digestive system",
         "gastrointestinal system",
         "gut" ;
     rdfs:subClassOf UBERON:0000467 .
@@ -7128,42 +8473,30 @@ UBERON:0001008 a owl:Class ;
     rdfs:label "renal system" ;
     NIFRID:synonym "excretory system",
         "renal or urinary system",
+        "renal system",
         "renal/urinary system",
         "systema urinaria",
         "systema urinarium",
         "urinary system",
         "urinary tract" ;
-    rdfs:subClassOf UBERON:8450002,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004122 ] .
+    rdfs:subClassOf UBERON:8450002 .
 
 UBERON:0001009 a owl:Class ;
     rdfs:label "circulatory system" ;
-    NIFRID:synonym "systema cardiovasculare" ;
+    NIFRID:synonym "circulatory system",
+        "systema cardiovasculare" ;
     rdfs:subClassOf UBERON:0000467 .
 
 UBERON:0001013 a owl:Class ;
     rdfs:label "adipose tissue" ;
     NIFRID:synonym "adipose",
+        "adipose tissue",
         "bodyfat",
         "fat",
         "fat tissue",
         "fatty depot",
         "fatty tissue" ;
-    rdfs:subClassOf UBERON:0011822,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001847 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007809 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0013489 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0013657 ] .
+    rdfs:subClassOf UBERON:0011822 .
 
 UBERON:0001015 a owl:Class ;
     rdfs:label "musculature" ;
@@ -7179,24 +8512,20 @@ UBERON:0001015 a owl:Class ;
     rdfs:subClassOf UBERON:0011216,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000383 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004708 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0034929 ] .
+            owl:someValuesFrom UBERON:0000383 ] .
 
 UBERON:0001016 a owl:Class ;
     rdfs:label "nervous system" ;
     NIFRID:synonym "nerve net",
+        "nervous system",
         "neurological system",
         "systema nervosum" ;
     rdfs:subClassOf UBERON:0000467 .
 
 UBERON:0001017 a owl:Class ;
     rdfs:label "central nervous system" ;
-    NIFRID:synonym "cerebrospinal axis",
+    NIFRID:synonym "central nervous system",
+        "cerebrospinal axis",
         "CNS",
         "neuraxis",
         "systema nervosum centrale" ;
@@ -7208,7 +8537,8 @@ UBERON:0001017 a owl:Class ;
 
 UBERON:0001018 a owl:Class ;
     rdfs:label "axon tract" ;
-    NIFRID:synonym "axonal tract",
+    NIFRID:synonym "axon tract",
+        "axonal tract",
         "nerve tract",
         "neuraxis tract",
         "tract",
@@ -7229,24 +8559,25 @@ UBERON:0001019 a owl:Class ;
         "neural fasciculus" ;
     rdfs:subClassOf UBERON:0000122 .
 
+UBERON:0001020 a owl:Class ;
+    rdfs:label "nervous system commissure" ;
+    NIFRID:synonym "commissure",
+        "commissure of neuraxis",
+        "nervous system commissure",
+        "neuraxis commissure",
+        "white matter commissure" ;
+    rdfs:subClassOf UBERON:0001018 .
+
 UBERON:0001021 a owl:Class ;
     rdfs:label "nerve" ;
-    NIFRID:synonym "nerves",
+    NIFRID:synonym "nerve",
+        "nerves",
         "neural subtree",
         "peripheral nerve" ;
     rdfs:subClassOf UBERON:0000122,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000010 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005984 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0016630 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0034929 ] .
+            owl:someValuesFrom UBERON:0000010 ] .
 
 UBERON:0001032 a owl:Class ;
     rdfs:label "sensory system" ;
@@ -7256,6 +8587,7 @@ UBERON:0001032 a owl:Class ;
         "sense organs set",
         "sensory organ system",
         "sensory subsystem",
+        "sensory system",
         "sensory systems",
         "set of sense organs" ;
     rdfs:subClassOf UBERON:0015203,
@@ -7266,18 +8598,21 @@ UBERON:0001032 a owl:Class ;
 UBERON:0001033 a owl:Class ;
     rdfs:label "gustatory system" ;
     NIFRID:synonym "gustatory organ system",
+        "gustatory system",
         "taste system" ;
     rdfs:subClassOf UBERON:0000467 .
 
 UBERON:0001041 a owl:Class ;
     rdfs:label "foregut" ;
-    NIFRID:synonym "praeenteron",
+    NIFRID:synonym "foregut",
+        "praeenteron",
         "proenteron" ;
     rdfs:subClassOf UBERON:0004921 .
 
 UBERON:0001042 a owl:Class ;
     rdfs:label "chordate pharynx" ;
-    NIFRID:synonym "pharynx" ;
+    NIFRID:synonym "chordate pharynx",
+        "pharynx" ;
     rdfs:subClassOf UBERON:0006562,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -7285,11 +8620,16 @@ UBERON:0001042 a owl:Class ;
 
 UBERON:0001043 a owl:Class ;
     rdfs:label "esophagus" ;
-    NIFRID:synonym "gullet",
+    NIFRID:synonym "esophagus",
+        "gullet",
         "oesophagus" ;
-    rdfs:subClassOf UBERON:0004921,
+    rdfs:subClassOf UBERON:0000062,
+        UBERON:0004921,
         UBERON:0005178,
         UBERON:0013765,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004908 ] .
@@ -7319,10 +8659,34 @@ UBERON:0001051 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001042 ] .
 
+UBERON:0001052 a owl:Class ;
+    rdfs:label "rectum" ;
+    NIFRID:synonym "intestinum rectum",
+        "rectal sac",
+        "rectum",
+        "terminal portion of intestine",
+        "terminal portion of large intestine" ;
+    rdfs:subClassOf UBERON:0004921,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000059 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006866 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012361 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0000059 ] .
+
 UBERON:0001062 a owl:Class ;
-    rdfs:label "Anatomical entity",
-        "anatomical entity" ;
-    rdfs:subClassOf BFO:0000004 .
+    rdfs:label "anatomical entity" ;
+    NIFRID:synonym "anatomical entity" ;
+    rdfs:subClassOf BFO:0000004,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003942 ] .
 
 UBERON:0001096 a owl:Class ;
     rdfs:label "wall of esophagus" ;
@@ -7336,6 +8700,7 @@ UBERON:0001096 a owl:Class ;
         "gullet wall",
         "oesophagus anatomical wall",
         "oesophagus wall",
+        "wall of esophagus",
         "wall of gullet",
         "wall of oesophagus" ;
     rdfs:subClassOf UBERON:0000328,
@@ -7343,9 +8708,18 @@ UBERON:0001096 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001043 ] .
 
+UBERON:0001100 a owl:Class ;
+    rdfs:label "pectoralis minor" ;
+    NIFRID:synonym "musculus pectoralis minor",
+        "pectoralis minor muscle",
+        "supracoracoideus",
+        "supracoracoideus muscle" ;
+    rdfs:subClassOf UBERON:0001495 .
+
 UBERON:0001103 a owl:Class ;
     rdfs:label "diaphragm" ;
-    NIFRID:synonym "diaphragm muscle",
+    NIFRID:synonym "diaphragm",
+        "diaphragm muscle",
         "diaphragm of thorax",
         "midriff",
         "phren",
@@ -7359,27 +8733,165 @@ UBERON:0001103 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001004 ] .
 
+UBERON:0001111 a owl:Class ;
+    rdfs:label "intercostal muscle" ;
+    NIFRID:synonym "intercostales",
+        "musculus intercostalis",
+        "respiratory muscle",
+        "rib muscle" ;
+    rdfs:subClassOf UBERON:0001630,
+        UBERON:0005175,
+        UBERON:8450004,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001443 ] .
+
+UBERON:0001112 a owl:Class ;
+    rdfs:label "latissimus dorsi muscle" ;
+    NIFRID:synonym "dorsal latissimus muscle",
+        "latissimi dorsi",
+        "latissimus dorsi",
+        "musculus latissimus dorsi" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0034908,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0008713 ] .
+
+UBERON:0001127 a owl:Class ;
+    rdfs:label "serratus dorsalis inferior muscle" ;
+    NIFRID:synonym "inferior serratus dorsalis",
+        "inferior serratus posterior",
+        "posterior serratus",
+        "serratus dorsalis caudalis",
+        "serratus posterior inferior" ;
+    rdfs:subClassOf UBERON:0011217 .
+
+UBERON:0001129 a owl:Class ;
+    rdfs:label "subscapularis muscle" ;
+    NIFRID:synonym "musculus subscapularis",
+        "subcoracoscapularis",
+        "subscapularis" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0010891,
+        UBERON:0034908,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003683 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0008713 ] .
+
+UBERON:0001133 a owl:Class ;
+    rdfs:label "cardiac muscle tissue" ;
+    NIFRID:synonym "cardiac muscle",
+        "cardiac muscle muscle tissue",
+        "cardiac muscle textus muscularis",
+        "cardiac muscle tissue",
+        "cardiac musculature",
+        "heart muscle muscle tissue",
+        "heart muscle textus muscularis",
+        "heart myocardium muscle tissue",
+        "heart myocardium textus muscularis",
+        "muscle of heart muscle tissue",
+        "muscle of heart textus muscularis",
+        "muscle tissue of cardiac muscle",
+        "muscle tissue of heart muscle",
+        "muscle tissue of heart myocardium",
+        "muscle tissue of muscle of heart",
+        "muscle tissue of myocardium",
+        "myocardium muscle tissue",
+        "myocardium textus muscularis",
+        "textus muscularis of cardiac muscle",
+        "textus muscularis of heart muscle",
+        "textus muscularis of heart myocardium",
+        "textus muscularis of muscle of heart",
+        "textus muscularis of myocardium" ;
+    rdfs:subClassOf UBERON:8600006,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007100 ] .
+
+UBERON:0001134 a owl:Class ;
+    rdfs:label "skeletal muscle tissue" ;
+    NIFRID:synonym "skeletal muscle",
+        "skeletal muscle system",
+        "skeletal muscle tissue",
+        "somatic muscle" ;
+    rdfs:subClassOf UBERON:0002036,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0014892 ] .
+
 UBERON:0001135 a owl:Class ;
     rdfs:label "smooth muscle tissue" ;
     NIFRID:synonym "involuntary muscle",
         "non-striated muscle",
         "smooth muscle",
+        "smooth muscle tissue",
         "textus muscularis levis; textus muscularis nonstriatus",
         "textus muscularis nonstriatus",
         "visceral muscle",
         "visceral muscle tissue" ;
     rdfs:subClassOf UBERON:0002385 .
 
+UBERON:0001136 a owl:Class ;
+    rdfs:label "mesothelium" ;
+    NIFRID:synonym "mesothelium" ;
+    rdfs:subClassOf UBERON:0000487,
+        UBERON:0012275,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000042 ] .
+
 UBERON:0001137 a owl:Class ;
     rdfs:label "dorsum" ;
     NIFRID:synonym "back",
         "back of body proper",
-        "dorsal part of organism" ;
+        "dorsal part of organism",
+        "dorsum" ;
     rdfs:subClassOf UBERON:0000475 .
+
+UBERON:0001148 a owl:Class ;
+    rdfs:label "median nerve" ;
+    NIFRID:synonym "nervus medianus" ;
+    rdfs:subClassOf UBERON:0003433,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001814 ] .
+
+UBERON:0001153 a owl:Class ;
+    rdfs:label "caecum" ;
+    NIFRID:synonym "blind intestine",
+        "blindgut",
+        "caeca",
+        "caecum",
+        "ceca",
+        "cecum",
+        "intestinum caecum",
+        "intestinum crassum caecum",
+        "intestinum crassum cecum" ;
+    rdfs:subClassOf UBERON:0009854,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000059 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001155 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0000059 ] .
 
 UBERON:0001155 a owl:Class ;
     rdfs:label "colon" ;
-    NIFRID:synonym "hindgut",
+    NIFRID:synonym "colon",
+        "hindgut",
         "large bowel",
         "posterior intestine" ;
     rdfs:subClassOf UBERON:0004921,
@@ -7387,16 +8899,58 @@ UBERON:0001155 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000059 ],
         [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0012652 ],
-        [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000059 ] .
+
+UBERON:0001156 a owl:Class ;
+    rdfs:label "ascending colon" ;
+    NIFRID:synonym "colon ascendens",
+        "spiral colon" ;
+    rdfs:subClassOf UBERON:0000168 .
+
+UBERON:0001157 a owl:Class ;
+    rdfs:label "transverse colon" ;
+    NIFRID:synonym "colon transversum" ;
+    rdfs:subClassOf UBERON:0000168 .
 
 UBERON:0001158 a owl:Class ;
     rdfs:label "descending colon" ;
     NIFRID:synonym "colon descendens" ;
     rdfs:subClassOf UBERON:0000168 .
+
+UBERON:0001159 a owl:Class ;
+    rdfs:label "sigmoid colon" ;
+    NIFRID:synonym "colon sigmoideum",
+        "pelvic colon",
+        "sigmoid colon",
+        "sigmoid flexure" ;
+    rdfs:subClassOf UBERON:0000168 .
+
+UBERON:0001160 a owl:Class ;
+    rdfs:label "fundus of stomach" ;
+    NIFRID:synonym "fundus gastricus",
+        "fundus gastricus (ventricularis)",
+        "fundus gastricus ventricularis",
+        "fundus ventricularis",
+        "fundus ventriculi",
+        "gastric fundus",
+        "stomach fundus" ;
+    rdfs:subClassOf UBERON:0009870,
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0000945 ] .
+
+UBERON:0001161 a owl:Class ;
+    rdfs:label "body of stomach" ;
+    NIFRID:synonym "body of stomach",
+        "corpus gastricum",
+        "corpus gastricum (ventriculare)",
+        "corpus ventriculare",
+        "corpus ventriculi",
+        "gastric body",
+        "gastric corpus",
+        "stomach body" ;
+    rdfs:subClassOf UBERON:0009870 .
 
 UBERON:0001165 a owl:Class ;
     rdfs:label "pyloric antrum" ;
@@ -7406,6 +8960,7 @@ UBERON:0001165 a owl:Class ;
         "antrum pylori",
         "antrum pyloricum",
         "gastric antrum",
+        "pyloric antrum",
         "stomach antrum",
         "stomach pyloric antrum" ;
     rdfs:subClassOf UBERON:0009870,
@@ -7422,10 +8977,10 @@ UBERON:0001166 a owl:Class ;
         "pars pylorica gastricae",
         "pyloric part of stomach",
         "pyloric region",
+        "pylorus",
         "stomach pyloric region",
         "valvula pylori" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0009870,
+    rdfs:subClassOf UBERON:0009870,
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000945 ] .
@@ -7439,6 +8994,7 @@ UBERON:0001167 a owl:Class ;
         "stomach wall",
         "ventriculus anatomical wall",
         "ventriculus wall",
+        "wall of stomach",
         "wall of ventriculus" ;
     rdfs:subClassOf UBERON:0000328,
         [ a owl:Restriction ;
@@ -7448,12 +9004,29 @@ UBERON:0001167 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000945 ] .
 
+UBERON:0001168 a owl:Class ;
+    rdfs:label "wall of small intestine" ;
+    NIFRID:synonym "anatomical wall of small bowel",
+        "anatomical wall of small intestine",
+        "small bowel anatomical wall",
+        "small bowel wall",
+        "small intestinal wall",
+        "small intestine anatomical wall",
+        "small intestine wall",
+        "wall of small bowel",
+        "wall of small intestine" ;
+    rdfs:subClassOf UBERON:0001262,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002108 ] .
+
 UBERON:0001169 a owl:Class ;
     rdfs:label "wall of large intestine" ;
     NIFRID:synonym "anatomical wall of large intestine",
         "large intestinal wall",
         "large intestine anatomical wall",
-        "large intestine wall" ;
+        "large intestine wall",
+        "wall of large intestine" ;
     rdfs:subClassOf UBERON:0001262,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -7461,8 +9034,8 @@ UBERON:0001169 a owl:Class ;
 
 UBERON:0001171 a owl:Class ;
     rdfs:label "portal lobule" ;
-    rdfs:subClassOf UBERON:0004119,
-        UBERON:0009911,
+    NIFRID:synonym "portal lobule" ;
+    rdfs:subClassOf UBERON:0009911,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001280 ],
@@ -7472,13 +9045,27 @@ UBERON:0001171 a owl:Class ;
 
 UBERON:0001172 a owl:Class ;
     rdfs:label "hepatic acinus" ;
-    NIFRID:synonym "liver acinus",
+    NIFRID:synonym "hepatic acinus",
+        "liver acinus",
         "portal acinus" ;
-    rdfs:subClassOf UBERON:0004119,
+    rdfs:subClassOf UBERON:0009842,
         UBERON:0011858,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001280 ] .
+
+UBERON:0001173 a owl:Class ;
+    rdfs:label "biliary tree" ;
+    NIFRID:synonym "biliary tract",
+        "biliary tree" ;
+    rdfs:subClassOf UBERON:0004119,
+        UBERON:0013765,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002294 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002423 ] .
 
 UBERON:0001182 a owl:Class ;
     rdfs:label "superior mesenteric artery" ;
@@ -7486,27 +9073,43 @@ UBERON:0001182 a owl:Class ;
         "superior mesenteric arterial tree" ;
     rdfs:subClassOf UBERON:0005616 .
 
+UBERON:0001184 a owl:Class ;
+    rdfs:label "renal artery" ;
+    NIFRID:synonym "arteria renalis",
+        "renal arterial tree",
+        "renal arteries" ;
+    rdfs:subClassOf UBERON:0012254 .
+
 UBERON:0001190 a owl:Class ;
     rdfs:label "ovarian artery" ;
     NIFRID:synonym "arteria ovarica",
-        "ovarian arterial tree" ;
-    rdfs:subClassOf UBERON:0001637 .
+        "ovarian arterial tree",
+        "ovarian artery" ;
+    rdfs:subClassOf UBERON:0001637,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
 
 UBERON:0001193 a owl:Class ;
     rdfs:label "hepatic artery" ;
     NIFRID:synonym "arteria hepatica",
-        "arteria hepatica propria" ;
+        "arteria hepatica propria",
+        "hepatic artery" ;
     rdfs:subClassOf UBERON:0001637,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001279 ] .
+            owl:someValuesFrom RO:0002577 ] .
 
 UBERON:0001194 a owl:Class ;
     rdfs:label "splenic artery" ;
     NIFRID:synonym "arteria lienalis",
         "arteria splenica",
-        "lienal artery" ;
-    rdfs:subClassOf UBERON:0004573 .
+        "lienal artery",
+        "splenic artery" ;
+    rdfs:subClassOf UBERON:0001637,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
 
 UBERON:0001195 a owl:Class ;
     rdfs:label "inferior pancreaticoduodenal artery" ;
@@ -7525,6 +9128,7 @@ UBERON:0001199 a owl:Class ;
         "Magenschleimhaut",
         "mucosa of organ of stomach",
         "mucosa of organ of ventriculus",
+        "mucosa of stomach",
         "mucosa of ventriculus",
         "mucous membrane of stomach",
         "mucous membrane of ventriculus",
@@ -7556,6 +9160,7 @@ UBERON:0001200 a owl:Class ;
     rdfs:label "submucosa of stomach" ;
     NIFRID:synonym "gastric submucosa",
         "stomach submucosa",
+        "submucosa of stomach",
         "submucosa of ventriculus",
         "submucous layer of stomach",
         "tela submucosa (gaster)",
@@ -7585,6 +9190,7 @@ UBERON:0001201 a owl:Class ;
         "serosa of anatomical wall of stomach",
         "serosa of anatomical wall of ventriculus",
         "serosa of gastric wall",
+        "serosa of stomach",
         "serosa of stomach anatomical wall",
         "serosa of stomach wall",
         "serosa of ventriculus anatomical wall",
@@ -7643,6 +9249,38 @@ UBERON:0001203 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001199 ] .
 
+UBERON:0001204 a owl:Class ;
+    rdfs:label "mucosa of small intestine" ;
+    NIFRID:synonym "mucosa of organ of small bowel",
+        "mucosa of organ of small intestine",
+        "mucosa of small bowel",
+        "mucosa of small intestine",
+        "mucous membrane of small bowel",
+        "mucous membrane of small intestine",
+        "organ mucosa of small bowel",
+        "organ mucosa of small intestine",
+        "small bowel mucosa",
+        "small bowel mucosa of organ",
+        "small bowel mucous membrane",
+        "small bowel organ mucosa",
+        "small intestinal mucosa",
+        "small intestine mucosa",
+        "small intestine mucosa of organ",
+        "small intestine mucous membrane",
+        "small intestine organ mucosa",
+        "tunica mucosa (intestinum tenue)",
+        "tunica mucosa intestini tenuis" ;
+    rdfs:subClassOf UBERON:0001242,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001168 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001242 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002108 ] .
+
 UBERON:0001207 a owl:Class ;
     rdfs:label "mucosa of large intestine" ;
     NIFRID:synonym "large intestinal mucosa",
@@ -7650,6 +9288,7 @@ UBERON:0001207 a owl:Class ;
         "large intestine mucosa of organ",
         "large intestine mucous membrane",
         "large intestine organ mucosa",
+        "mucosa of large intestine",
         "mucosa of organ of large intestine",
         "mucous membrane of large intestine",
         "organ mucosa of large intestine",
@@ -7670,6 +9309,7 @@ UBERON:0001209 a owl:Class ;
     NIFRID:synonym "large intestinal serosa",
         "large intestine serosa",
         "large intestine serous membrane",
+        "serosa of large intestine",
         "serous coat of large intestine",
         "serous membrane of large intestine",
         "tunica serosa intestini crassi",
@@ -7700,22 +9340,124 @@ UBERON:0001211 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001242 ] .
 
-UBERON:0001213 a owl:Class ;
-    rdfs:label "intestinal villus" ;
-    NIFRID:synonym "enteric villi",
-        "enteric villous",
-        "enteric villus",
-        "intestinal villi",
-        "intestinal villus layer",
-        "small intestine villus",
-        "villi intestinales",
-        "villus",
-        "villus intestinalis (intestinum tenue)" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0004923,
+UBERON:0001220 a owl:Class ;
+    rdfs:label "quadratus lumborum" ;
+    NIFRID:synonym "muscle of posterior abdominal wall" ;
+    rdfs:subClassOf UBERON:0002378,
+        UBERON:0004518 .
+
+UBERON:0001221 a owl:Class ;
+    rdfs:label "transversus abdominis muscle" ;
+    NIFRID:synonym "musculus transversus abdominis",
+        "transversalis",
+        "transversalis muscle",
+        "transverse abdominal",
+        "transverse abdominal muscle",
+        "transverse abdominis",
+        "transverse abdominus",
+        "transversis abdominus",
+        "transversus",
+        "transversus abdominis",
+        "transversus abdominus",
+        "transversus abdominus muscle" ;
+    rdfs:subClassOf UBERON:0002461,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001277 ] .
+            owl:someValuesFrom UBERON:0006635 ] .
+
+UBERON:0001224 a owl:Class ;
+    rdfs:label "renal pelvis" ;
+    NIFRID:synonym "kidney pelvis",
+        "p. renallis",
+        "pelvis of ureter",
+        "pyelum" ;
+    rdfs:subClassOf UBERON:0000064,
+        UBERON:0004111,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002113 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0036295 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0000056 ] .
+
+UBERON:0001225 a owl:Class ;
+    rdfs:label "cortex of kidney" ;
+    NIFRID:synonym "cortex renalis",
+        "kidney cortex",
+        "renal cortex" ;
+    rdfs:subClassOf UBERON:0001851,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002113 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0008987 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002113 ] .
+
+UBERON:0001229 a owl:Class ;
+    rdfs:label "renal corpuscle" ;
+    NIFRID:synonym "corpusculum renale",
+        "corpusculum renis",
+        "cortical renal corpuscle",
+        "kidney corpuscle",
+        "Malphigian corpuscle",
+        "Malpighian corpuscle" ;
+    rdfs:subClassOf UBERON:0000063,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001225 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001285 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007684 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001225 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001285 ] .
+
+UBERON:0001230 a owl:Class ;
+    rdfs:label "glomerular capsule" ;
+    NIFRID:synonym "Bowman's capsule",
+        "Bowmans capsule",
+        "capsula glomerularis",
+        "capsula glomeruli",
+        "Malphigian capsule",
+        "Malpighian capsule",
+        "Mueller capsule",
+        "Muellerian capsule",
+        "pronephric glomerular capsule",
+        "renal glomerular capsule" ;
+    rdfs:subClassOf UBERON:0000064,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001229 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001229 ] .
+
+UBERON:0001231 a owl:Class ;
+    rdfs:label "nephron tubule" ;
+    NIFRID:synonym "kidney tubule",
+        "renal tubule",
+        "tubulus renalis",
+        "uriniferous tubule" ;
+    rdfs:subClassOf UBERON:0004211,
+        UBERON:0009773,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001285 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001285 ] .
 
 UBERON:0001235 a owl:Class ;
     rdfs:label "adrenal cortex" ;
@@ -7728,7 +9470,6 @@ UBERON:0001235 a owl:Class ;
         "suprarenal cortex" ;
     rdfs:subClassOf UBERON:0001851,
         UBERON:0004120,
-        UBERON:0010313,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002369 ],
@@ -7748,7 +9489,6 @@ UBERON:0001236 a owl:Class ;
         "medulla of suprarenal gland",
         "suprarenal medulla" ;
     rdfs:subClassOf UBERON:0000958,
-        UBERON:0004120,
         UBERON:0010313,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -7763,6 +9503,7 @@ UBERON:0001242 a owl:Class ;
         "bowel mucosa of organ",
         "bowel mucous membrane",
         "bowel organ mucosa",
+        "intestinal mucosa",
         "intestine mucosa",
         "intestine mucosa of organ",
         "intestine mucous membrane",
@@ -7807,6 +9548,7 @@ UBERON:0001243 a owl:Class ;
         "serosa of bowel anatomical wall",
         "serosa of bowel wall",
         "serosa of intestinal wall",
+        "serosa of intestine",
         "serosa of intestine anatomical wall",
         "serosa of intestine wall",
         "serosa of wall of bowel",
@@ -7840,8 +9582,7 @@ UBERON:0001250 a owl:Class ;
         "red pulp",
         "spleen red pulp",
         "splenic red pulp" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:1000023,
+    rdfs:subClassOf UBERON:1000023,
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0002106 ] .
@@ -7869,7 +9610,6 @@ UBERON:0001258 a owl:Class ;
         "urinary bladder neck",
         "vesical neck" ;
     rdfs:subClassOf UBERON:0001560,
-        UBERON:0004120,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001255 ],
@@ -7886,7 +9626,8 @@ UBERON:0001262 a owl:Class ;
         "intestinal wall",
         "intestine anatomical wall",
         "intestine wall",
-        "wall of bowel" ;
+        "wall of bowel",
+        "wall of intestine" ;
     rdfs:subClassOf UBERON:0000328,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -7897,9 +9638,9 @@ UBERON:0001263 a owl:Class ;
     NIFRID:synonym "acinus pancreaticus",
         "pancreas acinus",
         "pancreatic acinar",
-        "pancreatic acini" ;
-    rdfs:subClassOf UBERON:0004119,
-        UBERON:0013232,
+        "pancreatic acini",
+        "pancreatic acinus" ;
+    rdfs:subClassOf UBERON:0013232,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000017 ],
@@ -7912,7 +9653,99 @@ UBERON:0001263 a owl:Class ;
 
 UBERON:0001264 a owl:Class ;
     rdfs:label "pancreas" ;
+    NIFRID:synonym "pancreas" ;
     rdfs:subClassOf UBERON:0002075 .
+
+UBERON:0001267 a owl:Class ;
+    rdfs:label "femoral nerve" ;
+    NIFRID:synonym "anterior crural nerve",
+        "nervus femoralis" ;
+    rdfs:subClassOf UBERON:0003431,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000978 ] .
+
+UBERON:0001271 a owl:Class ;
+    rdfs:label "pelvic girdle region" ;
+    NIFRID:synonym "girdle - pelvic",
+        "pelvic girdle" ;
+    rdfs:subClassOf UBERON:0007823,
+        UBERON:0015212,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002355 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010709 ] .
+
+UBERON:0001272 a owl:Class ;
+    rdfs:label "innominate bone" ;
+    NIFRID:synonym "basipterygium",
+        "bone of pelvic girdle",
+        "coxal bone",
+        "hip bone",
+        "innominate",
+        "innominate bone",
+        "os coxa",
+        "os coxae",
+        "os innominatum",
+        "pelvic bone" ;
+    rdfs:subClassOf UBERON:0007830,
+        UBERON:0010428,
+        UBERON:0015212,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001464 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007832 ] .
+
+UBERON:0001273 a owl:Class ;
+    rdfs:label "ilium" ;
+    NIFRID:synonym "iliac bone",
+        "ilium bone",
+        "illium",
+        "os iliacum",
+        "os ilii",
+        "os ilium" ;
+    rdfs:subClassOf UBERON:0002513,
+        UBERON:0007830,
+        UBERON:0015054,
+        UBERON:0015212,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001272 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007832 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0007830 ] .
+
+UBERON:0001276 a owl:Class ;
+    rdfs:label "epithelium of stomach" ;
+    NIFRID:synonym "epithelial tissue of stomach",
+        "epithelial tissue of ventriculus",
+        "epithelium of stomach",
+        "epithelium of ventriculus",
+        "gastric epithelium",
+        "stomach epithelial tissue",
+        "stomach epithelium",
+        "ventriculus epithelial tissue",
+        "ventriculus epithelium" ;
+    rdfs:subClassOf UBERON:0000485,
+        UBERON:0003350,
+        UBERON:0004808,
+        UBERON:0015833,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000945 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001199 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001199 ] .
 
 UBERON:0001277 a owl:Class ;
     rdfs:label "intestinal epithelium" ;
@@ -7922,6 +9755,7 @@ UBERON:0001277 a owl:Class ;
         "epithelial tissue of intestine",
         "epithelium of bowel",
         "epithelium of intestine",
+        "intestinal epithelium",
         "intestine epithelial tissue",
         "intestine epithelium",
         "villous epithelium" ;
@@ -7939,12 +9773,26 @@ UBERON:0001277 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000160 ] .
 
+UBERON:0001278 a owl:Class ;
+    rdfs:label "epithelium of large intestine" ;
+    NIFRID:synonym "epithelial tissue of large intestine",
+        "epithelium of large intestine",
+        "large intestinal epithelium",
+        "large intestine epithelial tissue",
+        "large intestine epithelium" ;
+    rdfs:subClassOf UBERON:0001277,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000059 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001207 ] .
+
 UBERON:0001279 a owl:Class ;
     rdfs:label "portal triad" ;
-    NIFRID:synonym "trias hepatica" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0004119,
-        UBERON:0034921,
+    NIFRID:synonym "portal triad",
+        "trias hepatica" ;
+    rdfs:subClassOf UBERON:0034921,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001172 ],
@@ -7956,6 +9804,7 @@ UBERON:0001280 a owl:Class ;
     rdfs:label "liver parenchyma" ;
     NIFRID:synonym "hepatic parenchyma",
         "hepatic parenchyme",
+        "liver parenchyma",
         "liver parenchyme",
         "parenchyma of liver" ;
     rdfs:subClassOf UBERON:0000353,
@@ -7966,6 +9815,47 @@ UBERON:0001280 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0002107 ] .
+
+UBERON:0001281 a owl:Class ;
+    rdfs:label "hepatic sinusoid" ;
+    NIFRID:synonym "hepatic sinusoids",
+        "liver hepatic sinusoids",
+        "liver sinusoid",
+        "liver sinusoidal blood vessel",
+        "sinusoid of liver",
+        "sinusoidal blood vessel of liver",
+        "vas capillare sinusoideum",
+        "vas sinusoideum" ;
+    rdfs:subClassOf UBERON:0003909,
+        UBERON:0015796,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002107 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004647 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006877 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0004647 ] .
+
+UBERON:0001285 a owl:Class ;
+    rdfs:label "nephron" ;
+    NIFRID:synonym "mature nephron",
+        "nephroneum",
+        "tubulus renalis" ;
+    rdfs:subClassOf UBERON:0000064,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007684 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002113 ] .
 
 UBERON:0001295 a owl:Class ;
     rdfs:label "endometrium" ;
@@ -7991,7 +9881,8 @@ UBERON:0001296 a owl:Class ;
         "tunica muscularis (myometrium)",
         "uterine myometrium",
         "uterine smooth muscle" ;
-    rdfs:subClassOf UBERON:0005156,
+    rdfs:subClassOf UBERON:0004923,
+        UBERON:0005156,
         UBERON:0034933,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -8000,14 +9891,11 @@ UBERON:0001296 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000995 ] .
 
-UBERON:0001300 a owl:Class ;
-    rdfs:label "scrotum" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0005156,
-        UBERON:0034929,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004053 ] .
+UBERON:0001298 a owl:Class ;
+    rdfs:label "psoas major muscle" ;
+    NIFRID:synonym "m. psoas major",
+        "psoas major" ;
+    rdfs:subClassOf UBERON:0008450 .
 
 UBERON:0001305 a owl:Class ;
     rdfs:label "ovarian follicle" ;
@@ -8017,9 +9905,82 @@ UBERON:0001305 a owl:Class ;
         "folliculi ovarici primarii",
         "folliculi ovarici vesiculosi",
         "ovary follicle" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0004120,
+    rdfs:subClassOf UBERON:0004120,
         UBERON:8450001 .
+
+UBERON:0001322 a owl:Class ;
+    rdfs:label "sciatic nerve" ;
+    NIFRID:synonym "ischiadic nerve",
+        "ischiatic nerve",
+        "nervus ischiadicus",
+        "nervus sciaticus" ;
+    rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001815 ] .
+
+UBERON:0001323 a owl:Class ;
+    rdfs:label "tibial nerve" ;
+    NIFRID:synonym "medial popliteal nerve",
+        "n. tibialis" ;
+    rdfs:subClassOf UBERON:0003431,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000978 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001322 ] .
+
+UBERON:0001324 a owl:Class ;
+    rdfs:label "common fibular nerve" ;
+    NIFRID:synonym "common peroneal nerve",
+        "extrernal peroneal nerve",
+        "lateral popliteal nerve",
+        "n. fibularis communis",
+        "n. peroneus communis",
+        "nervus fibularis communis",
+        "nervus peroneus communis" ;
+    rdfs:subClassOf UBERON:0003431,
+        UBERON:0035652,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000978 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001322 ] .
+
+UBERON:0001325 a owl:Class ;
+    rdfs:label "muscle of pelvis" ;
+    NIFRID:synonym "muscle organ of pelvis",
+        "pelvic muscle",
+        "pelvis muscle",
+        "pelvis muscle organ" ;
+    rdfs:subClassOf UBERON:0003833,
+        UBERON:0005179,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002355 ] .
+
+UBERON:0001327 a owl:Class ;
+    rdfs:label "coccygeus muscle" ;
+    NIFRID:synonym "coccygeus",
+        "ischiococcygeus",
+        "musculus coccygeus",
+        "musculus ischiococcygeus" ;
+    rdfs:subClassOf UBERON:0001325,
+        UBERON:0015212 .
+
+UBERON:0001331 a owl:Class ;
+    rdfs:label "skin of penis" ;
+    NIFRID:synonym "penile skin",
+        "penis skin",
+        "penis zone of skin",
+        "zone of skin of penis" ;
+    rdfs:subClassOf UBERON:0000014,
+        UBERON:0005156,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000989 ] .
 
 UBERON:0001333 a owl:Class ;
     rdfs:label "male urethra" ;
@@ -8035,7 +9996,6 @@ UBERON:0001338 a owl:Class ;
         "urethra gland (male or female)",
         "urethral mucuous gland" ;
     rdfs:subClassOf UBERON:0000414,
-        UBERON:0004120,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000057 ],
@@ -8045,6 +10005,17 @@ UBERON:0001338 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000057 ] .
+
+UBERON:0001339 a owl:Class ;
+    rdfs:label "ischiocavernosus muscle" ;
+    NIFRID:synonym "erector penis",
+        "ischiocavernosi",
+        "ischiocavernosus",
+        "ischiocavernous muscle",
+        "ishiocavernosus",
+        "ishiocavernosus muscle",
+        "musculus ishiocavernosus" ;
+    rdfs:subClassOf UBERON:0002379 .
 
 UBERON:0001344 a owl:Class ;
     rdfs:label "epithelium of vagina" ;
@@ -8071,9 +10042,314 @@ UBERON:0001348 a owl:Class ;
         "textus adiposus fuscus" ;
     rdfs:subClassOf UBERON:0001013 .
 
+UBERON:0001353 a owl:Class ;
+    rdfs:label "anal region" ;
+    NIFRID:synonym "anal region",
+        "posterior",
+        "posterior end of organism" ;
+    rdfs:subClassOf UBERON:0000475 .
+
+UBERON:0001366 a owl:Class ;
+    rdfs:label "parietal peritoneum" ;
+    NIFRID:synonym "parietal peritoneum",
+        "parietal serous membrane of peritoneum",
+        "peritoneal cavity lining" ;
+    rdfs:subClassOf UBERON:0022351,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002358 ] .
+
+UBERON:0001367 a owl:Class ;
+    rdfs:label "external anal sphincter" ;
+    NIFRID:synonym "external sphincter ani",
+        "musculus sphincter ani externus",
+        "sphincter ani externus" ;
+    rdfs:subClassOf UBERON:0003898,
+        UBERON:0004519,
+        UBERON:0004832,
+        UBERON:0004916,
+        UBERON:0007522,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006867 ] .
+
+UBERON:0001368 a owl:Class ;
+    rdfs:label "obturator externus" ;
+    NIFRID:synonym "external obturator",
+        "external obturatus",
+        "externus obturator",
+        "M. obturator externus",
+        "musculus obturatorius externus",
+        "obturator externus",
+        "obturatorius externus",
+        "obturatus externus" ;
+    rdfs:subClassOf UBERON:0011043,
+        UBERON:0011144,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004470 ] .
+
+UBERON:0001369 a owl:Class ;
+    rdfs:label "iliacus muscle" ;
+    NIFRID:synonym "anterior muscle of pelvic girdle",
+        "iliacus",
+        "iliacus muscle",
+        "musculus iliacus" ;
+    rdfs:subClassOf UBERON:0001497 .
+
+UBERON:0001370 a owl:Class ;
+    rdfs:label "gluteus maximus" ;
+    NIFRID:synonym "glutaeus maximus muscle",
+        "gluteus maximus muscle",
+        "gluteus superficialis",
+        "glutæus maximus",
+        "m.gluteus maximus",
+        "musculus gluteus maximus" ;
+    rdfs:subClassOf UBERON:0002000,
+        UBERON:0011645,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004470 ] .
+
+UBERON:0001371 a owl:Class ;
+    rdfs:label "gluteus medius" ;
+    NIFRID:synonym "gluteus medius muscle",
+        "musculus gluteus medius" ;
+    rdfs:subClassOf UBERON:0002000,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004470 ] .
+
+UBERON:0001372 a owl:Class ;
+    rdfs:label "psoas minor muscle" ;
+    NIFRID:synonym "m. psoas minor",
+        "psoas minor" ;
+    rdfs:subClassOf UBERON:0008450 .
+
+UBERON:0001373 a owl:Class ;
+    rdfs:label "sartorius muscle" ;
+    NIFRID:synonym "ambliens",
+        "M. sartorius",
+        "musculus sartorius",
+        "sartorius" ;
+    rdfs:subClassOf UBERON:0001630,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
+
+UBERON:0001374 a owl:Class ;
+    rdfs:label "biceps femoris" ;
+    NIFRID:synonym "biceps femoris muscle",
+        "musculus biceps femoris" ;
+    rdfs:subClassOf UBERON:0002463 .
+
+UBERON:0001375 a owl:Class ;
+    rdfs:label "semitendinosus" ;
+    NIFRID:synonym "musculus semitendinosus",
+        "semitendinosus muscle" ;
+    rdfs:subClassOf UBERON:0002463 .
+
+UBERON:0001376 a owl:Class ;
+    rdfs:label "tensor fasciae latae muscle" ;
+    NIFRID:synonym "musculus tensor fasciae latae",
+        "tensor fasciae lata",
+        "tensor fasciae lata muscle",
+        "tensor fasciae latae",
+        "tensor of fascia lata" ;
+    rdfs:subClassOf UBERON:0002000 .
+
+UBERON:0001377 a owl:Class ;
+    rdfs:label "quadriceps femoris" ;
+    NIFRID:synonym "musculus quadriceps femoris",
+        "quadricep muscle",
+        "quadriceps",
+        "quadriceps femoris muscle",
+        "quadriceps muscle",
+        "quadriceps muscle of the thigh",
+        "quadriceps muscle of thigh" ;
+    rdfs:subClassOf UBERON:0003663,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002103 ] .
+
+UBERON:0001378 a owl:Class ;
+    rdfs:label "rectus femoris" ;
+    NIFRID:synonym "musculus rectos femoris" ;
+    rdfs:subClassOf UBERON:0001377,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001377 ] .
+
+UBERON:0001379 a owl:Class ;
+    rdfs:label "vastus lateralis" ;
+    NIFRID:synonym "lateralis",
+        "vastus externus",
+        "vastus lateralis muscle" ;
+    rdfs:subClassOf UBERON:0001377,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001377 ] .
+
+UBERON:0001380 a owl:Class ;
+    rdfs:label "vastus medialis" ;
+    NIFRID:synonym "medialis",
+        "vastus internus",
+        "vastus medialis muscle" ;
+    rdfs:subClassOf UBERON:0001377,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001377 ] .
+
+UBERON:0001381 a owl:Class ;
+    rdfs:label "semimembranosus muscle" ;
+    NIFRID:synonym "musculus semimembranosus",
+        "semimembranosus" ;
+    rdfs:subClassOf UBERON:0002463 .
+
+UBERON:0001382 a owl:Class ;
+    rdfs:label "pectineus muscle" ;
+    NIFRID:synonym "M. pectineus",
+        "musculus pectineus",
+        "pectineus" ;
+    rdfs:subClassOf UBERON:0004252,
+        UBERON:0011144,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000376 ] .
+
+UBERON:0001383 a owl:Class ;
+    rdfs:label "muscle of leg" ;
+    NIFRID:synonym "leg muscle",
+        "leg muscle organ",
+        "leg skeletal muscle",
+        "leg skeletal muscle tissue",
+        "muscle of hindlimb zeugopod or stylopod",
+        "muscle of thigh or crus",
+        "muscle of upper or lower hindlimb segment",
+        "muscle of upper/lower leg",
+        "muscle organ of leg",
+        "skeletal muscle of leg" ;
+    rdfs:subClassOf UBERON:0003663,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000978 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004466 ] .
+
+UBERON:0001385 a owl:Class ;
+    rdfs:label "tibialis anterior" ;
+    NIFRID:synonym "anterior tibialis",
+        "ibialis anticus",
+        "musculus tibialis anterior",
+        "tibialis anterior muscle",
+        "tibialis cranialis",
+        "tibilais cranialis" ;
+    rdfs:subClassOf UBERON:0008230 .
+
+UBERON:0001386 a owl:Class ;
+    rdfs:label "extensor digitorum longus" ;
+    NIFRID:synonym "extensor digitorum longus muscle",
+        "musculus extensor digitorum longus",
+        "toe extensor",
+        "toe extensor muscle" ;
+    rdfs:subClassOf UBERON:0000311,
+        UBERON:0003663,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002103 ] .
+
+UBERON:0001387 a owl:Class ;
+    rdfs:label "fibularis longus" ;
+    NIFRID:synonym "fibularis longus",
+        "fibularis longus muscle",
+        "musculus peroneus longus",
+        "peronaei longus",
+        "peronaeus longus",
+        "peroneous longus",
+        "peroneus longus",
+        "peroneus longus muscle" ;
+    rdfs:subClassOf UBERON:0009132 .
+
+UBERON:0001388 a owl:Class ;
+    rdfs:label "gastrocnemius" ;
+    NIFRID:synonym "gastrocnemius muscle",
+        "m. gastrocnemius",
+        "m.gastrocnemius",
+        "musculus gastrocnemius" ;
+    rdfs:subClassOf UBERON:0004256,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001665 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003823 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0003661 ] .
+
+UBERON:0001389 a owl:Class ;
+    rdfs:label "soleus muscle" ;
+    NIFRID:synonym "soleus" ;
+    rdfs:subClassOf UBERON:0004256,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001665 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0003661 ] .
+
+UBERON:0001391 a owl:Class ;
+    rdfs:label "popliteus muscle" ;
+    NIFRID:synonym "m.popliteus",
+        "musculus popliteus",
+        "poplitea",
+        "popliteal",
+        "popliteal muscle",
+        "popliteus" ;
+    rdfs:subClassOf UBERON:0001383 .
+
+UBERON:0001392 a owl:Class ;
+    rdfs:label "flexor hallucis longus" ;
+    NIFRID:synonym "flexor hallucis longus muscle" ;
+    rdfs:subClassOf UBERON:0000366,
+        UBERON:0001383,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000978 ] .
+
+UBERON:0001419 a owl:Class ;
+    rdfs:label "skin of limb" ;
+    NIFRID:synonym "limb skin",
+        "limb zone of skin",
+        "zone of skin of limb" ;
+    rdfs:subClassOf UBERON:0000014,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002101 ] .
+
+UBERON:0001421 a owl:Class ;
+    rdfs:label "pectoral girdle region" ;
+    NIFRID:synonym "cingulum membri superioris",
+        "girdle - pectoral",
+        "pectoral girdle",
+        "pectoral girdle region",
+        "pectoral region",
+        "shoulder girdle",
+        "upper limb girdle" ;
+    rdfs:subClassOf UBERON:0007823,
+        UBERON:0015212,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010708 ] .
+
 UBERON:0001434 a owl:Class ;
     rdfs:label "skeletal system" ;
     NIFRID:synonym "set of all bones and joints",
+        "skeletal system",
         "skeleton system",
         "Skelettsystem" ;
     rdfs:subClassOf UBERON:0011216,
@@ -8081,11 +10357,25 @@ UBERON:0001434 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002204 ] .
 
+UBERON:0001443 a owl:Class ;
+    rdfs:label "chest" ;
+    NIFRID:synonym "anterolateral part of thorax",
+        "front of thorax",
+        "pectus",
+        "thoracic body wall",
+        "thorax",
+        "ventral part of thoracic region" ;
+    rdfs:subClassOf UBERON:0009569,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000915 ] .
+
 UBERON:0001444 a owl:Class ;
     rdfs:label "subdivision of head" ;
     NIFRID:synonym "head region",
         "head subdivision",
-        "region of head" ;
+        "region of head",
+        "subdivision of head" ;
     rdfs:subClassOf UBERON:0000475,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -8093,16 +10383,116 @@ UBERON:0001444 a owl:Class ;
 
 UBERON:0001456 a owl:Class ;
     rdfs:label "face" ;
-    NIFRID:synonym "facia/facies",
+    NIFRID:synonym "face",
+        "facia/facies",
         "visage" ;
     rdfs:subClassOf UBERON:0001444,
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000033 ] .
 
+UBERON:0001460 a owl:Class ;
+    rdfs:label "arm" ;
+    NIFRID:synonym "brachium",
+        "upper extremity" ;
+    rdfs:subClassOf UBERON:0006058,
+        UBERON:0008785,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
+
+UBERON:0001461 a owl:Class ;
+    rdfs:label "elbow" ;
+    NIFRID:synonym "articulatio cubiti",
+        "cubital region",
+        "elbow limb segment",
+        "elbow region" ;
+    rdfs:subClassOf UBERON:0002529,
+        UBERON:0008785,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ] .
+
+UBERON:0001463 a owl:Class ;
+    rdfs:label "manual digit 1" ;
+    NIFRID:synonym "alula",
+        "digit 1 of fore-paw",
+        "digit 1 of manus",
+        "digitus 1",
+        "digitus I",
+        "digitus primus",
+        "digitus primus [I]",
+        "finger 1",
+        "first digit of hand",
+        "first finger",
+        "fore digit I",
+        "fore limb digit 1",
+        "forelimb dewclaw",
+        "hand digit 1",
+        "manual digit 1",
+        "manual digit I",
+        "pollex",
+        "thumb" ;
+    rdfs:subClassOf UBERON:0006048,
+        UBERON:0019231,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012141 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:5001463 ] .
+
+UBERON:0001464 a owl:Class ;
+    rdfs:label "hip" ;
+    NIFRID:synonym "coxa",
+        "hip region",
+        "regio coxae" ;
+    rdfs:subClassOf UBERON:0000475,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010709 ] .
+
+UBERON:0001465 a owl:Class ;
+    rdfs:label "knee" ;
+    NIFRID:synonym "knee region" ;
+    rdfs:subClassOf UBERON:0008784,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000978 ] .
+
+UBERON:0001467 a owl:Class ;
+    rdfs:label "shoulder" ;
+    NIFRID:synonym "articulatio humeri",
+        "shoulder region" ;
+    rdfs:subClassOf UBERON:0000475,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010708 ] .
+
+UBERON:0001470 a owl:Class ;
+    rdfs:label "glenohumeral joint" ;
+    NIFRID:synonym "articulatio humeri",
+        "humeral joint",
+        "humeroscapular joint",
+        "joint of shoulder",
+        "shoulder joint" ;
+    rdfs:subClassOf UBERON:0011108,
+        UBERON:0011139,
+        UBERON:0016884,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001467 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004753 ] .
+
 UBERON:0001474 a owl:Class ;
     rdfs:label "bone element" ;
     NIFRID:synonym "bone",
+        "bone element",
         "bone organ",
         "bones" ;
     rdfs:subClassOf UBERON:0004765,
@@ -8110,10 +10500,297 @@ UBERON:0001474 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001434 ] .
 
+UBERON:0001476 a owl:Class ;
+    rdfs:label "deltoid" ;
+    NIFRID:synonym "common shoulder muscle",
+        "deltoid muscle",
+        "deltoideus",
+        "deltoideus muscle",
+        "m. deltoideus",
+        "musculus deltoideus" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0034908,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0008713 ] .
+
+UBERON:0001477 a owl:Class ;
+    rdfs:label "infraspinatus muscle" ;
+    NIFRID:synonym "infrascapularis",
+        "infraspinatus",
+        "musculus infraspinatus" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0010891,
+        UBERON:0034908,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003683 ] .
+
+UBERON:0001478 a owl:Class ;
+    rdfs:label "teres major muscle" ;
+    NIFRID:synonym "musculus teres major",
+        "teres major" ;
+    rdfs:subClassOf UBERON:0010467 .
+
+UBERON:0001482 a owl:Class ;
+    rdfs:label "muscle of shoulder" ;
+    NIFRID:synonym "muscle organ of shoulder",
+        "shoulder muscle",
+        "shoulder muscle organ" ;
+    rdfs:subClassOf UBERON:0014892,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004476 ] .
+
+UBERON:0001483 a owl:Class ;
+    rdfs:label "skin of shoulder" ;
+    NIFRID:synonym "shoulder skin",
+        "shoulder zone of skin",
+        "zone of skin of shoulder" ;
+    rdfs:subClassOf UBERON:0000014,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001467 ] .
+
+UBERON:0001484 a owl:Class ;
+    rdfs:label "articular capsule" ;
+    NIFRID:synonym "articular capsule",
+        "capsula articularis",
+        "capsulae articulares",
+        "fibrous capsule of joint",
+        "joint capsule",
+        "joint fibrous capsule" ;
+    rdfs:subClassOf UBERON:0000094 .
+
+UBERON:0001489 a owl:Class ;
+    rdfs:label "manus joint" ;
+    NIFRID:synonym "articulationes manus",
+        "hand joint",
+        "joint of hand",
+        "joint of manus",
+        "joint of terminal segment of free upper limb",
+        "manual joint" ;
+    rdfs:subClassOf UBERON:0003839,
+        UBERON:0003841,
+        UBERON:0011139,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
+
+UBERON:0001491 a owl:Class ;
+    rdfs:label "wrist joint" ;
+    NIFRID:synonym "carpal region joint",
+        "joint of carpal region",
+        "joint of wrist",
+        "radiocarpal joint" ;
+    rdfs:subClassOf UBERON:0001489,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004452 ] .
+
+UBERON:0001492 a owl:Class ;
+    rdfs:label "radial nerve" ;
+    NIFRID:synonym "nervus radialis" ;
+    rdfs:subClassOf UBERON:0003433,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001814 ] .
+
+UBERON:0001493 a owl:Class ;
+    rdfs:label "axillary nerve" ;
+    NIFRID:synonym "auxillery nerve",
+        "circumflex humeral nerve",
+        "circumflex nerve",
+        "nervus axillaris" ;
+    rdfs:subClassOf UBERON:0003433,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001814 ] .
+
+UBERON:0001494 a owl:Class ;
+    rdfs:label "ulnar nerve" ;
+    NIFRID:synonym "nervus ulnaris" ;
+    rdfs:subClassOf UBERON:0003433,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001814 ] .
+
+UBERON:0001495 a owl:Class ;
+    rdfs:label "pectoral muscle" ;
+    NIFRID:synonym "breast muscle",
+        "M. pectoralis",
+        "muscle of pectoral part of chest",
+        "muscle of pectoral region",
+        "pectoralis",
+        "pectoralis group muscle",
+        "pectoralis muscle" ;
+    rdfs:subClassOf UBERON:0003830,
+        UBERON:0008196,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004464 ] .
+
+UBERON:0001496 a owl:Class ;
+    rdfs:label "ascending aorta" ;
+    NIFRID:synonym "aorta ascendens",
+        "ascending aorta",
+        "ascending thoracic aorta",
+        "pars ascendens aortae" ;
+    rdfs:subClassOf UBERON:0001515,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001515 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001515 ] .
+
+UBERON:0001497 a owl:Class ;
+    rdfs:label "muscle of pelvic girdle" ;
+    NIFRID:synonym "girdle-pelvic muscle organ",
+        "muscle organ of girdle-pelvic",
+        "muscle organ of pelvic girdle",
+        "muscle organ of pelvic girdle bone",
+        "pelvic girdle muscle",
+        "pelvic girdle muscle organ",
+        "pelvic girdle skeletal muscle" ;
+    rdfs:subClassOf UBERON:0001325,
+        UBERON:0010890,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001271 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004470 ] .
+
+UBERON:0001498 a owl:Class ;
+    rdfs:label "muscle of pes" ;
+    NIFRID:synonym "foot muscle",
+        "foot muscle organ",
+        "muscle of foot",
+        "muscle organ of foot" ;
+    rdfs:subClassOf UBERON:0003663,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002387 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004488 ] .
+
+UBERON:0001499 a owl:Class ;
+    rdfs:label "muscle of arm" ;
+    NIFRID:synonym "arm muscle",
+        "arm muscle system",
+        "arm skeletal muscle",
+        "arm skeletal muscle tissue",
+        "muscle of upper arm or lower arm",
+        "upper arm / lower arm muscle" ;
+    rdfs:subClassOf UBERON:0003662,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004474 ] .
+
+UBERON:0001500 a owl:Class ;
+    rdfs:label "muscle of manus" ;
+    NIFRID:synonym "hand muscle",
+        "manus muscle",
+        "manus muscle organ",
+        "muscle of hand",
+        "muscle organ of manus" ;
+    rdfs:subClassOf UBERON:0003662,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004489 ] .
+
+UBERON:0001501 a owl:Class ;
+    rdfs:label "lumbrical muscle of manus" ;
+    NIFRID:synonym "hand lumbrical",
+        "hand lumbrical muscle",
+        "lumbrical muscle of hand",
+        "lumbrical of hand",
+        "musculi lumbricales manus" ;
+    rdfs:subClassOf UBERON:0014375 .
+
+UBERON:0001502 a owl:Class ;
+    rdfs:label "interosseous muscle of manus" ;
+    NIFRID:synonym "hand interosseous muscle",
+        "interosseous muscle of hand",
+        "manus interosseous muscle" ;
+    rdfs:subClassOf UBERON:0006508,
+        UBERON:0014375,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
+
+UBERON:0001503 a owl:Class ;
+    rdfs:label "dorsal interosseous of manus" ;
+    NIFRID:synonym "dorsal hand interosseus muscle",
+        "dorsal interosseous muscle of hand",
+        "dorsal interosseous of hand",
+        "dorsal manus interosseous muscle",
+        "musculi interossei dorsales manus" ;
+    rdfs:subClassOf UBERON:0001502 .
+
+UBERON:0001504 a owl:Class ;
+    rdfs:label "lumbrical muscle of pes" ;
+    NIFRID:synonym "foot lumbrical",
+        "foot lumbrical muscle",
+        "lumbrical muscle of foot",
+        "lumbrical of foot",
+        "pes lumbrical",
+        "pes lumbrical muscle" ;
+    rdfs:subClassOf UBERON:0014378 .
+
+UBERON:0001505 a owl:Class ;
+    rdfs:label "coracobrachialis muscle" ;
+    NIFRID:synonym "coracobrachial",
+        "coracobrachialis",
+        "coracobrachialis muscle",
+        "musculus coracobrachialis",
+        "Pirogoff's aponeurosis" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0004255 .
+
+UBERON:0001506 a owl:Class ;
+    rdfs:label "brachialis muscle" ;
+    NIFRID:synonym "brachialis",
+        "brachialis anticus muscle",
+        "Casserio's muscle",
+        "musculus brachialis" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0001499 .
+
+UBERON:0001507 a owl:Class ;
+    rdfs:label "biceps brachii" ;
+    NIFRID:synonym "biceps",
+        "biceps brachii %26 brachialis muscles",
+        "biceps brachii muscle",
+        "biceps cubiti",
+        "biceps muscle",
+        "musculus biceps brachii" ;
+    rdfs:subClassOf UBERON:0004255,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003822 ] .
+
 UBERON:0001508 a owl:Class ;
-    rdfs:label "('Aortic arch', 'arch of aorta')",
-        "arch of aorta" ;
+    rdfs:label "arch of aorta" ;
     NIFRID:synonym "aortic arch",
+        "arch of aorta",
         "arcus aortae",
         "thoracic aorta" ;
     rdfs:subClassOf UBERON:0001515,
@@ -8124,11 +10801,70 @@ UBERON:0001508 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001515 ] .
 
+UBERON:0001509 a owl:Class ;
+    rdfs:label "triceps brachii" ;
+    NIFRID:synonym "musculus triceps brachii",
+        "triceps",
+        "triceps brachii muscle",
+        "triceps muscle" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0004255,
+        UBERON:0034908,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003822 ] .
+
+UBERON:0001510 a owl:Class ;
+    rdfs:label "skin of knee" ;
+    NIFRID:synonym "knee skin",
+        "knee zone of skin",
+        "zone of skin of knee" ;
+    rdfs:subClassOf UBERON:0001511,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001465 ] .
+
+UBERON:0001511 a owl:Class ;
+    rdfs:label "skin of leg" ;
+    NIFRID:synonym "leg skin",
+        "leg zone of skin",
+        "zone of skin of leg" ;
+    rdfs:subClassOf UBERON:0003532,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000978 ] .
+
+UBERON:0001513 a owl:Class ;
+    rdfs:label "skin of pes" ;
+    NIFRID:synonym "foot skin",
+        "skin of foot",
+        "skin of hind-paw" ;
+    rdfs:subClassOf UBERON:0003532,
+        UBERON:0015790,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002387 ] .
+
+UBERON:0001514 a owl:Class ;
+    rdfs:label "descending aorta" ;
+    NIFRID:synonym "aorta descendens",
+        "descending aorta",
+        "pars descendens aortae" ;
+    rdfs:subClassOf UBERON:0004120,
+        UBERON:0005800,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000947 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001009 ] .
+
 UBERON:0001515 a owl:Class ;
     rdfs:label "thoracic aorta" ;
     NIFRID:synonym "aorta thoracalis",
         "aorta thoracica",
         "pars thoracica aortae",
+        "thoracic aorta",
         "thoracic part of aorta" ;
     rdfs:subClassOf UBERON:0005800,
         [ a owl:Restriction ;
@@ -8138,20 +10874,149 @@ UBERON:0001515 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000947 ] .
 
+UBERON:0001516 a owl:Class ;
+    rdfs:label "abdominal aorta" ;
+    NIFRID:synonym "abdominal aorta",
+        "abdominal part of aorta",
+        "aorta abdominalis",
+        "descending abdominal aorta",
+        "pars abdominalis aortae" ;
+    rdfs:subClassOf UBERON:0005800,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001514 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001514 ] .
+
+UBERON:0001517 a owl:Class ;
+    rdfs:label "skin of elbow" ;
+    NIFRID:synonym "cubital region zone of skin",
+        "elbow skin",
+        "elbow zone of skin",
+        "zone of skin of cubital region",
+        "zone of skin of elbow" ;
+    rdfs:subClassOf UBERON:0002427,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001461 ] .
+
+UBERON:0001519 a owl:Class ;
+    rdfs:label "skin of manus" ;
+    NIFRID:synonym "hand skin",
+        "manus skin",
+        "skin of fore-paw",
+        "skin of hand" ;
+    rdfs:subClassOf UBERON:0003531,
+        UBERON:0015790,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
+
+UBERON:0001520 a owl:Class ;
+    rdfs:label "pronator teres" ;
+    NIFRID:synonym "musculus pronator teres",
+        "pronator teres muscle" ;
+    rdfs:subClassOf UBERON:0003662,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
+
+UBERON:0001521 a owl:Class ;
+    rdfs:label "flexor carpi radialis muscle" ;
+    NIFRID:synonym "flexor carpi radialis" ;
+    rdfs:subClassOf UBERON:0000366,
+        UBERON:0004254,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002386 ] .
+
+UBERON:0001522 a owl:Class ;
+    rdfs:label "flexor carpi ulnaris muscle" ;
+    NIFRID:synonym "flexor carpi ulnaris",
+        "musculus flexor carpi ulnaris" ;
+    rdfs:subClassOf UBERON:0000366,
+        UBERON:0004254,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002386 ] .
+
+UBERON:0001523 a owl:Class ;
+    rdfs:label "flexor digitorum profundus" ;
+    NIFRID:synonym "flexor digitorum profundus muscle",
+        "musculus flexor digitorum profundus" ;
+    rdfs:subClassOf UBERON:0000366,
+        UBERON:0004255,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003822 ] .
+
+UBERON:0001524 a owl:Class ;
+    rdfs:label "extensor carpi radialis longus muscle" ;
+    NIFRID:synonym "extensor carpi radialis longus",
+        "musculus extensor carpi radialis longus" ;
+    rdfs:subClassOf UBERON:0011867 .
+
+UBERON:0001525 a owl:Class ;
+    rdfs:label "extensor carpi radialis brevis muscle" ;
+    NIFRID:synonym "extensor carpi radialis brevis",
+        "musculus extensor carpi radialis brevis" ;
+    rdfs:subClassOf UBERON:0011867 .
+
+UBERON:0001526 a owl:Class ;
+    rdfs:label "extensor carpi ulnaris muscle" ;
+    NIFRID:synonym "ECU muscle",
+        "extensor carpi ulnaris",
+        "musculus extensor carpi ulnaris" ;
+    rdfs:subClassOf UBERON:0011024 .
+
+UBERON:0001527 a owl:Class ;
+    rdfs:label "abductor pollicis longus" ;
+    NIFRID:synonym "abductor pollicis longus muscle",
+        "musculus abductor pollicis longus" ;
+    rdfs:subClassOf UBERON:0011534,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
+
 UBERON:0001530 a owl:Class ;
     rdfs:label "common carotid artery plus branches" ;
     NIFRID:synonym "a. carotis communis",
         "carotid artery",
         "carotid artery system",
         "common carotid artery",
+        "common carotid artery plus branches",
         "trunk of common carotid tree" ;
-    rdfs:subClassOf UBERON:0004573 .
+    rdfs:subClassOf UBERON:0004573,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
+
+UBERON:0001532 a owl:Class ;
+    rdfs:label "internal carotid artery" ;
+    NIFRID:synonym "arteria carotis interna",
+        "cranial carotid artery",
+        "ICA",
+        "internal carotid",
+        "internal carotid artery" ;
+    rdfs:subClassOf UBERON:0003496,
+        UBERON:0005396,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000033 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001530 ] .
 
 UBERON:0001555 a owl:Class ;
     rdfs:label "digestive tract" ;
     NIFRID:synonym "alimentary canal",
         "alimentary tract",
         "digestive canal",
+        "digestive tract",
         "digestive tube",
         "enteric tract",
         "gut",
@@ -8170,11 +11035,13 @@ UBERON:0001556 a owl:Class ;
 
 UBERON:0001557 a owl:Class ;
     rdfs:label "upper respiratory tract" ;
+    NIFRID:synonym "upper respiratory tract" ;
     rdfs:subClassOf UBERON:0000072 .
 
 UBERON:0001558 a owl:Class ;
     rdfs:label "lower respiratory tract" ;
-    NIFRID:synonym "lower respiratory system" ;
+    NIFRID:synonym "lower respiratory system",
+        "lower respiratory tract" ;
     rdfs:subClassOf UBERON:0000072 .
 
 UBERON:0001560 a owl:Class ;
@@ -8202,6 +11069,7 @@ UBERON:0001605 a owl:Class ;
     rdfs:label "ciliary muscle" ;
     NIFRID:synonym "Bowman`s muscles",
         "ciliaris",
+        "ciliary muscle",
         "musculus ciliaris",
         "musculus ciliarus" ;
     rdfs:subClassOf UBERON:0003386,
@@ -8215,6 +11083,7 @@ UBERON:0001606 a owl:Class ;
     rdfs:label "muscle of iris" ;
     NIFRID:synonym "iris muscle",
         "iris muscle organ",
+        "muscle of iris",
         "muscle organ of iris" ;
     rdfs:subClassOf UBERON:0011222,
         [ a owl:Restriction ;
@@ -8240,8 +11109,12 @@ UBERON:0001607 a owl:Class ;
         "sphincter pupillae muscle",
         "spincter pupillae" ;
     rdfs:subClassOf UBERON:0001606,
+        UBERON:0004121,
         UBERON:0004234,
         UBERON:0007521,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001769 ] .
@@ -8250,15 +11123,15 @@ UBERON:0001629 a owl:Class ;
     rdfs:label "carotid body" ;
     NIFRID:synonym "carotid glomus",
         "glomus caroticum" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0034979,
+    rdfs:subClassOf UBERON:0034979,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001530 ] .
+            owl:someValuesFrom UBERON:0000010 ] .
 
 UBERON:0001630 a owl:Class ;
     rdfs:label "muscle organ" ;
-    NIFRID:synonym "muscle" ;
+    NIFRID:synonym "muscle",
+        "muscle organ" ;
     rdfs:subClassOf UBERON:0000062,
         UBERON:0005090,
         [ a owl:Restriction ;
@@ -8271,7 +11144,8 @@ UBERON:0001637 a owl:Class ;
         "arterial system",
         "arterial tree organ part",
         "arterial vessel",
-        "arteries" ;
+        "arteries",
+        "artery" ;
     rdfs:subClassOf UBERON:0003509,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -8280,6 +11154,7 @@ UBERON:0001637 a owl:Class ;
 UBERON:0001638 a owl:Class ;
     rdfs:label "vein" ;
     NIFRID:synonym "vascular element",
+        "vein",
         "vena",
         "venae",
         "venous subtree",
@@ -8287,10 +11162,27 @@ UBERON:0001638 a owl:Class ;
         "venous vessel" ;
     rdfs:subClassOf UBERON:0003920 .
 
+UBERON:0001639 a owl:Class ;
+    rdfs:label "hepatic portal vein" ;
+    NIFRID:synonym "hepatic portal tree",
+        "hepatic portal vein",
+        "HPV",
+        "liver portal vein",
+        "portal vein",
+        "portal vein of liver",
+        "primary hepatic portal vein",
+        "primary hepatic portal veins",
+        "vena portae hepatis" ;
+    rdfs:subClassOf UBERON:0002017,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010194 ] .
+
 UBERON:0001640 a owl:Class ;
     rdfs:label "celiac artery" ;
     NIFRID:synonym "arteria coeliaca",
         "arteria cœliaca",
+        "celiac artery",
         "celiac tree",
         "celiac trunk",
         "coeliac artery",
@@ -8299,7 +11191,8 @@ UBERON:0001640 a owl:Class ;
         "coeliac trunk",
         "truncus coeliacus",
         "truncus cœliacus" ;
-    rdfs:subClassOf UBERON:0012254 .
+    rdfs:subClassOf UBERON:0004573,
+        UBERON:0012254 .
 
 UBERON:0001643 a owl:Class ;
     rdfs:label "oculomotor nerve" ;
@@ -8312,12 +11205,12 @@ UBERON:0001643 a owl:Class ;
         "occulomotor",
         "oculomotor III",
         "oculomotor III nerve",
+        "oculomotor nerve",
         "oculomotor nerve [III]",
         "oculomotor nerve or its root",
         "oculomotor nerve tree",
         "third cranial nerve" ;
-    rdfs:subClassOf UBERON:0001785,
-        UBERON:0004121 .
+    rdfs:subClassOf UBERON:0001785 .
 
 UBERON:0001645 a owl:Class ;
     rdfs:label "trigeminal nerve" ;
@@ -8328,6 +11221,7 @@ UBERON:0001645 a owl:Class ;
         "nerve V",
         "nervus trigeminus",
         "nervus trigeminus [v]",
+        "trigeminal nerve",
         "trigeminal nerve [V]",
         "trigeminal nerve tree",
         "trigeminal V",
@@ -8342,6 +11236,7 @@ UBERON:0001647 a owl:Class ;
         "CN-VII",
         "cranial nerve VII",
         "face nerve",
+        "facial nerve",
         "facial nerve [VII]",
         "facial nerve or its root",
         "facial nerve tree",
@@ -8366,6 +11261,7 @@ UBERON:0001649 a owl:Class ;
         "cranial nerve IX",
         "glossopharyngeal IX",
         "glossopharyngeal IX nerve",
+        "glossopharyngeal nerve",
         "glossopharyngeal nerve [IX]",
         "glossopharyngeal nerve tree",
         "nerve IX",
@@ -8382,6 +11278,7 @@ UBERON:0001650 a owl:Class ;
     NIFRID:synonym "12n",
         "CN-XII",
         "cranial nerve XII",
+        "hypoglossal nerve",
         "hypoglossal nerve [XII]",
         "hypoglossal nerve tree",
         "hypoglossal nerve/ root",
@@ -8394,15 +11291,64 @@ UBERON:0001650 a owl:Class ;
         "twelfth cranial nerve" ;
     rdfs:subClassOf UBERON:0001785 .
 
+UBERON:0001665 a owl:Class ;
+    rdfs:label "triceps surae" ;
+    NIFRID:synonym "calf muscle",
+        "gastrosoleus",
+        "gastrosoleus complex",
+        "musculus triceps surae",
+        "sural triceps" ;
+    rdfs:subClassOf UBERON:0004256,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003823 ] .
+
+UBERON:0001666 a owl:Class ;
+    rdfs:label "flexor digitorum longus" ;
+    rdfs:subClassOf UBERON:0001383 .
+
+UBERON:0001667 a owl:Class ;
+    rdfs:label "tibialis posterior" ;
+    NIFRID:synonym "ibialis posticus",
+        "musculus tibialis posterior",
+        "posterior tibialis",
+        "tibialis caudalis",
+        "tibialis posterior muscle" ;
+    rdfs:subClassOf UBERON:0008230 .
+
+UBERON:0001675 a owl:Class ;
+    rdfs:label "trigeminal ganglion" ;
+    NIFRID:synonym "5th ganglion",
+        "fifth ganglion",
+        "fused trigeminal ganglion",
+        "ganglion of trigeminal complex",
+        "ganglion of trigeminal nerve",
+        "ganglion semilunare",
+        "ganglion trigeminale",
+        "Gasser's ganglion",
+        "Gasserian ganglia",
+        "Gasserian ganglion",
+        "gV",
+        "semilunar ganglion",
+        "trigeminal ganglia",
+        "trigeminal ganglion",
+        "trigeminal V ganglion",
+        "trigeminus ganglion" ;
+    rdfs:subClassOf UBERON:0001714,
+        UBERON:0001800,
+        UBERON:0004121 .
+
 UBERON:0001678 a owl:Class ;
     rdfs:label "temporal bone" ;
-    NIFRID:synonym "os temporale" ;
+    NIFRID:synonym "os temporale",
+        "temporal bone" ;
     rdfs:subClassOf UBERON:0008193 .
 
 UBERON:0001690 a owl:Class ;
     rdfs:label "ear" ;
     NIFRID:synonym "auditory apparatus",
-        "auris" ;
+        "auris",
+        "ear" ;
     rdfs:subClassOf UBERON:0000020,
         UBERON:0010314,
         [ a owl:Restriction ;
@@ -8412,24 +11358,6 @@ UBERON:0001690 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002105 ] .
 
-UBERON:0001691 a owl:Class ;
-    rdfs:label "external ear" ;
-    NIFRID:synonym "auricular region",
-        "auricular region of head",
-        "auris externa",
-        "outer ear" ;
-    rdfs:subClassOf UBERON:0001444,
-        UBERON:0015212,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001690 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0000033 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0001690 ] .
-
 UBERON:0001694 a owl:Class ;
     rdfs:label "petrous part of temporal bone" ;
     NIFRID:synonym "pars petrosa (os temporale)",
@@ -8438,6 +11366,7 @@ UBERON:0001694 a owl:Class ;
         "petrosal",
         "petrosal bone",
         "petrous bone",
+        "petrous part of temporal bone",
         "temporal bone petrous part" ;
     rdfs:subClassOf UBERON:0005913,
         [ a owl:Restriction ;
@@ -8452,6 +11381,7 @@ UBERON:0001701 a owl:Class ;
     NIFRID:synonym "ganglion of glossopharyngeal nerve",
         "ganglion of glosspharyngeal nerve",
         "gIX",
+        "glossopharyngeal ganglion",
         "glossopharyngeal IX ganglion",
         "petrosal ganglion" ;
     rdfs:subClassOf UBERON:0009127 .
@@ -8461,19 +11391,30 @@ UBERON:0001703 a owl:Class ;
     NIFRID:synonym "brain box",
         "brain case",
         "brain pan",
-        "braincase" ;
+        "braincase",
+        "neurocranium" ;
     rdfs:subClassOf UBERON:0011158,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0003128 ] .
 
+UBERON:0001705 a owl:Class ;
+    rdfs:label "nail" ;
+    NIFRID:synonym "claw",
+        "nail/claw",
+        "talon" ;
+    rdfs:subClassOf UBERON:0009564,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001003 ] .
+
 UBERON:0001710 a owl:Class ;
     rdfs:label "lower jaw region" ;
-    NIFRID:synonym "lower part of mouth",
+    NIFRID:synonym "lower jaw region",
+        "lower part of mouth",
         "mandibular part of mouth",
         "mandibular series" ;
     rdfs:subClassOf UBERON:0000475,
-        UBERON:0010314,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0011595 ] .
@@ -8494,6 +11435,9 @@ UBERON:0001714 a owl:Class ;
     rdfs:subClassOf UBERON:0000045,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000033 ] .
 
 UBERON:0001715 a owl:Class ;
@@ -8508,6 +11452,7 @@ UBERON:0001715 a owl:Class ;
         "oculomotor III nuclear complex",
         "oculomotor III nucleus",
         "oculomotor motornucleus",
+        "oculomotor nuclear complex",
         "oculomotor nucleus",
         "OM",
         "third cranial nerve nucleus" ;
@@ -8517,13 +11462,30 @@ UBERON:0001715 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001943 ] .
 
+UBERON:0001717 a owl:Class ;
+    rdfs:label "spinal nucleus of trigeminal nerve" ;
+    NIFRID:synonym "nucleus spinalis nervi trigemini",
+        "spinal nucleus of cranial nerve v",
+        "spinal nucleus of the trigeminal",
+        "spinal trigeminal nucleus",
+        "trigeminal nerve spinal tract nucleus",
+        "trigeminal spinal nucleus",
+        "trigeminal spinal sensory nucleus",
+        "trigeminal v spinal sensory nucleus" ;
+    rdfs:subClassOf UBERON:0004132,
+        UBERON:0007635,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001896 ] .
+
 UBERON:0001719 a owl:Class ;
     rdfs:label "nucleus ambiguus" ;
     NIFRID:synonym "Amb",
         "ambiguous nucleus",
         "ambiguus nucleus",
         "nucleus innominatus" ;
-    rdfs:subClassOf UBERON:0007635,
+    rdfs:subClassOf UBERON:0004121,
+        UBERON:0007635,
         UBERON:0011775,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -8531,13 +11493,17 @@ UBERON:0001719 a owl:Class ;
 
 UBERON:0001720 a owl:Class ;
     rdfs:label "cochlear nucleus" ;
-    NIFRID:synonym "cochlear nucleus of acoustic nerve",
+    NIFRID:synonym "cochlear nucleus",
+        "cochlear nucleus of acoustic nerve",
         "cochlear nucleus of eighth cranial nerve",
         "cochlear VIII nucleus",
         "nucleus of cochlear nerve",
         "statoacoustic (VIII) nucleus",
         "vestibulocochlear nucleus" ;
     rdfs:subClassOf UBERON:0007635,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002610 ],
@@ -8547,7 +11513,8 @@ UBERON:0001720 a owl:Class ;
 
 UBERON:0001723 a owl:Class ;
     rdfs:label "tongue" ;
-    NIFRID:synonym "glossus" ;
+    NIFRID:synonym "glossus",
+        "tongue" ;
     rdfs:subClassOf UBERON:0000020,
         UBERON:0013765,
         [ a owl:Restriction ;
@@ -8568,10 +11535,14 @@ UBERON:0001736 a owl:Class ;
         "maxillary gland",
         "submandibular salivary gland",
         "submaxillary gland" ;
-    rdfs:subClassOf UBERON:0001829 .
+    rdfs:subClassOf UBERON:0001829,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001710 ] .
 
 UBERON:0001737 a owl:Class ;
     rdfs:label "larynx" ;
+    NIFRID:synonym "larynx" ;
     rdfs:subClassOf UBERON:0000072,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -8584,8 +11555,7 @@ UBERON:0001744 a owl:Class ;
     rdfs:label "lymphoid tissue" ;
     NIFRID:synonym "lymphatic tissue",
         "lymphocytic tissue" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0034769,
+    rdfs:subClassOf UBERON:0034769,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002193 ],
@@ -8601,7 +11571,6 @@ UBERON:0001750 a owl:Class ;
         "nasolacrimal drainage system",
         "nasolacrimal system" ;
     rdfs:subClassOf UBERON:0000467,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000019 ],
@@ -8615,20 +11584,6 @@ UBERON:0001750 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000019 ] .
 
-UBERON:0001757 a owl:Class ;
-    rdfs:label "pinna" ;
-    NIFRID:synonym "auricle",
-        "auricle of ear",
-        "auricle of external ear",
-        "auricula",
-        "auricula (auris externa)",
-        "pinna of ear",
-        "pinnae" ;
-    rdfs:subClassOf UBERON:0001444,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001691 ] .
-
 UBERON:0001759 a owl:Class ;
     rdfs:label "vagus nerve" ;
     NIFRID:synonym "10n",
@@ -8641,6 +11596,7 @@ UBERON:0001759 a owl:Class ;
         "tenth cranial nerve",
         "vagal nerve",
         "vagus",
+        "vagus nerve",
         "vagus nerve [X]",
         "vagus nerve or its root",
         "vagus nerve tree",
@@ -8660,26 +11616,20 @@ UBERON:0001768 a owl:Class ;
         "uvea",
         "uveal tract",
         "vascular layer of eyeball" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0004923,
+    rdfs:subClassOf UBERON:0004923,
         UBERON:0010314,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001801 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000019 ] .
 
 UBERON:0001769 a owl:Class ;
     rdfs:label "iris" ;
     NIFRID:synonym "anterior uvea",
         "irides",
+        "iris",
         "irises" ;
     rdfs:subClassOf UBERON:0000481,
         UBERON:0004121,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001768 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0011892 ],
@@ -8693,6 +11643,7 @@ UBERON:0001774 a owl:Class ;
         "muscle of trunk",
         "muscle organ of torso",
         "muscle organ of trunk",
+        "skeletal muscle of trunk",
         "torso muscle organ",
         "trunk muscle",
         "trunk muscle organ",
@@ -8710,13 +11661,12 @@ UBERON:0001775 a owl:Class ;
     rdfs:label "ciliary body" ;
     NIFRID:synonym "anterior uvea",
         "ciliary bodies",
+        "ciliary body",
         "corpus ciliare",
         "ocular ciliary body" ;
     rdfs:subClassOf UBERON:0000481,
         UBERON:0004121,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001768 ],
+        UBERON:0010314,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0011892 ],
@@ -8733,6 +11683,7 @@ UBERON:0001780 a owl:Class ;
         "nerve of vertebral column",
         "nervi spinales",
         "spinal column nerve",
+        "spinal nerve",
         "spinal nerve tree",
         "spinal nerves",
         "spine nerve",
@@ -8740,16 +11691,19 @@ UBERON:0001780 a owl:Class ;
     rdfs:subClassOf UBERON:0001021,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000010 ] .
 
 UBERON:0001781 a owl:Class ;
     rdfs:label "layer of retina" ;
-    NIFRID:synonym "retina layer",
+    NIFRID:synonym "layer of retina",
+        "retina layer",
         "retina neuronal layer",
         "retinal layer",
         "retinal neuronal layer" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0022303,
+    rdfs:subClassOf UBERON:0022303,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000966 ],
@@ -8759,7 +11713,8 @@ UBERON:0001781 a owl:Class ;
 
 UBERON:0001785 a owl:Class ;
     rdfs:label "cranial nerve" ;
-    NIFRID:synonym "cranial nerves",
+    NIFRID:synonym "cranial nerve",
+        "cranial nerves",
         "cranial neural tree organ",
         "nervus cranialis" ;
     rdfs:subClassOf UBERON:0011779,
@@ -8868,20 +11823,24 @@ UBERON:0001795 a owl:Class ;
 
 UBERON:0001800 a owl:Class ;
     rdfs:label "sensory ganglion" ;
-    NIFRID:synonym "ganglion sensorium" ;
-    rdfs:subClassOf UBERON:0000045 .
+    NIFRID:synonym "ganglion sensorium",
+        "sensory ganglion" ;
+    rdfs:subClassOf UBERON:0000045,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
 
 UBERON:0001801 a owl:Class ;
     rdfs:label "anterior segment of eyeball" ;
     NIFRID:synonym "anterior eye segment",
         "anterior segment eye",
         "anterior segment of eye",
+        "anterior segment of eyeball",
         "anterior segment of the eye",
         "eye anterior segment",
         "segmentum anterius (bulbus oculi)",
         "segmentum anterius bulbi oculi" ;
     rdfs:subClassOf UBERON:0000063,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0010230 ],
@@ -8895,11 +11854,11 @@ UBERON:0001802 a owl:Class ;
         "posterior eye segment",
         "posterior segment eye",
         "posterior segment of eye",
+        "posterior segment of eyeball",
         "posterior segment of the eye",
         "segmentum posterius (bulbus oculi)",
         "segmentum posterius bulbi oculi" ;
     rdfs:subClassOf UBERON:0000063,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0010230 ],
@@ -8909,12 +11868,16 @@ UBERON:0001802 a owl:Class ;
 
 UBERON:0001805 a owl:Class ;
     rdfs:label "autonomic ganglion" ;
-    NIFRID:synonym "autonomic nervous system ganglion",
+    NIFRID:synonym "autonomic ganglion",
+        "autonomic nervous system ganglion",
         "ganglion autonomicum",
         "ganglion of autonomic nervous system",
         "ganglion of visceral nervous system",
         "visceral nervous system ganglion" ;
     rdfs:subClassOf UBERON:0003338,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002410 ] .
@@ -8925,10 +11888,10 @@ UBERON:0001806 a owl:Class ;
         "ganglion of sympathetic part of autonomic division of nervous system",
         "ganglion sympatheticum",
         "ganglion sympathicum",
+        "sympathetic ganglion",
         "sympathetic nervous system ganglion",
         "sympathetic part of autonomic division of nervous system ganglion" ;
     rdfs:subClassOf UBERON:0001805,
-        UBERON:0010313,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000013 ],
@@ -8955,7 +11918,8 @@ UBERON:0001807 a owl:Class ;
 
 UBERON:0001808 a owl:Class ;
     rdfs:label "parasympathetic ganglion" ;
-    NIFRID:synonym "ganglion parasympathicum" ;
+    NIFRID:synonym "ganglion parasympathicum",
+        "parasympathetic ganglion" ;
     rdfs:subClassOf UBERON:0001805,
         UBERON:0010313,
         [ a owl:Restriction ;
@@ -8965,6 +11929,17 @@ UBERON:0001808 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000011 ] .
 
+UBERON:0001809 a owl:Class ;
+    rdfs:label "enteric ganglion" ;
+    NIFRID:synonym "intramural ganglion" ;
+    rdfs:subClassOf UBERON:0001808,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002005 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002005 ] .
+
 UBERON:0001810 a owl:Class ;
     rdfs:label "nerve plexus" ;
     NIFRID:synonym "plexus" ;
@@ -8972,6 +11947,31 @@ UBERON:0001810 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001016 ] .
+
+UBERON:0001813 a owl:Class ;
+    rdfs:label "spinal nerve plexus" ;
+    NIFRID:synonym "plexus nervorum spinalium",
+        "plexus of spinal nerves",
+        "somatic nerve plexus",
+        "spinal nerve plexus" ;
+    rdfs:subClassOf UBERON:0001810,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
+
+UBERON:0001814 a owl:Class ;
+    rdfs:label "brachial nerve plexus" ;
+    NIFRID:synonym "brachial plexus",
+        "plexus brachialis" ;
+    rdfs:subClassOf UBERON:0000122,
+        UBERON:0001813 .
+
+UBERON:0001815 a owl:Class ;
+    rdfs:label "lumbosacral nerve plexus" ;
+    NIFRID:synonym "lumbosacral plexus",
+        "plexus lumbosacralis" ;
+    rdfs:subClassOf UBERON:0000122,
+        UBERON:0001813 .
 
 UBERON:0001816 a owl:Class ;
     rdfs:label "autonomic nerve plexus" ;
@@ -8994,7 +11994,6 @@ UBERON:0001817 a owl:Class ;
         "preorbital gland",
         "tear gland" ;
     rdfs:subClassOf UBERON:0002365,
-        UBERON:0004121,
         UBERON:0004859,
         UBERON:0015154,
         [ a owl:Restriction ;
@@ -9007,16 +12006,28 @@ UBERON:0001817 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001750 ] .
 
+UBERON:0001820 a owl:Class ;
+    rdfs:label "sweat gland" ;
+    NIFRID:synonym "glandula sudorifera",
+        "sudoriferous gland",
+        "sudoriparous gland" ;
+    rdfs:subClassOf UBERON:0002365,
+        UBERON:0007771,
+        UBERON:0019319,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001003 ] .
+
 UBERON:0001826 a owl:Class ;
     rdfs:label "nasal cavity mucosa" ;
     NIFRID:synonym "mucosa of nose",
         "mucous membrane of nose",
+        "nasal cavity mucosa",
         "nasal mucosa",
         "tunica mucosa nasalis",
         "tunica mucosa nasi" ;
     rdfs:subClassOf UBERON:0000379,
-        UBERON:0004119,
-        UBERON:0004121,
+        UBERON:0004785,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0015788 ] .
@@ -9035,7 +12046,10 @@ UBERON:0001831 a owl:Class ;
         UBERON:0012102,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001567 ] .
+            owl:someValuesFrom UBERON:0001567 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001710 ] .
 
 UBERON:0001832 a owl:Class ;
     rdfs:label "sublingual gland" ;
@@ -9049,11 +12063,11 @@ UBERON:0001832 a owl:Class ;
 
 UBERON:0001839 a owl:Class ;
     rdfs:label "bony labyrinth" ;
-    NIFRID:synonym "labyrinthus osseus",
+    NIFRID:synonym "bony labyrinth",
+        "labyrinthus osseus",
         "osseous labyrinth",
         "osseus labyrinth" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0034921,
+    rdfs:subClassOf UBERON:0034921,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001694 ],
@@ -9066,14 +12080,14 @@ UBERON:0001839 a owl:Class ;
 
 UBERON:0001844 a owl:Class ;
     rdfs:label "cochlea" ;
-    NIFRID:synonym "cochleae",
+    NIFRID:synonym "cochlea",
+        "cochleae",
         "cochlear duct",
         "cochlear organ",
         "cochlear part of bony labyrinth",
         "lagena",
         "lagenas" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0034921,
+    rdfs:subClassOf UBERON:0034921,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001839 ],
@@ -9085,38 +12099,19 @@ UBERON:0001846 a owl:Class ;
     rdfs:label "internal ear" ;
     NIFRID:synonym "auris interna",
         "inner ear",
+        "internal ear",
         "labyrinth",
         "otocyst" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0034921,
+    rdfs:subClassOf UBERON:0034921,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001690 ] .
 
-UBERON:0001847 a owl:Class ;
-    rdfs:label "lobule of pinna" ;
-    NIFRID:synonym "auricular lobule",
-        "ear lobe",
-        "ear lobule",
-        "earlobe",
-        "lobe of ear",
-        "lobule of auricle",
-        "lobule of auricle of ear",
-        "lobulus auriculae",
-        "pinna lobule" ;
-    rdfs:subClassOf UBERON:0034929,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001757 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0001691 ] .
-
 UBERON:0001849 a owl:Class ;
     rdfs:label "membranous labyrinth" ;
-    NIFRID:synonym "labyrinthus membranaceus" ;
+    NIFRID:synonym "labyrinthus membranaceus",
+        "membranous labyrinth" ;
     rdfs:subClassOf UBERON:0000062,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001846 ] .
@@ -9140,7 +12135,6 @@ UBERON:0001855 a owl:Class ;
         "scala medias",
         "scala of Loewenberg" ;
     rdfs:subClassOf UBERON:0000025,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002499 ] .
@@ -9150,16 +12144,17 @@ UBERON:0001862 a owl:Class ;
     NIFRID:synonym "inner ear vestibular component",
         "labyrinthus vestibularis",
         "vestibular apparatus",
-        "vestibular component" ;
+        "vestibular component",
+        "vestibular labyrinth" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001849 ] .
 
 UBERON:0001869 a owl:Class ;
     rdfs:label "cerebral hemisphere" ;
-    NIFRID:synonym "cerebrum",
+    NIFRID:synonym "cerebral hemisphere",
+        "cerebrum",
         "hemisphere",
         "hemispheric regions",
         "hemispherium cerebri",
@@ -9167,7 +12162,6 @@ UBERON:0001869 a owl:Class ;
         "nucleus amygdaloideus medialis",
         "nucleus medialis amygdalae" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
         UBERON:0015212,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -9176,7 +12170,8 @@ UBERON:0001869 a owl:Class ;
 UBERON:0001871 a owl:Class ;
     rdfs:label "temporal lobe" ;
     NIFRID:synonym "lobus temporalis",
-        "temporal cortex" ;
+        "temporal cortex",
+        "temporal lobe" ;
     rdfs:subClassOf UBERON:0016526,
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
@@ -9185,6 +12180,7 @@ UBERON:0001871 a owl:Class ;
 UBERON:0001872 a owl:Class ;
     rdfs:label "parietal lobe" ;
     NIFRID:synonym "lobus parietalis",
+        "parietal lobe",
         "parietal region",
         "regio parietalis" ;
     rdfs:subClassOf UBERON:0016526,
@@ -9194,19 +12190,18 @@ UBERON:0001872 a owl:Class ;
 
 UBERON:0001875 a owl:Class ;
     rdfs:label "globus pallidus" ;
-    NIFRID:synonym "globus pallidus (Burdach)",
+    NIFRID:synonym "globus pallidus",
+        "globus pallidus (Burdach)",
         "nucleus pallidus",
         "pale body",
         "paleostriatum",
         "pallidium",
         "pallidum" ;
-    rdfs:subClassOf UBERON:0009663,
+    rdfs:subClassOf UBERON:0004121,
+        UBERON:0009663,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001869 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002263 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002420 ],
@@ -9219,7 +12214,8 @@ UBERON:0001875 a owl:Class ;
 
 UBERON:0001876 a owl:Class ;
     rdfs:label "amygdala" ;
-    NIFRID:synonym "amygdaloid area",
+    NIFRID:synonym "amygdala",
+        "amygdaloid area",
         "amygdaloid body",
         "amygdaloid complex",
         "amygdaloid nuclear complex",
@@ -9266,46 +12262,16 @@ UBERON:0001880 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002743 ] .
 
-UBERON:0001882 a owl:Class ;
-    rdfs:label "nucleus accumbens" ;
-    NIFRID:synonym "accumbens nucleus",
-        "colliculus nuclei caudati",
-        "colliculus of caudate nucleus",
-        "nucleus accumbens septi" ;
-    rdfs:subClassOf UBERON:0009663,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000349 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001869 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005403 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0005403 ] .
-
-UBERON:0001883 a owl:Class ;
-    rdfs:label "olfactory tubercle" ;
-    NIFRID:synonym "tuberculum olfactorium" ;
-    rdfs:subClassOf UBERON:0009663,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002894 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005401 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0002894 ] .
-
 UBERON:0001884 a owl:Class ;
     rdfs:label "phrenic nerve" ;
     NIFRID:synonym "diaphragmatic nerve",
         "nervus phrenicus",
-        "phrenic" ;
-    rdfs:subClassOf UBERON:0003443 .
+        "phrenic",
+        "phrenic nerve" ;
+    rdfs:subClassOf UBERON:0003443,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000962 ] .
 
 UBERON:0001885 a owl:Class ;
     rdfs:label "dentate gyrus of hippocampal formation" ;
@@ -9313,6 +12279,7 @@ UBERON:0001885 a owl:Class ;
         "dentate area",
         "dentate area (dentate gyrus)",
         "dentate gyrus",
+        "dentate gyrus of hippocampal formation",
         "fascia dentata",
         "gyrus dentatus",
         "hippocampal dentate gyrus" ;
@@ -9324,8 +12291,10 @@ UBERON:0001885 a owl:Class ;
 UBERON:0001890 a owl:Class ;
     rdfs:label "forebrain" ;
     NIFRID:synonym "FB",
+        "forebrain",
         "prosencephalon" ;
     rdfs:subClassOf UBERON:0002616,
+        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000955 ],
@@ -9336,8 +12305,10 @@ UBERON:0001890 a owl:Class ;
 UBERON:0001891 a owl:Class ;
     rdfs:label "midbrain" ;
     NIFRID:synonym "MB",
-        "mesencephalon" ;
+        "mesencephalon",
+        "midbrain" ;
     rdfs:subClassOf UBERON:0002616,
+        UBERON:0004121,
         UBERON:0010314,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -9350,8 +12321,10 @@ UBERON:0001893 a owl:Class ;
     rdfs:label "telencephalon" ;
     NIFRID:synonym "cerebrum",
         "endbrain",
-        "supratentorial region" ;
+        "supratentorial region",
+        "telencephalon" ;
     rdfs:subClassOf UBERON:0002616,
+        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001890 ] .
@@ -9366,6 +12339,7 @@ UBERON:0001894 a owl:Class ;
         "mature diencephalon",
         "thalamencephalon" ;
     rdfs:subClassOf UBERON:0002616,
+        UBERON:0004121,
         UBERON:0010314,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -9377,8 +12351,10 @@ UBERON:0001894 a owl:Class ;
 UBERON:0001895 a owl:Class ;
     rdfs:label "metencephalon" ;
     NIFRID:synonym "epencephalon",
-        "epencephalon-2" ;
-    rdfs:subClassOf UBERON:0004733,
+        "epencephalon-2",
+        "metencephalon" ;
+    rdfs:subClassOf UBERON:0004121,
+        UBERON:0004733,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002028 ],
@@ -9391,10 +12367,10 @@ UBERON:0001896 a owl:Class ;
     NIFRID:synonym "bulb",
         "bulbus",
         "medulla",
+        "medulla oblongata",
         "medulla oblonzata",
         "metepencephalon" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002028 ],
@@ -9408,7 +12384,8 @@ UBERON:0001896 a owl:Class ;
 UBERON:0001897 a owl:Class ;
     rdfs:label "dorsal plus ventral thalamus",
         "Thalamus" ;
-    NIFRID:synonym "Th",
+    NIFRID:synonym "dorsal plus ventral thalamus",
+        "Th",
         "thalamencephalon",
         "thalami",
         "thalamus",
@@ -9447,108 +12424,25 @@ UBERON:0001898 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001894 ] .
 
-UBERON:0001899 a owl:Class ;
-    rdfs:label "epithalamus" ;
-    NIFRID:synonym "epithalamus",
-        "ETh" ;
-    rdfs:subClassOf UBERON:0002616,
+UBERON:0001902 a owl:Class ;
+    rdfs:label "epithelium of small intestine" ;
+    NIFRID:synonym "epithelial tissue of small bowel",
+        "epithelial tissue of small intestine",
+        "epithelium of small bowel",
+        "epithelium of small intestine",
+        "mid intestine epithelium",
+        "small bowel epithelial tissue",
+        "small bowel epithelium",
+        "small intestinal epithelium",
+        "small intestine epithelial tissue",
+        "small intestine epithelium" ;
+    rdfs:subClassOf UBERON:0001277,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001897 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0001894 ] .
-
-UBERON:0001900 a owl:Class ;
-    rdfs:label "ventral thalamus" ;
-    NIFRID:synonym "perithalamus",
-        "prethalamus",
-        "SbTh",
-        "subthalamic region",
-        "subthalamus",
-        "thalamus ventralis",
-        "ventral thalamus" ;
-    rdfs:subClassOf UBERON:0002616,
+            owl:someValuesFrom UBERON:0001204 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001897 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0001894 ] .
-
-UBERON:0001903 a owl:Class ;
-    rdfs:label "thalamic reticular nucleus" ;
-    NIFRID:synonym "nuclei reticulares (thalami)",
-        "nucleus reticularis",
-        "nucleus reticularis thalami",
-        "nucleus reticulatus (thalami)",
-        "nucleus thalamicus reticularis",
-        "reticular nuclear group",
-        "reticular nucleus of thalamus",
-        "reticular nucleus of the thalamus",
-        "reticular nucleus thalamus (Arnold)",
-        "reticular nucleus-2",
-        "reticular thalamic nucleus",
-        "reticulatum thalami (Hassler)" ;
-    rdfs:subClassOf UBERON:0015234,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001900 ] .
-
-UBERON:0001904 a owl:Class ;
-    rdfs:label "habenula" ;
-    NIFRID:synonym "ganglion intercrurale",
-        "ganglion interpedunculare",
-        "habenula complex",
-        "habenulae",
-        "habenular complex",
-        "habenular nuclei",
-        "Hb",
-        "nuclei habenulares",
-        "nucleus habenularis",
-        "pineal peduncle" ;
-    rdfs:subClassOf UBERON:0002616,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001899 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0001899 ] .
-
-UBERON:0001906 a owl:Class ;
-    rdfs:label "subthalamic nucleus" ;
-    NIFRID:synonym "body of Forel",
-        "body of Luys",
-        "corpus Luysi",
-        "corpus subthalamicum",
-        "Luy's body",
-        "Luys' body",
-        "Luys' nucleus",
-        "nucleus of corpus luysii",
-        "nucleus of Luys",
-        "nucleus subthalamicus",
-        "subthalamic nucleus (of Luys)",
-        "subthalamic nucleus of Luys" ;
-    rdfs:subClassOf UBERON:0015233,
-        UBERON:0015234,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001900 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002776 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0001900 ] .
-
-UBERON:0001907 a owl:Class ;
-    rdfs:label "zona incerta" ;
-    NIFRID:synonym "nucleus of the zona incerta",
-        "zona incerta proper" ;
-    rdfs:subClassOf UBERON:0015234,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001900 ] .
+            owl:someValuesFrom UBERON:0002108 ] .
 
 UBERON:0001926 a owl:Class ;
     rdfs:label "lateral geniculate body" ;
@@ -9557,13 +12451,15 @@ UBERON:0001926 a owl:Class ;
         "corpus geniculatum laterales",
         "corpus geniculatus lateralis",
         "external geniculate body",
+        "lateral geniculate body",
         "lateral geniculate complex",
         "lateral geniculate nucleus",
         "LGB",
         "LGN",
         "nucleus corporis geniculati lateralis",
         "nucleus geniculatus lateralis" ;
-    rdfs:subClassOf UBERON:0015233,
+    rdfs:subClassOf UBERON:0007692,
+        UBERON:0015233,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002704 ],
@@ -9604,6 +12500,7 @@ UBERON:0001928 a owl:Class ;
         "area preoptica",
         "nuclei preoptici",
         "POA",
+        "preoptic area",
         "preoptic hypothalamic area",
         "preoptic hypothalamic region",
         "preoptic nuclei",
@@ -9628,6 +12525,7 @@ UBERON:0001930 a owl:Class ;
         "paraventricular hypothalamic nucleus",
         "paraventricular nucleus",
         "paraventricular nucleus hypothalamus (Malone)",
+        "paraventricular nucleus of hypothalamus",
         "paraventricular nucleus of the hypothalamus",
         "parvocellular hypothalamic nucleus",
         "subcommissural nucleus (Ziehen)" ;
@@ -9656,6 +12554,7 @@ UBERON:0001931 a owl:Class ;
 UBERON:0001943 a owl:Class ;
     rdfs:label "midbrain tegmentum" ;
     NIFRID:synonym "mesencephalic tegmentum",
+        "midbrain tegmentum",
         "MTg",
         "tegmentum",
         "tegmentum mesencephali",
@@ -9667,27 +12566,7 @@ UBERON:0001943 a owl:Class ;
             owl:someValuesFrom UBERON:0001891 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002298 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002623 ] .
-
-UBERON:0001944 a owl:Class ;
-    rdfs:label "pretectal region" ;
-    NIFRID:synonym "area praetectalis",
-        "area pretectalis",
-        "nuclei pretectales",
-        "nucleus praetectalis",
-        "praetectum",
-        "pretectal area",
-        "pretectal nuclei",
-        "pretectum",
-        "regio pretectalis" ;
-    rdfs:subClassOf UBERON:0003528,
-        UBERON:0007245,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000955 ] .
+            owl:someValuesFrom UBERON:0002298 ] .
 
 UBERON:0001945 a owl:Class ;
     rdfs:label "superior colliculus" ;
@@ -9741,26 +12620,11 @@ UBERON:0001946 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002314 ] .
 
-UBERON:0001947 a owl:Class ;
-    rdfs:label "red nucleus" ;
-    NIFRID:synonym "nucleus rotundus subthalamo-peduncularis",
-        "nucleus ruber",
-        "nucleus ruber tegmenti",
-        "nucleus ruber tegmenti (Stilling)",
-        "R",
-        "red nucleus (Burdach)" ;
-    rdfs:subClassOf UBERON:0006331,
-        UBERON:0007414,
-        UBERON:0009661,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001943 ] .
-
 UBERON:0001948 a owl:Class ;
     rdfs:label "Regional part of spinal cord" ;
-    NIFRID:synonym "spinal cord part" ;
+    NIFRID:synonym "regional part of spinal cord",
+        "spinal cord part" ;
     rdfs:subClassOf UBERON:0000073,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002240 ] .
@@ -9773,6 +12637,7 @@ UBERON:0001950 a owl:Class ;
         "iso-cortex",
         "isocortex",
         "isocortex (sensu lato)",
+        "neocortex",
         "neocortex (isocortex)",
         "neopallial cortex",
         "neopallium",
@@ -9816,8 +12681,7 @@ UBERON:0001959 a owl:Class ;
         "spleen white pulp",
         "splenic white pulp",
         "white pulp" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:1000023,
+    rdfs:subClassOf UBERON:1000023,
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0002106 ] .
@@ -9833,7 +12697,6 @@ UBERON:0001960 a owl:Class ;
     rdfs:subClassOf UBERON:0004177,
         UBERON:0005172,
         UBERON:0010393,
-        UBERON:0013765,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001959 ],
@@ -9861,48 +12724,16 @@ UBERON:0001962 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001555 ] .
 
-UBERON:0001965 a owl:Class ;
-    rdfs:label "substantia nigra pars compacta" ;
-    NIFRID:synonym "compact part of substantia nigra",
-        "nucleus substantiae nigrae, pars compacta",
-        "pars compacta",
-        "pars compacta of substantia nigra",
-        "pars compacta substantiae nigrae",
-        "SNC",
-        "SNpc",
-        "substantia nigra compact part",
-        "substantia nigra compacta",
-        "substantia nigra, compact division",
-        "substantia nigra, compact part",
-        "substantia nigra, pars compacta" ;
-    rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002038 ] .
-
-UBERON:0001966 a owl:Class ;
-    rdfs:label "substantia nigra pars reticulata" ;
-    NIFRID:synonym "nucleus substantiae nigrae, pars compacta",
-        "nucleus substantiae nigrae, pars reticularis",
-        "pars compacta of substantia nigra",
-        "pars reticularis",
-        "pars reticularis substantiae nigrae",
-        "pars reticulata",
-        "reticular part of substantia nigra",
-        "SNPR",
-        "SNR",
-        "substantia nigra reticular part",
-        "substantia nigra, pars compacta",
-        "substantia nigra, pars diffusa",
-        "substantia nigra, pars reticulata",
-        "substantia nigra, reticular division",
-        "substantia nigra, reticular part" ;
-    rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002038 ] .
+UBERON:0001964 a owl:Class ;
+    rdfs:label "least splanchnic nerve" ;
+    NIFRID:synonym "least thoracic splanchnic nerve",
+        "lowest splanchnic nerve",
+        "nervus splanchnicus imus",
+        "ramus renalis nervus splanchnici minoris",
+        "renal branch of lesser splanchnic nerve",
+        "renal nerve",
+        "thoracic splanchnic nerve" ;
+    rdfs:subClassOf UBERON:0018679 .
 
 UBERON:0001975 a owl:Class ;
     rdfs:label "serosa of esophagus" ;
@@ -9913,6 +12744,7 @@ UBERON:0001975 a owl:Class ;
         "oesophagus serosa",
         "oesophagus serous membrane",
         "serosa of abdominal part of esophagus",
+        "serosa of esophagus",
         "serosa of gullet",
         "serosa of oesophagus",
         "serous coat of oesophagus",
@@ -9930,37 +12762,40 @@ UBERON:0001975 a owl:Class ;
 
 UBERON:0001980 a owl:Class ;
     rdfs:label "arteriole" ;
-    NIFRID:synonym "arteriola" ;
+    NIFRID:synonym "arteriola",
+        "arteriole" ;
     rdfs:subClassOf UBERON:0003509,
         UBERON:8410081,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0003988 ],
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001637 ] .
 
 UBERON:0001981 a owl:Class ;
     rdfs:label "blood vessel" ;
-    NIFRID:synonym "region of vascular tree organ",
+    NIFRID:synonym "blood vessel",
+        "region of vascular tree organ",
         "vas sanguineum",
         "vascular element",
         "vascular tree organ region" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000055,
-        UBERON:0004120,
+    rdfs:subClassOf UBERON:0000055,
+        UBERON:0010000,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001213 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004535 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004537 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005629 ] .
+            owl:someValuesFrom UBERON:0004537 ] .
+
+UBERON:0001982 a owl:Class ;
+    rdfs:label "capillary" ;
+    NIFRID:synonym "blood capillary",
+        "capillary",
+        "capillary vessel" ;
+    rdfs:subClassOf UBERON:0001981,
+        UBERON:8410081 .
+
+UBERON:0001986 a owl:Class ;
+    rdfs:label "endothelium" ;
+    NIFRID:synonym "endothelium" ;
+    rdfs:subClassOf UBERON:0000487,
+        UBERON:0012275 .
 
 UBERON:0001989 a owl:Class ;
     rdfs:label "superior cervical ganglion" ;
@@ -9988,12 +12823,15 @@ UBERON:0001997 a owl:Class ;
         "nasal cavity olfactory epithelium",
         "nasal epithelium",
         "nasal sensory epithelium",
+        "olfactory epithelium",
         "olfactory membrane",
         "olfactory sensory epithelium",
         "pseudostratified main olfactory epithelium",
         "sensory olfactory epithelium" ;
     rdfs:subClassOf UBERON:0005384,
         UBERON:0006934,
+        UBERON:0010371,
+        UBERON:0010499,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000012 ],
@@ -10007,12 +12845,20 @@ UBERON:0001997 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0005725 ] .
 
+UBERON:0002000 a owl:Class ;
+    rdfs:label "gluteal muscle" ;
+    NIFRID:synonym "gluteus",
+        "gluteus muscle" ;
+    rdfs:subClassOf UBERON:0001497,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0013691 ] .
+
 UBERON:0002005 a owl:Class ;
     rdfs:label "enteric nervous system" ;
     NIFRID:synonym "enteric PNS",
         "PNS - enteric" ;
-    rdfs:subClassOf UBERON:0010313,
-        UBERON:0011216,
+    rdfs:subClassOf UBERON:0011216,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002410 ],
@@ -10039,9 +12885,13 @@ UBERON:0002012 a owl:Class ;
         "pulmonary arterial subtree",
         "pulmonary arterial tree",
         "pulmonary arterial tree organ part",
+        "pulmonary artery",
         "truncus pulmonalis" ;
     rdfs:subClassOf UBERON:0001637,
         UBERON:0013768,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0008886 ] .
@@ -10067,6 +12917,38 @@ UBERON:0002014 a owl:Class ;
         "plexus pelvicus" ;
     rdfs:subClassOf UBERON:0001816 .
 
+UBERON:0002017 a owl:Class ;
+    rdfs:label "portal vein" ;
+    NIFRID:synonym "portal vein",
+        "portal venous tree organ part" ;
+    rdfs:subClassOf UBERON:0001638,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0005806 ] .
+
+UBERON:0002019 a owl:Class ;
+    rdfs:label "accessory XI nerve" ;
+    NIFRID:synonym "accessory nerve",
+        "accessory nerve [XI]",
+        "accessory spinal nerve",
+        "accessory XI",
+        "accessory XI nerve",
+        "cervical accessory nerve",
+        "CN-XI",
+        "cranial nerve XI",
+        "eleventh cranial nerve",
+        "nervus accessorius [XI]",
+        "pars spinalis nervus accessorius",
+        "radix spinalis nervus accessorius",
+        "spinal accessory nerve",
+        "spinal accessory nerve tree",
+        "spinal part of accessory nerve",
+        "Willis' nerve" ;
+    rdfs:subClassOf UBERON:0035642,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
+
 UBERON:0002020 a owl:Class ;
     rdfs:label "gray matter" ;
     NIFRID:synonym "gray mater",
@@ -10081,10 +12963,7 @@ UBERON:0002020 a owl:Class ;
     rdfs:subClassOf UBERON:0011215,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001017 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002742 ] .
+            owl:someValuesFrom UBERON:0001017 ] .
 
 UBERON:0002022 a owl:Class ;
     rdfs:label "insula" ;
@@ -10138,8 +13017,10 @@ UBERON:0002024 a owl:Class ;
 
 UBERON:0002028 a owl:Class ;
     rdfs:label "hindbrain" ;
-    NIFRID:synonym "rhombencephalon" ;
+    NIFRID:synonym "hindbrain",
+        "rhombencephalon" ;
     rdfs:subClassOf UBERON:0002616,
+        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000955 ],
@@ -10153,6 +13034,7 @@ UBERON:0002034 a owl:Class ;
         "nucleus suprachiasmaticus hypothalami",
         "SCh",
         "SCN",
+        "suprachiasmatic nucleus",
         "suprachiasmatic nucleus (Spiegel-Zwieg)",
         "suprachiasmatic nucleus of hypothalamus" ;
     rdfs:subClassOf UBERON:0006568,
@@ -10167,23 +13049,16 @@ UBERON:0002034 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001898 ] .
 
-UBERON:0002035 a owl:Class ;
-    rdfs:label "medial preoptic nucleus" ;
-    NIFRID:synonym "area praeoptica medialis",
-        "area preopticus medialis",
-        "medial preoptic hypothalamic nucleus",
-        "MPO",
-        "nucleus praeopticus medialis",
-        "nucleus preopticus medialis" ;
-    rdfs:subClassOf UBERON:0006568,
-        UBERON:0007251,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007769 ] .
+UBERON:0002036 a owl:Class ;
+    rdfs:label "striated muscle tissue" ;
+    NIFRID:synonym "striated muscle",
+        "striated muscle tissue" ;
+    rdfs:subClassOf UBERON:0002385 .
 
 UBERON:0002037 a owl:Class ;
     rdfs:label "cerebellum" ;
-    NIFRID:synonym "corpus cerebelli",
+    NIFRID:synonym "cerebellum",
+        "corpus cerebelli",
         "epencephalon-1",
         "infratentorial region",
         "parencephalon" ;
@@ -10198,94 +13073,11 @@ UBERON:0002037 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001895 ] .
 
-UBERON:0002038 a owl:Class ;
-    rdfs:label "substantia nigra" ;
-    NIFRID:synonym "nucleus of basis pedunculi",
-        "nucleus pigmentosus subthalamo-peduncularis",
-        "SN",
-        "Soemmering's substance",
-        "substancia nigra",
-        "substantia nigra (Soemmerringi)" ;
-    rdfs:subClassOf UBERON:0009661,
-        UBERON:0015212,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001891 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002420 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002623 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0001891 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0010011 ] .
-
-UBERON:0002043 a owl:Class ;
-    rdfs:label "dorsal raphe nucleus" ;
-    NIFRID:synonym "cell group b7",
-        "dorsal nucleus of the raphe",
-        "dorsal nucleus raphe",
-        "dorsal raphe",
-        "dorsal raphé",
-        "DR",
-        "DRN",
-        "inferior raphe nucleus",
-        "nucleus dorsalis raphes",
-        "nucleus raphe dorsalis",
-        "nucleus raphe posterior",
-        "nucleus raphes dorsalis",
-        "nucleus raphes posterior",
-        "posterior raphe nucleus" ;
-    rdfs:subClassOf UBERON:0007415,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002639 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004684 ] .
-
-UBERON:0002045 a owl:Class ;
-    rdfs:label "cuneate nucleus" ;
-    NIFRID:synonym "Burdach's nucleus",
-        "burdachs nucleus",
-        "Cu",
-        "cuneate",
-        "cuneate nucleus (Burdach)",
-        "cuneate nucleus of the medulla",
-        "nucleus cuneatus",
-        "nucleus cuneatus medialis",
-        "nucleus restiformis" ;
-    rdfs:subClassOf UBERON:0018238,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001896 ] .
-
-UBERON:0002047 a owl:Class ;
-    rdfs:label "pontine raphe nucleus" ;
-    NIFRID:synonym "nucleus raphe pontis",
-        "nucleus raphes pontis",
-        "raphe (mediana pontina)",
-        "raphe of pons",
-        "raphe pontis",
-        "raphe pontis nucleus" ;
-    rdfs:subClassOf UBERON:0006331,
-        UBERON:0009662,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0003023 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004684 ] .
-
 UBERON:0002048 a owl:Class ;
     rdfs:label "lung" ;
-    NIFRID:synonym "pulmo" ;
+    NIFRID:synonym "lung",
+        "pulmo" ;
     rdfs:subClassOf UBERON:0000171,
-        UBERON:0004119,
         UBERON:0005178,
         UBERON:0015212,
         [ a owl:Restriction ;
@@ -10297,35 +13089,12 @@ UBERON:0002048 a owl:Class ;
 
 UBERON:0002049 a owl:Class ;
     rdfs:label "vasculature" ;
-    NIFRID:synonym "vascular network" ;
+    NIFRID:synonym "vascular network",
+        "vasculature" ;
     rdfs:subClassOf UBERON:0000477,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004708 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007798 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0016630 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0034929 ] .
-
-UBERON:0002050 a owl:Class ;
-    rdfs:label "embryonic structure" ;
-    NIFRID:synonym "developing embryonic structure",
-        "developing structure",
-        "embryonale Struktur",
-        "embryonic anatomical structure",
-        "embryonic structures" ;
-    rdfs:subClassOf UBERON:0005423,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000922 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004716 ] .
+            owl:someValuesFrom UBERON:0007798 ] .
 
 UBERON:0002058 a owl:Class ;
     rdfs:label "main ciliary ganglion" ;
@@ -10353,33 +13122,14 @@ UBERON:0002059 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000011 ] .
 
-UBERON:0002072 a owl:Class ;
-    rdfs:label "hypodermis" ;
-    NIFRID:synonym "hypoderm",
-        "sub-tegumental tissue",
-        "subcutaneous tissue",
-        "subcutis",
-        "subtegumental tissue",
-        "superficial fascia",
-        "tela subcutanea",
-        "vertebrate hypodermis" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0004120,
-        UBERON:0013754,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002199 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0012125 ] .
-
 UBERON:0002075 a owl:Class ;
     rdfs:label "viscus" ;
     NIFRID:synonym "splanchnic tissue",
         "viscera",
         "visceral organ",
         "visceral organ system",
-        "visceral tissue" ;
+        "visceral tissue",
+        "viscus" ;
     rdfs:subClassOf UBERON:0005177,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -10394,7 +13144,10 @@ UBERON:0002078 a owl:Class ;
         "right atrium of heart",
         "right cardiac atrium" ;
     rdfs:subClassOf UBERON:0002081,
-        UBERON:0035554 .
+        UBERON:0035554,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
 
 UBERON:0002079 a owl:Class ;
     rdfs:label "left cardiac atrium" ;
@@ -10405,17 +13158,24 @@ UBERON:0002079 a owl:Class ;
         "left atrium of heart",
         "left cardiac atrium" ;
     rdfs:subClassOf UBERON:0002081,
-        UBERON:0035553 .
+        UBERON:0035553,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
 
 UBERON:0002080 a owl:Class ;
     rdfs:label "heart right ventricle" ;
     NIFRID:synonym "cardiac right ventricle",
+        "heart right ventricle",
         "right cardiac ventricle",
         "right ventricle",
         "right ventricle of heart",
         "ventriculus dexter" ;
     rdfs:subClassOf UBERON:0002082,
-        UBERON:0035554 .
+        UBERON:0035554,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
 
 UBERON:0002081 a owl:Class ;
     rdfs:label "cardiac atrium" ;
@@ -10424,19 +13184,23 @@ UBERON:0002081 a owl:Class ;
         "atrium",
         "atrium of heart",
         "cardiac atria",
+        "cardiac atrium",
         "heart atrium" ;
-    rdfs:subClassOf UBERON:0004151,
+    rdfs:subClassOf UBERON:0004120,
+        UBERON:0004151,
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000948 ] .
 
 UBERON:0002082 a owl:Class ;
     rdfs:label "cardiac ventricle" ;
-    NIFRID:synonym "heart ventricle",
+    NIFRID:synonym "cardiac ventricle",
+        "heart ventricle",
         "lower chamber of heart",
         "ventricle",
         "ventricle of heart" ;
-    rdfs:subClassOf UBERON:0004151,
+    rdfs:subClassOf UBERON:0004120,
+        UBERON:0004151,
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000948 ] .
@@ -10444,12 +13208,30 @@ UBERON:0002082 a owl:Class ;
 UBERON:0002084 a owl:Class ;
     rdfs:label "heart left ventricle" ;
     NIFRID:synonym "cardiac left ventricle",
+        "heart left ventricle",
         "left cardiac ventricle",
         "left ventricle",
         "left ventricle of heart",
         "ventriculus sinister cordis" ;
     rdfs:subClassOf UBERON:0002082,
-        UBERON:0035553 .
+        UBERON:0035553,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
+
+UBERON:0002091 a owl:Class ;
+    rdfs:label "appendicular skeleton" ;
+    NIFRID:synonym "appendicular skeleton",
+        "entire appendicular skeleton",
+        "paired fin skeleton",
+        "skeleton appendiculare" ;
+    rdfs:subClassOf UBERON:0010912,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0011249 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001434 ] .
 
 UBERON:0002095 a owl:Class ;
     rdfs:label "mesentery" ;
@@ -10457,11 +13239,28 @@ UBERON:0002095 a owl:Class ;
         "mesentery (generic)" ;
     rdfs:subClassOf UBERON:0000042 .
 
+UBERON:0002097 a owl:Class ;
+    rdfs:label "skin of body" ;
+    NIFRID:synonym "entire integument",
+        "entire skin",
+        "integument",
+        "integumental organ",
+        "pelt",
+        "skin",
+        "skin of body",
+        "skin organ" ;
+    rdfs:subClassOf UBERON:0000062,
+        UBERON:0010314,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002199 ] .
+
 UBERON:0002100 a owl:Class ;
     rdfs:label "trunk" ;
     NIFRID:synonym "Rumpf",
         "thoracolumbar region",
         "torso",
+        "trunk",
         "trunk region" ;
     rdfs:subClassOf UBERON:0011676,
         [ a owl:Restriction ;
@@ -10479,10 +13278,55 @@ UBERON:0002101 a owl:Class ;
         "tetrapod limb" ;
     rdfs:subClassOf UBERON:0004708 .
 
+UBERON:0002102 a owl:Class ;
+    rdfs:label "forelimb" ;
+    NIFRID:synonym "anteriormost limb",
+        "fore limb",
+        "foreleg",
+        "forelimb",
+        "free part of upper limb",
+        "free upper limb",
+        "membrum superius",
+        "pectoral flipper",
+        "pectoral limb",
+        "superior member",
+        "upper extremity",
+        "upper limb" ;
+    rdfs:subClassOf UBERON:0002101,
+        UBERON:0004710,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000153 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010708 ] .
+
+UBERON:0002103 a owl:Class ;
+    rdfs:label "hindlimb" ;
+    NIFRID:synonym "free lower limb",
+        "free part of lower limb",
+        "hind limb",
+        "hind-limb",
+        "hindlimb",
+        "inferior member",
+        "lower extremity",
+        "lower limb",
+        "membrum inferius",
+        "pelvic appendage" ;
+    rdfs:subClassOf UBERON:0002101,
+        UBERON:0004709,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000154 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010709 ] .
+
 UBERON:0002104 a owl:Class ;
     rdfs:label "visual system" ;
     NIFRID:synonym "photosensory system",
-        "visual organ system" ;
+        "visual organ system",
+        "visual system" ;
     rdfs:subClassOf UBERON:0001032 .
 
 UBERON:0002105 a owl:Class ;
@@ -10490,22 +13334,20 @@ UBERON:0002105 a owl:Class ;
     NIFRID:synonym "auditory organ system",
         "auditory system",
         "auditory/vestibular system",
+        "vestibulo-auditory system",
         "vestibuloauditory system" ;
     rdfs:subClassOf UBERON:0001032 .
 
 UBERON:0002106 a owl:Class ;
     rdfs:label "spleen" ;
-    NIFRID:synonym "lien" ;
+    NIFRID:synonym "lien",
+        "spleen" ;
     rdfs:subClassOf UBERON:0004177,
         UBERON:0005057,
-        UBERON:0013765,
         UBERON:0017672,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000916 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001007 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002390 ],
@@ -10516,7 +13358,8 @@ UBERON:0002106 a owl:Class ;
 UBERON:0002107 a owl:Class ;
     rdfs:label "liver" ;
     NIFRID:synonym "iecur",
-        "jecur" ;
+        "jecur",
+        "liver" ;
     rdfs:subClassOf UBERON:0002365,
         UBERON:0004119,
         UBERON:0005172,
@@ -10577,6 +13420,7 @@ UBERON:0002112 a owl:Class ;
         "oesophagus non-striated muscle",
         "oesophagus smooth muscle",
         "oesophagus smooth muscle tissue",
+        "smooth muscle of esophagus",
         "smooth muscle of gullet",
         "smooth muscle of oesophagus",
         "smooth muscle tissue of esophagus",
@@ -10593,33 +13437,73 @@ UBERON:0002112 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001043 ] .
 
+UBERON:0002113 a owl:Class ;
+    rdfs:label "kidney" ;
+    NIFRID:synonym "reniculate kidney" ;
+    rdfs:subClassOf UBERON:0000489,
+        UBERON:0005172,
+        UBERON:0015212,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000916 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0011143 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001008 ] .
+
+UBERON:0002114 a owl:Class ;
+    rdfs:label "duodenum" ;
+    NIFRID:synonym "duodenum",
+        "proximal intestine",
+        "upper intestine" ;
+    rdfs:subClassOf UBERON:0004921,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002108 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002108 ] .
+
+UBERON:0002115 a owl:Class ;
+    rdfs:label "jejunum" ;
+    NIFRID:synonym "intestinum jejunum",
+        "mid-intestine",
+        "middle intestine" ;
+    rdfs:subClassOf UBERON:0004921,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002108 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002108 ] .
+
+UBERON:0002116 a owl:Class ;
+    rdfs:label "ileum" ;
+    NIFRID:synonym "distal intestine",
+        "intestinum ileum",
+        "lower intestine",
+        "posterior intestine" ;
+    rdfs:subClassOf UBERON:0004921,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002108 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002108 ] .
+
 UBERON:0002118 a owl:Class ;
     rdfs:label "right ovary" ;
+    NIFRID:synonym "right ovary" ;
     rdfs:subClassOf UBERON:0000992,
         UBERON:0015212 .
 
 UBERON:0002119 a owl:Class ;
     rdfs:label "left ovary" ;
+    NIFRID:synonym "left ovary" ;
     rdfs:subClassOf UBERON:0000992,
         UBERON:0015212 .
-
-UBERON:0002125 a owl:Class ;
-    rdfs:label "thymus lobule" ;
-    NIFRID:synonym "lobule of thymus",
-        "thymic lobule",
-        "thymus lobule" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000077,
-        UBERON:0009911,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002370 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005483 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0002370 ] .
 
 UBERON:0002126 a owl:Class ;
     rdfs:label "solitary tract nuclear complex" ;
@@ -10637,6 +13521,7 @@ UBERON:0002128 a owl:Class ;
         "superior olivary complex" ;
     NIFRID:synonym "nucleus olivaris superior",
         "regio olivaris superioris",
+        "superior olivary complex",
         "superior olivary nuclei",
         "superior olivary nucleus",
         "superior olivary nucleus (Barr & Kiernan)",
@@ -10661,7 +13546,8 @@ UBERON:0002128 a owl:Class ;
 
 UBERON:0002129 a owl:Class ;
     rdfs:label "cerebellar cortex" ;
-    NIFRID:synonym "cortex cerebellaris",
+    NIFRID:synonym "cerebellar cortex",
+        "cortex cerebellaris",
         "cortex cerebelli",
         "cortex of cerebellar hemisphere" ;
     rdfs:subClassOf UBERON:0019263,
@@ -10675,6 +13561,7 @@ UBERON:0002129 a owl:Class ;
 UBERON:0002130 a owl:Class ;
     rdfs:label "cerebellar nuclear complex" ;
     NIFRID:synonym "central nuclei",
+        "cerebellar nuclear complex",
         "cerebellar nuclei",
         "deep cerebellar nuclear complex",
         "deep cerebellar nuclei",
@@ -10689,21 +13576,6 @@ UBERON:0002130 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002037 ] .
-
-UBERON:0002136 a owl:Class ;
-    rdfs:label "hilus of dentate gyrus" ;
-    NIFRID:synonym "CA4",
-        "dentate gyrus hilus",
-        "field CA4 of hippocampal formation",
-        "hilus gyri dentati",
-        "hilus of the dentate gyrus",
-        "multiform layer of dentate gyrus",
-        "polymorphic later of dentate gyrus",
-        "region CA4" ;
-    rdfs:subClassOf UBERON:0005401,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001885 ] .
 
 UBERON:0002141 a owl:Class ;
     rdfs:label "parvocellular oculomotor nucleus" ;
@@ -10734,52 +13606,12 @@ UBERON:0002142 a owl:Class ;
         "nucleus tegmenti pedunculopontinus",
         "peduncular pontine nucleus",
         "pedunculopontine nucleus",
+        "pedunculopontine tegmental nucleus",
         "PPTg" ;
     rdfs:subClassOf UBERON:0007415,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002639 ] .
-
-UBERON:0002145 a owl:Class ;
-    rdfs:label "interpeduncular nucleus" ;
-    NIFRID:synonym "interpedunclear nucleus",
-        "interpeduncular ganglion",
-        "interpeduncular nuclei",
-        "interpeduncular nucleus (Gudden)",
-        "interpeduncular nucleus of midbrain",
-        "interpeduncular nucleus tegmentum",
-        "IP",
-        "nucleus interpeduncularis",
-        "nucleus interpeduncularis medialis" ;
-    rdfs:subClassOf UBERON:0006331,
-        UBERON:0007414,
-        UBERON:0009661,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001943 ] .
-
-UBERON:0002148 a owl:Class ;
-    rdfs:label "locus ceruleus" ;
-    NIFRID:synonym "blue nucleus",
-        "caerulean nucleus",
-        "loci coeruleus",
-        "locus caeruleus",
-        "locus cinereus",
-        "locus coeruleu",
-        "locus coeruleus",
-        "locus coeruleus (Vicq d'Azyr)",
-        "Noradrenergic cell group A6",
-        "nucleus caeruleus",
-        "nucleus loci caerulei",
-        "nucleus of locus caeruleus",
-        "nucleus pigmentosus pontis",
-        "substantia ferruginea" ;
-    rdfs:subClassOf UBERON:0006331,
-        UBERON:0009662,
-        UBERON:8440015,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0003023 ] .
 
 UBERON:0002149 a owl:Class ;
     rdfs:label "superior salivatory nucleus" ;
@@ -10787,8 +13619,10 @@ UBERON:0002149 a owl:Class ;
         "nucleus salivatorius cranialis",
         "nucleus salivatorius rostralis",
         "nucleus salivatorius superior",
-        "superior salivary nucleus" ;
+        "superior salivary nucleus",
+        "superior salivatory nucleus" ;
     rdfs:subClassOf UBERON:0000126,
+        UBERON:0004121,
         UBERON:0004133,
         UBERON:0007635,
         [ a owl:Restriction ;
@@ -10798,79 +13632,19 @@ UBERON:0002149 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0003023 ] .
 
-UBERON:0002151 a owl:Class ;
-    rdfs:label "pontine nuclear group" ;
-    NIFRID:synonym "nuclei brachii pontis",
-        "nuclei pontis",
-        "nucleus pontis",
-        "pontine gray",
-        "pontine gray matter",
-        "pontine grey matter",
-        "pontine nuclear complex",
-        "pontine nuclear group",
-        "pontine nuclei",
-        "pontine nucleus" ;
-    rdfs:subClassOf UBERON:0006331,
-        UBERON:0009662,
+UBERON:0002165 a owl:Class ;
+    rdfs:label "endocardium" ;
+    NIFRID:synonym "endocardial lining",
+        "endocardial tissue",
+        "endocardium",
+        "heart endocardial tissue",
+        "heart endocardium" ;
+    rdfs:subClassOf UBERON:0002523,
+        UBERON:0004120,
+        UBERON:0005983,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002567 ] .
-
-UBERON:0002155 a owl:Class ;
-    rdfs:label "gigantocellular nucleus" ;
-    NIFRID:synonym "gigantocellular group",
-        "gigantocellular reticular nuclei",
-        "gigantocellular reticular nucleus",
-        "nucleus gigantocellularis",
-        "nucleus reticularis gigantocellularis" ;
-    rdfs:subClassOf UBERON:0007635,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001896 ] .
-
-UBERON:0002160 a owl:Class ;
-    rdfs:label "nucleus prepositus" ;
-    NIFRID:synonym "nucleus praepositus",
-        "nucleus praepositus hypoglossi",
-        "nucleus prepositus hypoglossi",
-        "nucleus prepositus hypoglossus",
-        "prepositus hypoglossal nucleus",
-        "prepositus nucleus",
-        "prepositus nucleus (Marburg)",
-        "PrP" ;
-    rdfs:subClassOf UBERON:0007635,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000988 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001896 ] .
-
-UBERON:0002161 a owl:Class ;
-    rdfs:label "gracile nucleus" ;
-    NIFRID:synonym "Goll's nucleus",
-        "golls nucleus",
-        "gracile nucleus (Goll)",
-        "gracile nucleus of the medulla",
-        "gracile nucleus, general",
-        "gracile nucleus, principal part",
-        "nucleus gracilis" ;
-    rdfs:subClassOf UBERON:0018238,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001896 ] .
-
-UBERON:0002162 a owl:Class ;
-    rdfs:label "area postrema" ;
-    NIFRID:synonym "AP",
-        "chemoreceptor trigger zone" ;
-    rdfs:subClassOf UBERON:0010135,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001896 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002422 ] .
+            owl:someValuesFrom UBERON:0000948 ] .
 
 UBERON:0002175 a owl:Class ;
     rdfs:label "intermediolateral nucleus" ;
@@ -10895,11 +13669,30 @@ UBERON:0002180 a owl:Class ;
     rdfs:subClassOf UBERON:0006127,
         UBERON:0015212 .
 
+UBERON:0002181 a owl:Class ;
+    rdfs:label "substantia gelatinosa" ;
+    NIFRID:synonym "central gelatinous substance of spinal cord",
+        "gelatinous substance of dorsal horn of spinal cord",
+        "gelatinous substance of posterior horn of spinal cord",
+        "gelatinous substance of Rolando",
+        "lamina II of gray matter of spinal cord",
+        "lamina spinalis II",
+        "rexed lamina II",
+        "spinal lamina II",
+        "substantia gelatinosa cornu posterioris medullae spinalis",
+        "substantia gelatinosa of spinal cord dorsal horn",
+        "substantia gelatinosa of spinal cord posterior horn" ;
+    rdfs:subClassOf UBERON:0016570,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002256 ] .
+
 UBERON:0002185 a owl:Class ;
     rdfs:label "bronchus" ;
     NIFRID:synonym "bronchi",
         "bronchial tissue",
-        "bronchial trunk" ;
+        "bronchial trunk",
+        "bronchus" ;
     rdfs:subClassOf UBERON:0000117,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -10915,7 +13708,7 @@ UBERON:0002186 a owl:Class ;
             owl:someValuesFrom UBERON:0002048 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0010368 ] .
+            owl:someValuesFrom UBERON:0007196 ] .
 
 UBERON:0002187 a owl:Class ;
     rdfs:label "terminal bronchiole" ;
@@ -10925,34 +13718,16 @@ UBERON:0002187 a owl:Class ;
     rdfs:subClassOf UBERON:0002186,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0010368 ],
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0010369 ] .
-
-UBERON:0002190 a owl:Class ;
-    rdfs:label "subcutaneous adipose tissue" ;
-    NIFRID:synonym "fatty layer of subcutaneous tissue",
-        "fatty layer of superficial fascia",
-        "hypodermis fat layer",
-        "panniculus adiposus",
-        "panniculus adiposus (tela subcutanea)",
-        "panniculus adiposus telae subcutaneae",
-        "subcutaneous fat",
-        "subcutaneous fat layer" ;
-    rdfs:subClassOf UBERON:0001013,
-        UBERON:0004120,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002072 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0002072 ] .
 
 UBERON:0002191 a owl:Class ;
     rdfs:label "subiculum" ;
     NIFRID:synonym "gyrus parahippocampalis",
         "subicular cortex",
+        "subiculum",
         "subiculum cornu ammonis",
         "subiculum hippocampi" ;
     rdfs:subClassOf UBERON:0002616,
@@ -10964,60 +13739,16 @@ UBERON:0002193 a owl:Class ;
     rdfs:label "hemolymphoid system" ;
     NIFRID:synonym "haemolymphoid system",
         "hematolymphoid system",
+        "hemolymphoid system",
         "lymphomyeloid complex" ;
     rdfs:subClassOf UBERON:0000467 .
-
-UBERON:0002197 a owl:Class ;
-    rdfs:label "median eminence of neurohypophysis" ;
-    NIFRID:synonym "eminentia medialis (Shantha)",
-        "eminentia mediana",
-        "eminentia mediana hypothalami",
-        "eminentia postinfundibularis",
-        "ME",
-        "medial eminence",
-        "median eminence",
-        "median eminence of hypothalamus",
-        "median eminence of posterior lobe of pituitary gland",
-        "median eminence of tuber cinereum" ;
-    rdfs:subClassOf UBERON:0003296,
-        UBERON:0010134,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002198 ] .
-
-UBERON:0002198 a owl:Class ;
-    rdfs:label "neurohypophysis" ;
-    NIFRID:synonym "infundibular process",
-        "lobus nervosus",
-        "lobus nervosus neurohypophysis",
-        "lobus posterior",
-        "lobus posterior (glandula pituitaria)",
-        "lobus posterior hypophysis",
-        "neural lobe",
-        "neural lobe of pituitary",
-        "neural lobe of pituitary gland",
-        "neuro hypophysis",
-        "neurohypophysis",
-        "NHP",
-        "pituitary gland neural lobe",
-        "pituitary gland, neural lobe",
-        "pituitary gland, posterior lobe",
-        "posterior lobe of hypophysis",
-        "posterior lobe of pituitary",
-        "posterior lobe of pituitary gland",
-        "posterior pituitary",
-        "posterior pituitary gland" ;
-    rdfs:subClassOf UBERON:0003296,
-        UBERON:0010134,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000007 ] .
 
 UBERON:0002199 a owl:Class ;
     rdfs:label "integument" ;
     NIFRID:synonym "dermal system",
         "dermis plus epidermis plus hypodermis",
         "dermoid system",
+        "integument",
         "integumentum commune",
         "skin",
         "skin and subcutaneous tissue",
@@ -11025,67 +13756,71 @@ UBERON:0002199 a owl:Class ;
         "tegument",
         "the integument",
         "vertebrate integument" ;
-    rdfs:subClassOf PR:000050567,
+    rdfs:subClassOf UBERON:0010314,
         UBERON:0011216,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002416 ] .
 
+UBERON:0002200 a owl:Class ;
+    rdfs:label "vasculature of head" ;
+    NIFRID:synonym "adult head vascular network",
+        "adult head vasculature",
+        "cranial vasculature",
+        "head vascular network",
+        "head vasculature",
+        "vascular network of adult head",
+        "vascular network of head",
+        "vasculature of adult head",
+        "vasculature of head" ;
+    rdfs:subClassOf UBERON:0002049,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000033 ] .
+
+UBERON:0002201 a owl:Class ;
+    rdfs:label "vasculature of trunk" ;
+    NIFRID:synonym "torso vascular network",
+        "torso vasculature",
+        "trunk vascular network",
+        "trunk vasculature",
+        "vascular network of torso",
+        "vascular network of trunk",
+        "vasculature of torso",
+        "vasculature of trunk" ;
+    rdfs:subClassOf UBERON:0002049,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002100 ] .
+
 UBERON:0002204 a owl:Class ;
     rdfs:label "musculoskeletal system" ;
-    NIFRID:synonym "musculo-skeletal system" ;
+    NIFRID:synonym "musculo-skeletal system",
+        "musculoskeletal system" ;
     rdfs:subClassOf UBERON:0000467 .
-
-UBERON:0002206 a owl:Class ;
-    rdfs:label "mammillary body" ;
-    NIFRID:synonym "corpora mamillaria",
-        "corpora mammillaria",
-        "corpus mamillare",
-        "corpus mamillaris",
-        "corpus mammillare",
-        "mammillary area",
-        "MMB" ;
-    rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000349 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002272 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002770 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0001894 ] .
-
-UBERON:0002209 a owl:Class ;
-    rdfs:label "fibrous joint" ;
-    NIFRID:synonym "articulatio fibrosa",
-        "junctura fibrosa" ;
-    rdfs:subClassOf UBERON:0011134 .
 
 UBERON:0002211 a owl:Class ;
     rdfs:label "nerve root" ;
     NIFRID:synonym "initial segment of nerve",
+        "nerve root",
         "radix nervi" ;
     rdfs:subClassOf UBERON:0000122,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001016 ] .
 
-UBERON:0002213 a owl:Class ;
-    rdfs:label "cartilaginous joint" ;
-    NIFRID:synonym "articulatio cartilaginea",
-        "junctura cartilaginea" ;
-    rdfs:subClassOf UBERON:0011134 .
-
-UBERON:0002216 a owl:Class ;
-    rdfs:label "symphysis" ;
-    NIFRID:synonym "secondary cartilaginous joint" ;
-    rdfs:subClassOf UBERON:0002209,
-        UBERON:0002213 .
+UBERON:0002217 a owl:Class ;
+    rdfs:label "synovial joint" ;
+    NIFRID:synonym "articulatio synoviale",
+        "diarthrodial joints",
+        "diarthroses",
+        "diarthrosis",
+        "diarthrosis joint",
+        "synovial joint" ;
+    rdfs:subClassOf UBERON:0000982 .
 
 UBERON:0002227 a owl:Class ;
     rdfs:label "spiral organ of cochlea" ;
@@ -11100,7 +13835,6 @@ UBERON:0002227 a owl:Class ;
         "spiral organ",
         "spiral organ of Corti" ;
     rdfs:subClassOf UBERON:0000020,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001855 ] .
@@ -11113,6 +13847,7 @@ UBERON:0002240 a owl:Class ;
         "fissura cerebrocerebellaris",
         "medulla spinalis",
         "SpC",
+        "spinal cord",
         "spinal cord structure",
         "spinal medulla" ;
     rdfs:subClassOf UBERON:0000489,
@@ -11129,8 +13864,18 @@ UBERON:0002240 a owl:Class ;
 UBERON:0002241 a owl:Class ;
     rdfs:label "chondrocranium" ;
     NIFRID:synonym "calvarium",
+        "chondrocranium",
         "neurocranium" ;
     rdfs:subClassOf UBERON:0011159 .
+
+UBERON:0002252 a owl:Class ;
+    rdfs:label "splenius" ;
+    NIFRID:synonym "splenius muscle" ;
+    rdfs:subClassOf UBERON:0002324,
+        UBERON:0004518,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001137 ] .
 
 UBERON:0002256 a owl:Class ;
     rdfs:label "dorsal horn of spinal cord" ;
@@ -11215,7 +13960,6 @@ UBERON:0002259 a owl:Class ;
         "quadrigeminal body",
         "set of colliculi" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002314 ],
@@ -11274,24 +14018,12 @@ UBERON:0002262 a owl:Class ;
     NIFRID:synonym "coeliac ganglion" ;
     rdfs:subClassOf UBERON:0003964 .
 
-UBERON:0002263 a owl:Class ;
-    rdfs:label "lentiform nucleus" ;
-    NIFRID:synonym "lenticular nucleus",
-        "nucleus lenticularis",
-        "nucleus lentiformis" ;
-    rdfs:subClassOf UBERON:0009663,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000369 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005403 ] .
-
 UBERON:0002264 a owl:Class ;
     rdfs:label "Olfactory bulb",
         "olfactory bulb" ;
     NIFRID:synonym "bulbus olfactorius",
         "bulbus olfactorius (Morgagni)",
+        "olfactory bulb",
         "olfactory lobe",
         "olfactory lobe (Barr & Kiernan)" ;
     rdfs:subClassOf UBERON:0002616,
@@ -11312,17 +14044,6 @@ UBERON:0002264 a owl:Class ;
     ilxtr:hasIlxId ILX:0107921 ;
     ilxtr:hasIlxPreferredId UBERON:0002264 .
 
-UBERON:0002267 a owl:Class ;
-    rdfs:label "laterodorsal tegmental nucleus" ;
-    NIFRID:synonym "anterodorsal tegmental nucleus",
-        "lateroposterior tegmental nucleus",
-        "nucleus tegmentalis posterolateralis" ;
-    rdfs:subClassOf UBERON:0006331,
-        UBERON:0007414,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002298 ] .
-
 UBERON:0002268 a owl:Class ;
     rdfs:label "olfactory organ" ;
     NIFRID:synonym "main olfactory organ",
@@ -11338,10 +14059,10 @@ UBERON:0002268 a owl:Class ;
 UBERON:0002271 a owl:Class ;
     rdfs:label "periventricular zone of hypothalamus" ;
     NIFRID:synonym "hypothalamus periventricular zone",
+        "periventricular zone of hypothalamus",
         "periventricular zone of the hypothalamus",
         "zona periventricularis hypothalamicae" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001898 ] .
@@ -11350,10 +14071,10 @@ UBERON:0002272 a owl:Class ;
     rdfs:label "medial zone of hypothalamus" ;
     NIFRID:synonym "hypothalamic medial zone behavioral control column",
         "hypothalamus medial zone",
+        "medial zone of hypothalamus",
         "medial zone of the hypothalamus",
         "zona medialis hypothalamicae" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001898 ] .
@@ -11362,10 +14083,10 @@ UBERON:0002273 a owl:Class ;
     rdfs:label "lateral zone of hypothalamus" ;
     NIFRID:synonym "hypothalamic lateral zone",
         "hypothalamus lateral zone",
+        "lateral zone of hypothalamus",
         "lateral zone of the hypothalamus",
         "zona lateralis hypothalamicae" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001898 ] .
@@ -11374,6 +14095,7 @@ UBERON:0002275 a owl:Class ;
     rdfs:label "reticular formation" ;
     NIFRID:synonym "brain stem reticular formation",
         "brainstem reticular formation",
+        "reticular formation",
         "reticular formation (classical)",
         "reticular formation of the brainstem" ;
     rdfs:subClassOf UBERON:0002616,
@@ -11381,33 +14103,29 @@ UBERON:0002275 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002298 ] .
 
-UBERON:0002285 a owl:Class ;
-    rdfs:label "telencephalic ventricle" ;
-    NIFRID:synonym "forebrain ventricle",
-        "lateral ventricle",
-        "lateral ventricle of brain",
-        "lateral ventricles",
-        "tectal ventricle",
-        "telencephalic ventricle",
-        "telencephalic ventricles",
-        "telencephalic vesicle",
-        "telencephalon lateral ventricle" ;
-    rdfs:subClassOf UBERON:0004086,
+UBERON:0002294 a owl:Class ;
+    rdfs:label "biliary system" ;
+    NIFRID:synonym "biliary apparatus",
+        "biliary system",
+        "biliary tract" ;
+    rdfs:subClassOf UBERON:0011216,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001893 ] .
+            owl:someValuesFrom UBERON:0002423 ] .
 
 UBERON:0002298 a owl:Class ;
     rdfs:label "brainstem" ;
     NIFRID:synonym "accessory medullary lamina of pallidum",
         "brain stem",
+        "brainstem",
         "lamella pallidi incompleta",
         "lamina medullaris accessoria",
         "lamina medullaris incompleta pallidi",
         "lamina pallidi incompleta",
         "truncus encephali",
         "truncus encephalicus" ;
-    rdfs:subClassOf UBERON:0002616,
+    rdfs:subClassOf UBERON:0000481,
+        UBERON:0002616,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000955 ],
@@ -11428,10 +14146,34 @@ UBERON:0002301 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001950 ] .
 
+UBERON:0002302 a owl:Class ;
+    rdfs:label "myocardium of atrium" ;
+    NIFRID:synonym "atrial myocardium",
+        "atrium cardiac muscle",
+        "atrium myocardium",
+        "myocardium of atrium" ;
+    rdfs:subClassOf UBERON:0002349,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002081 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002081 ] .
+
+UBERON:0002303 a owl:Class ;
+    rdfs:label "juxtaglomerular apparatus" ;
+    NIFRID:synonym "complexus juxtaglomerularis",
+        "juxtaglomerular complex" ;
+    rdfs:subClassOf UBERON:0000061,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001225 ] .
+
 UBERON:0002304 a owl:Class ;
     rdfs:label "layer of dentate gyrus" ;
     NIFRID:synonym "dentate gyrus cell layer",
-        "dentate gyrus layer" ;
+        "dentate gyrus layer",
+        "layer of dentate gyrus" ;
     rdfs:subClassOf UBERON:0011215,
         UBERON:0022303,
         [ a owl:Restriction ;
@@ -11439,12 +14181,12 @@ UBERON:0002304 a owl:Class ;
             owl:someValuesFrom UBERON:0001885 ] .
 
 UBERON:0002305 a owl:Class ;
-    rdfs:label "Cytoarchitectural fields of hippocampal formation",
-        "layer of hippocampus" ;
+    rdfs:label "layer of hippocampus" ;
     NIFRID:synonym "cytoarchitectural fields of hippocampal formation",
         "hippocampus layer",
         "hippocampus proper layer",
-        "layer of cornu ammonis" ;
+        "layer of cornu ammonis",
+        "layer of hippocampus" ;
     rdfs:subClassOf UBERON:0011215,
         UBERON:0016548,
         [ a owl:Restriction ;
@@ -11457,7 +14199,8 @@ UBERON:0002305 a owl:Class ;
 UBERON:0002308 a owl:Class ;
     rdfs:label "nucleus of brain" ;
     NIFRID:synonym "brain nuclei",
-        "brain nucleus" ;
+        "brain nucleus",
+        "nucleus of brain" ;
     rdfs:subClassOf UBERON:0000125,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -11480,6 +14223,7 @@ UBERON:0002313 a owl:Class ;
         "hippocampal pyramidal cell layer",
         "hippocampal pyramidal layer",
         "hippocampus pyramidal cell layer",
+        "hippocampus pyramidal layer",
         "hippocampus stratum pyramidale",
         "pyramidal cell layer of the hippocampus",
         "pyramidal layer of hippocampus",
@@ -11490,6 +14234,7 @@ UBERON:0002313 a owl:Class ;
 UBERON:0002314 a owl:Class ;
     rdfs:label "midbrain tectum" ;
     NIFRID:synonym "mesencephalic tectum",
+        "midbrain tectum",
         "neuraxis tectum",
         "t. mesencephali",
         "tectum",
@@ -11527,15 +14272,13 @@ UBERON:0002316 a owl:Class ;
         "neuronal white matter",
         "substantia alba",
         "white mater",
+        "white matter",
         "white matter of neuraxis",
         "white substance" ;
     rdfs:subClassOf UBERON:0011215,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001017 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002742 ] .
+            owl:someValuesFrom UBERON:0001017 ] .
 
 UBERON:0002318 a owl:Class ;
     rdfs:label "white matter of spinal cord" ;
@@ -11544,6 +14287,7 @@ UBERON:0002318 a owl:Class ;
         "spinal cord white substance",
         "substantia alba medullae spinalis",
         "white matter of neuraxis of spinal cord",
+        "white matter of spinal cord",
         "white substance of spinal cord" ;
     rdfs:subClassOf UBERON:0002316,
         [ a owl:Restriction ;
@@ -11553,26 +14297,71 @@ UBERON:0002318 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0002240 ] .
 
+UBERON:0002324 a owl:Class ;
+    rdfs:label "muscle of back" ;
+    NIFRID:synonym "back muscle",
+        "back muscle organ",
+        "muscle of back",
+        "muscle organ of back" ;
+    rdfs:subClassOf UBERON:0001774,
+        UBERON:0005174,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001137 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004469 ] .
+
 UBERON:0002330 a owl:Class ;
     rdfs:label "exocrine system" ;
-    NIFRID:synonym "exocrine glandular system" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000467 .
+    NIFRID:synonym "exocrine glandular system",
+        "exocrine system" ;
+    rdfs:subClassOf UBERON:0000467 .
+
+UBERON:0002343 a owl:Class ;
+    rdfs:label "abdomen musculature" ;
+    NIFRID:synonym "abdomen musculature",
+        "abdominal musculature",
+        "muscle group of abdomen",
+        "muscles of abdomen",
+        "musculature of abdomen",
+        "musculature of abdominal wall",
+        "set of muscles of abdomen" ;
+    rdfs:subClassOf UBERON:0004479,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000916 ] .
 
 UBERON:0002348 a owl:Class ;
     rdfs:label "epicardium" ;
-    NIFRID:synonym "heart epicardium",
+    NIFRID:synonym "epicardium",
+        "heart epicardium",
         "pericardium visceral mesothelium",
         "visceral serous pericardium of heart",
         "visceral serous pericardium proper" ;
     rdfs:subClassOf UBERON:0000481,
-        UBERON:0004120,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000948 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002425 ] .
+
+UBERON:0002349 a owl:Class ;
+    rdfs:label "myocardium" ;
+    NIFRID:synonym "cardiac muscle",
+        "heart muscle",
+        "heart myocardium",
+        "muscle of heart",
+        "myocardium" ;
+    rdfs:subClassOf UBERON:0005983,
+        UBERON:0018260,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000383 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000948 ] .
 
 UBERON:0002355 a owl:Class ;
     rdfs:label "pelvic region of trunk" ;
@@ -11586,21 +14375,49 @@ UBERON:0002355 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002417 ] .
 
+UBERON:0002356 a owl:Class ;
+    rdfs:label "perineum" ;
+    NIFRID:synonym "perineal region",
+        "regio perinealis" ;
+    rdfs:subClassOf UBERON:0009569,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002417 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012469 ] .
+
 UBERON:0002357 a owl:Class ;
     rdfs:label "serous pericardium" ;
     NIFRID:synonym "pericardium serosum",
+        "serous pericardium",
         "serous portion of pericardium" ;
     rdfs:subClassOf UBERON:0000042,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002406 ] .
+
+UBERON:0002358 a owl:Class ;
+    rdfs:label "peritoneum" ;
+    NIFRID:synonym "peritonaeum",
+        "peritoneum" ;
+    rdfs:subClassOf UBERON:0000042,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003697 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0035820 ] .
 
 UBERON:0002365 a owl:Class ;
     rdfs:label "exocrine gland" ;
     NIFRID:synonym "ducted gland",
+        "exocrine gland",
         "glandula exocrina" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0002530,
+    rdfs:subClassOf UBERON:0002530,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002330 ] .
@@ -11614,7 +14431,8 @@ UBERON:0002366 a owl:Class ;
         "glandula bulbourethralis",
         "Mery's gland",
         "Méry gland" ;
-    rdfs:subClassOf UBERON:0006868,
+    rdfs:subClassOf UBERON:0000414,
+        UBERON:0006868,
         UBERON:0010147,
         UBERON:0010186,
         [ a owl:Restriction ;
@@ -11632,12 +14450,13 @@ UBERON:0002367 a owl:Class ;
     NIFRID:synonym "male prostate",
         "prostata",
         "prostate" ;
-    rdfs:subClassOf UBERON:0000077,
+    rdfs:subClassOf UBERON:0004119,
         UBERON:0010147 .
 
 UBERON:0002368 a owl:Class ;
     rdfs:label "endocrine gland" ;
     NIFRID:synonym "ductless gland",
+        "endocrine gland",
         "glandula endocrina",
         "glandulae endocrinae" ;
     rdfs:subClassOf UBERON:0002530,
@@ -11660,6 +14479,7 @@ UBERON:0002369 a owl:Class ;
         "suprarenal gland" ;
     rdfs:subClassOf UBERON:0005172,
         UBERON:0006858,
+        UBERON:0010314,
         UBERON:0015212,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -11672,9 +14492,8 @@ UBERON:0002370 a owl:Class ;
     rdfs:label "thymus" ;
     NIFRID:synonym "thymus gland",
         "thymus organ" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000077,
-        UBERON:0002368,
+    rdfs:subClassOf UBERON:0002368,
+        UBERON:0004119,
         UBERON:0004177,
         UBERON:0005057,
         UBERON:0005058,
@@ -11691,37 +14510,110 @@ UBERON:0002370 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002405 ] .
 
+UBERON:0002377 a owl:Class ;
+    rdfs:label "muscle of neck" ;
+    NIFRID:synonym "muscle of neck",
+        "muscle organ of neck",
+        "muscle organ of neck (volume)",
+        "neck (volume) muscle organ",
+        "neck muscle",
+        "neck muscle organ" ;
+    rdfs:subClassOf UBERON:0010959,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000974 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004465 ] .
+
+UBERON:0002378 a owl:Class ;
+    rdfs:label "muscle of abdomen" ;
+    NIFRID:synonym "abdomen muscle",
+        "abdomen muscle organ",
+        "abdominal muscle",
+        "abdominal wall muscle",
+        "abdominal wall musculature",
+        "muscle of abdomen",
+        "muscle organ of abdomen" ;
+    rdfs:subClassOf UBERON:0003833,
+        UBERON:0005172,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000916 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002343 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003697 ] .
+
+UBERON:0002379 a owl:Class ;
+    rdfs:label "perineal muscle" ;
+    NIFRID:synonym "muscle of perineum",
+        "muscle organ of perineal region",
+        "muscle organ of perineum",
+        "perineal region muscle organ",
+        "perineum muscle organ" ;
+    rdfs:subClassOf UBERON:0001325,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002356 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004486 ] .
+
+UBERON:0002380 a owl:Class ;
+    rdfs:label "trapezius muscle" ;
+    NIFRID:synonym "musculus trapezius",
+        "spinotrapezius",
+        "trapezius" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0010313 .
+
+UBERON:0002381 a owl:Class ;
+    rdfs:label "pectoralis major" ;
+    NIFRID:synonym "musculus pectoralis major",
+        "pectoralis major muscle",
+        "pectoralis major muscle structure" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0001495 .
+
+UBERON:0002382 a owl:Class ;
+    rdfs:label "rectus abdominis muscle" ;
+    NIFRID:synonym "m. rectus abdominis",
+        "musculus rectus abdominis",
+        "rectus abdominis" ;
+    rdfs:subClassOf UBERON:0002461,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006635 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0008777 ] .
+
+UBERON:0002383 a owl:Class ;
+    rdfs:label "supraspinatus muscle" ;
+    NIFRID:synonym "musculus supraspinatus",
+        "supraspinatus" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0010891,
+        UBERON:0034908,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003683 ] .
+
 UBERON:0002384 a owl:Class ;
     rdfs:label "connective tissue" ;
     NIFRID:synonym "Bindegewebe",
+        "connective tissue",
         "portion of connective tissue",
         "textus connectivus" ;
-    rdfs:subClassOf UBERON:0000479,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000042 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000211 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000344 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000403 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000440 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005051 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0006655 ] .
+    rdfs:subClassOf UBERON:0000479 .
 
 UBERON:0002385 a owl:Class ;
     rdfs:label "muscle tissue" ;
-    NIFRID:synonym "muscular tissue",
+    NIFRID:synonym "muscle tissue",
+        "muscular tissue",
         "portion of muscle tissue",
         "textus muscularis" ;
     rdfs:subClassOf UBERON:0000479,
@@ -11729,6 +14621,88 @@ UBERON:0002385 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001015 ] .
+
+UBERON:0002386 a owl:Class ;
+    rdfs:label "forelimb zeugopod" ;
+    NIFRID:synonym "antebrachial region",
+        "antebrachium",
+        "antibrachium",
+        "arm middle limb segment",
+        "arm zeugopod",
+        "brachial region middle limb segment",
+        "brachial region zeugopod",
+        "fore epipodium",
+        "forearm",
+        "forelimb epipodium",
+        "forelimb zeugopodium",
+        "forelimb zygopod",
+        "intermediate segment of free upper limb",
+        "lower arm",
+        "lower segment of arm",
+        "middle limb segment of arm",
+        "middle limb segment of brachial region",
+        "middle limb segment of forelimb",
+        "middle limb segment of proximal segment of free upper limb",
+        "regio antebrachialis",
+        "wing zeugopod",
+        "zeugopod of arm",
+        "zeugopod of brachial region",
+        "zeugopod of forelimb",
+        "zeugopod of proximal segment of free upper limb" ;
+    rdfs:subClassOf UBERON:0002471,
+        UBERON:0008785,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
+
+UBERON:0002387 a owl:Class ;
+    rdfs:label "pes" ;
+    NIFRID:synonym "foot",
+        "hind foot",
+        "hind limb autopodium",
+        "hind paw",
+        "hind-paw",
+        "hindfeet",
+        "hindfoot",
+        "hindfoot of quadruped",
+        "hindlimb autopod",
+        "hindlimb autopodium",
+        "hindlimb distal free limb segment",
+        "hindpaw",
+        "pes",
+        "terminal segment of free lower limb" ;
+    rdfs:subClassOf UBERON:0002470,
+        UBERON:0008784,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002103 ] .
+
+UBERON:0002389 a owl:Class ;
+    rdfs:label "manual digit" ;
+    NIFRID:synonym "digit of hand",
+        "digit of manus",
+        "digitus manus",
+        "finger",
+        "fore digit",
+        "forelimb digit",
+        "hand digit",
+        "manual digit (phalangeal portion) plus soft tissue" ;
+    rdfs:subClassOf UBERON:0002544,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012141 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:5002389 ] .
 
 UBERON:0002390 a owl:Class ;
     rdfs:label "hematopoietic system" ;
@@ -11738,6 +14712,7 @@ UBERON:0002390 a owl:Class ;
         "haemopoietic system",
         "hematological system",
         "hematolymphoid system",
+        "hematopoietic system",
         "hemopoietic system",
         "organa haemopoietica" ;
     rdfs:subClassOf UBERON:0000467,
@@ -11746,13 +14721,62 @@ UBERON:0002390 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002193 ] .
 
+UBERON:0002394 a owl:Class ;
+    rdfs:label "bile duct" ;
+    NIFRID:synonym "bile duct",
+        "bile tube",
+        "biliary duct",
+        "gall duct",
+        "hepatic duct" ;
+    rdfs:subClassOf UBERON:0000025,
+        UBERON:0003928,
+        UBERON:0004119,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001173 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001173 ] .
+
+UBERON:0002398 a owl:Class ;
+    rdfs:label "manus" ;
+    NIFRID:synonym "fore foot",
+        "fore paw",
+        "fore-paw",
+        "forefeet",
+        "forefoot",
+        "forefoot of quadruped",
+        "forelimb autopod",
+        "forelimb autopodium",
+        "forepaw",
+        "hand",
+        "hand region",
+        "terminal segment of free upper limb" ;
+    rdfs:subClassOf UBERON:0002470,
+        UBERON:0008785,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
+
+UBERON:0002403 a owl:Class ;
+    rdfs:label "internal intercostal muscle" ;
+    NIFRID:synonym "intercostal muscle internal layer",
+        "intercostales internus" ;
+    rdfs:subClassOf UBERON:0001111 .
+
+UBERON:0002404 a owl:Class ;
+    rdfs:label "transversus thoracis" ;
+    rdfs:subClassOf UBERON:0002426 .
+
 UBERON:0002405 a owl:Class ;
     rdfs:label "immune system" ;
+    NIFRID:synonym "immune system" ;
     rdfs:subClassOf UBERON:0015203 .
 
 UBERON:0002406 a owl:Class ;
     rdfs:label "pericardial sac" ;
-    NIFRID:synonym "pericardium" ;
+    NIFRID:synonym "pericardial sac",
+        "pericardium" ;
     rdfs:subClassOf UBERON:0005181,
         UBERON:0005906,
         [ a owl:Restriction ;
@@ -11764,8 +14788,11 @@ UBERON:0002406 a owl:Class ;
 
 UBERON:0002407 a owl:Class ;
     rdfs:label "pericardium" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000481,
+    NIFRID:synonym "pericardium" ;
+    rdfs:subClassOf UBERON:0000481,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom NCBITaxon:6072 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0015410 ] .
@@ -11774,6 +14801,7 @@ UBERON:0002410 a owl:Class ;
     rdfs:label "autonomic nervous system" ;
     NIFRID:synonym "ANS",
         "autonomic division of peripheral nervous system",
+        "autonomic nervous system",
         "autonomic part of peripheral nervous system",
         "divisio autonomica systematis nervosi peripherici",
         "pars autonomica systematis nervosi peripherici",
@@ -11790,7 +14818,6 @@ UBERON:0002410 a owl:Class ;
 UBERON:0002411 a owl:Class ;
     rdfs:label "clitoris" ;
     rdfs:subClassOf UBERON:0000062,
-        UBERON:0004120,
         UBERON:0005156,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -11804,25 +14831,40 @@ UBERON:0002416 a owl:Class ;
     NIFRID:synonym "body surface",
         "dermal system",
         "external covering of organism",
+        "integumental system",
         "integumentary system",
         "integumentum commune",
         "organism surface",
         "surface" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000467 .
+    rdfs:subClassOf UBERON:0000467 .
 
 UBERON:0002417 a owl:Class ;
     rdfs:label "abdominal segment of trunk" ;
     NIFRID:synonym "abdomen/pelvis/perineum",
+        "abdominal segment of trunk",
         "lower body",
         "lower trunk",
         "lumbar region" ;
     rdfs:subClassOf UBERON:0009569,
         UBERON:0011676 .
 
+UBERON:0002419 a owl:Class ;
+    rdfs:label "skin gland" ;
+    NIFRID:synonym "glandulae cutis",
+        "set of skin glands",
+        "skin gland",
+        "skin glands",
+        "skin glands set" ;
+    rdfs:subClassOf UBERON:0003297,
+        UBERON:0006003,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002097 ] .
+
 UBERON:0002420 a owl:Class ;
     rdfs:label "basal ganglion" ;
     NIFRID:synonym "basal ganglia",
+        "basal ganglion",
         "basal ganglion of telencephalon",
         "basal nucleus",
         "nuclei basales" ;
@@ -11836,6 +14878,7 @@ UBERON:0002421 a owl:Class ;
     rdfs:label "hippocampal formation" ;
     NIFRID:synonym "archipallium",
         "formatio hippocampi",
+        "hippocampal formation",
         "hippocampus",
         "hippocampus (Crosby)",
         "major hippocampus",
@@ -11849,33 +14892,13 @@ UBERON:0002421 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000956 ] .
 
-UBERON:0002422 a owl:Class ;
-    rdfs:label "fourth ventricle" ;
-    NIFRID:synonym "4th ventricle",
-        "fourth ventricle proper",
-        "hindbrain ventricle",
-        "IVth ventricle",
-        "rhombencephalic ventricle",
-        "rhombencephalic vesicle",
-        "ventricle IV",
-        "ventricle of hindbrain",
-        "ventricle of rhombencephalon",
-        "ventriculus quartus" ;
-    rdfs:subClassOf UBERON:0004086,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002028 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0002028 ] .
-
 UBERON:0002423 a owl:Class ;
     rdfs:label "hepatobiliary system" ;
     NIFRID:synonym "hepaticobiliary system",
+        "hepatobiliary system",
         "liver and biliary system",
         "liver/biliary system" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0011216,
+    rdfs:subClassOf UBERON:0011216,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001007 ] .
@@ -11888,7 +14911,8 @@ UBERON:0002425 a owl:Class ;
         "serous visceral pericardium",
         "visceral lamina of serous pericardium",
         "visceral layer of serous pericardium",
-        "visceral pericardium" ;
+        "visceral pericardium",
+        "visceral serous pericardium" ;
     rdfs:subClassOf UBERON:0022350,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -11896,6 +14920,34 @@ UBERON:0002425 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0002407 ] .
+
+UBERON:0002426 a owl:Class ;
+    rdfs:label "chest muscle" ;
+    NIFRID:synonym "anterior thoracic region muscle organ",
+        "anterolateral part of thorax muscle organ",
+        "chest muscle organ",
+        "front of thorax muscle organ",
+        "muscle of thorax",
+        "muscle organ of anterior thoracic region",
+        "muscle organ of anterolateral part of thorax",
+        "muscle organ of chest",
+        "muscle organ of front of thorax",
+        "musculus thoracicus",
+        "thoracic muscle" ;
+    rdfs:subClassOf UBERON:0003830,
+        UBERON:0005175,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001443 ] .
+
+UBERON:0002427 a owl:Class ;
+    rdfs:label "arm skin" ;
+    NIFRID:synonym "brachial region skin",
+        "skin of arm" ;
+    rdfs:subClassOf UBERON:0003531,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ] .
 
 UBERON:0002430 a owl:Class ;
     rdfs:label "lateral hypothalamic area" ;
@@ -11944,19 +14996,6 @@ UBERON:0002435 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0010011 ] .
 
-UBERON:0002437 a owl:Class ;
-    rdfs:label "cerebral hemisphere white matter" ;
-    NIFRID:synonym "cerebral hemisphere white matter",
-        "cerebral white matter",
-        "hemisphere white matter",
-        "region of cerebral white matter",
-        "substantia medullaris cerebri",
-        "white matter structure of cerebral hemisphere" ;
-    rdfs:subClassOf UBERON:0011299,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001869 ] .
-
 UBERON:0002439 a owl:Class ;
     rdfs:label "myenteric nerve plexus" ;
     NIFRID:synonym "Auberbach plexus",
@@ -11996,6 +15035,30 @@ UBERON:0002441 a owl:Class ;
         "stellate ganglion" ;
     rdfs:subClassOf UBERON:0001991 .
 
+UBERON:0002461 a owl:Class ;
+    rdfs:label "anterior abdominal wall muscle" ;
+    NIFRID:synonym "muscle of anterior abdominal wall",
+        "ventral abdominal wall muscle" ;
+    rdfs:subClassOf UBERON:0002378,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006635 ] .
+
+UBERON:0002463 a owl:Class ;
+    rdfs:label "muscle of posterior compartment of hindlimb stylopod" ;
+    NIFRID:synonym "hamstring",
+        "hamstring muscle",
+        "muscle of posterior compartment of thigh",
+        "muscularis compartimentum femoris posterius",
+        "posterior fascial compartment of thigh",
+        "posterior femoral muscle",
+        "posterior femoral muscles",
+        "set of hamstring muscles" ;
+    rdfs:subClassOf UBERON:0004252,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000376 ] .
+
 UBERON:0002464 a owl:Class ;
     rdfs:label "nerve trunk" ;
     NIFRID:synonym "peripheral nerve trunk",
@@ -12020,37 +15083,52 @@ UBERON:0002465 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002405 ] .
 
-UBERON:0002476 a owl:Class ;
-    rdfs:label "lateral globus pallidus" ;
-    NIFRID:synonym "external globus pallidus",
-        "external pallidum",
-        "external part of globus pallidus",
-        "globus pallidus (rat)",
-        "globus pallidus extermal segment",
-        "globus pallidus external segment",
-        "globus pallidus externus",
-        "globus pallidus lateral part",
-        "globus pallidus lateral segment",
-        "globus pallidus lateralis",
-        "globus pallidus, external segment",
-        "globus pallidus, lateral part",
-        "globus pallidus, lateral segment",
-        "globus pallidus, pars externa",
-        "lateral division of globus pallidus",
-        "lateral pallidal segment",
-        "lateral pallidum",
-        "lateral part of globus pallidus",
-        "lateral segment of globus pallidus",
-        "lateral segment of the globus pallidus",
-        "nucleus lateralis globi pallidi",
-        "pallidum dorsal region external segment",
-        "pallidum I",
-        "pallidus II",
-        "pars lateralis globi pallidi medialis" ;
-    rdfs:subClassOf UBERON:0005401,
+UBERON:0002470 a owl:Class ;
+    rdfs:label "autopod region" ;
+    NIFRID:synonym "autopod",
+        "autopodial element",
+        "autopodial limb segment",
+        "autopodial segment",
+        "autopodium",
+        "autopodium region",
+        "distal free limb segment",
+        "distal segment of free limb",
+        "distal segment of limb",
+        "manus/pes",
+        "paw",
+        "paw/hand/foot/hoof",
+        "pod" ;
+    rdfs:subClassOf UBERON:0002529,
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002101 ] .
+
+UBERON:0002471 a owl:Class ;
+    rdfs:label "zeugopod" ;
+    NIFRID:synonym "epipodium",
+        "middle free limb segment",
+        "middle limb segment",
+        "middle part of limb",
+        "middle segment of free limb",
+        "zeugopod limb segment",
+        "zeugopodial limb segment",
+        "zeugopodium",
+        "zygopod",
+        "zygopodium" ;
+    rdfs:subClassOf UBERON:0002529 .
+
+UBERON:0002472 a owl:Class ;
+    rdfs:label "stylopod" ;
+    NIFRID:synonym "propodium",
+        "proximal free limb segment",
+        "proximal part of limb",
+        "proximal segment of free limb",
+        "stylopodial limb segment",
+        "stylopodium" ;
+    rdfs:subClassOf UBERON:0002529,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001875 ] .
+            owl:someValuesFrom UBERON:0002101 ] .
 
 UBERON:0002477 a owl:Class ;
     rdfs:label "medial globus pallidus" ;
@@ -12072,6 +15150,7 @@ UBERON:0002477 a owl:Class ;
         "internal pallidum",
         "internal part of globus pallidus",
         "medial division of globus pallidus",
+        "medial globus pallidus",
         "medial globus pallidus (entopeduncular nucleus)",
         "medial pallidal segment",
         "medial part of globus pallidus",
@@ -12097,13 +15176,26 @@ UBERON:0002493 a owl:Class ;
         UBERON:0005156,
         UBERON:0015212,
         [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000995 ],
+        [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000995 ] .
+
+UBERON:0002495 a owl:Class ;
+    rdfs:label "long bone" ;
+    NIFRID:synonym "os longum" ;
+    rdfs:subClassOf UBERON:0001474,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002091 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002091 ] .
 
 UBERON:0002499 a owl:Class ;
     rdfs:label "cochlear labyrinth" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001849 ] .
@@ -12123,16 +15215,32 @@ UBERON:0002509 a owl:Class ;
     rdfs:label "mesenteric lymph node" ;
     NIFRID:synonym "mesenteric node",
         "nodi lymphoidei mesenterici" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0015860,
+    rdfs:subClassOf UBERON:0015860,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002095 ] .
+
+UBERON:0002513 a owl:Class ;
+    rdfs:label "endochondral bone" ;
+    NIFRID:synonym "cartilaginous bone",
+        "endochondral bone",
+        "endochondral bones",
+        "ossified chondrogenic bone" ;
+    rdfs:subClassOf UBERON:0001474,
+        UBERON:0010363 .
+
+UBERON:0002515 a owl:Class ;
+    rdfs:label "periosteum" ;
+    rdfs:subClassOf UBERON:0000158,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001474 ] .
 
 UBERON:0002517 a owl:Class ;
     rdfs:label "basicranium" ;
     NIFRID:synonym "base of cranium",
         "base of skull",
+        "basicranium",
         "basis cranii",
         "cranial base" ;
     rdfs:subClassOf UBERON:0000075,
@@ -12146,6 +15254,14 @@ UBERON:0002517 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0003128 ] .
 
+UBERON:0002523 a owl:Class ;
+    rdfs:label "tunica intima" ;
+    NIFRID:synonym "Bichat's tunic",
+        "intima",
+        "tunica intima",
+        "tunica intima vasorum" ;
+    rdfs:subClassOf UBERON:0004923 .
+
 UBERON:0002529 a owl:Class ;
     rdfs:label "limb segment" ;
     NIFRID:synonym "extremity part",
@@ -12157,74 +15273,57 @@ UBERON:0002529 a owl:Class ;
     rdfs:subClassOf UBERON:0010538,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002101 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0006058 ] .
+            owl:someValuesFrom UBERON:0002101 ] .
 
 UBERON:0002530 a owl:Class ;
     rdfs:label "gland" ;
     NIFRID:synonym "Druese",
+        "gland",
         "glandula",
         "glandular organ" ;
     rdfs:subClassOf UBERON:0000062 .
 
-UBERON:0002551 a owl:Class ;
-    rdfs:label "interstitial nucleus of Cajal" ;
-    NIFRID:synonym "ICjl",
-        "interstitial nucleus",
-        "interstitial nucleus of Cajal",
-        "interstitial nucleus of medial longitudinal fasciculus",
-        "interstitial nucleus of medial longitudinal fasciculus (Crosby)",
-        "interstitial nucleus of the medial longitudinal fascicle (Boyce 1895)",
-        "interstitial nucleus of the medial longitudinal fasciculus",
-        "NIC",
-        "nucleus interstitialis",
-        "nucleus interstitialis Cajal",
-        "nucleus of the posterior commissure (Kvlliker)" ;
-    rdfs:subClassOf UBERON:0006331,
-        UBERON:0007414,
-        UBERON:0009661,
+UBERON:0002544 a owl:Class ;
+    rdfs:label "digit" ;
+    NIFRID:synonym "acropodial unit",
+        "digit (phalangeal portion) plus soft tissue",
+        "limb digit" ;
+    rdfs:subClassOf UBERON:0005881,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001943 ] .
+            owl:someValuesFrom UBERON:0012140 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012354 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:5002544 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002470 ] .
 
-UBERON:0002567 a owl:Class ;
-    rdfs:label "basal part of pons" ;
-    NIFRID:synonym "basal part of the pons",
-        "basal portion of pons",
-        "base of pons",
-        "basilar part of pons",
-        "basilar pons",
-        "basis pontis",
-        "pars anterior pontis",
-        "pars basilaris pontis",
-        "pars ventralis pontis",
-        "pons proper",
-        "ventral pons",
-        "ventral portion of pons" ;
-    rdfs:subClassOf UBERON:0002616,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000988 ] .
-
-UBERON:0002573 a owl:Class ;
-    rdfs:label "pontine reticular formation" ;
-    NIFRID:synonym "formatio reticularis pontis",
-        "pons of varolius reticular formation",
-        "pons reticular formation",
-        "pontine reticular nucleus",
-        "pontine reticular nucleus rostral part",
-        "reticular formation of pons",
-        "reticular formation of pons of varolius" ;
-    rdfs:subClassOf UBERON:0007245,
-        UBERON:0019263,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002275 ],
+UBERON:0002549 a owl:Class ;
+    rdfs:label "ventral trigeminal tract" ;
+    NIFRID:synonym "anterior trigeminothalamic tract",
+        "tractus trigeminalis ventralis",
+        "tractus trigeminothalamicus anterior",
+        "trigeminal lemniscus-2",
+        "ventral crossed tract",
+        "ventral secondary ascending tract of V",
+        "ventral trigeminal pathway",
+        "ventral trigeminal tract",
+        "ventral trigeminothalamic tract" ;
+    rdfs:subClassOf UBERON:0004171,
+        UBERON:0007702,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0003023 ] .
+
+UBERON:0002553 a owl:Class ;
+    rdfs:label "anatomical cavity" ;
+    NIFRID:synonym "anatomical cavity",
+        "cavity" ;
+    rdfs:subClassOf UBERON:0000464 .
 
 UBERON:0002580 a owl:Class ;
     rdfs:label "brachium of superior colliculus" ;
@@ -12260,15 +15359,6 @@ UBERON:0002581 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001872 ] .
 
-UBERON:0002587 a owl:Class ;
-    rdfs:label "nucleus subceruleus" ;
-    NIFRID:synonym "nucleus subcaeruleus",
-        "nucleus subcoeruleus",
-        "subcaerulean nucleus",
-        "subceruleus nucleus",
-        "subcoeruleus nucleus" ;
-    rdfs:subClassOf UBERON:0002308 .
-
 UBERON:0002590 a owl:Class ;
     rdfs:label "Prepyriform area",
         "prepyriform area" ;
@@ -12301,39 +15391,42 @@ UBERON:0002590 a owl:Class ;
     ilxtr:hasIlxId ILX:0109236 ;
     ilxtr:hasIlxPreferredId UBERON:0004725 .
 
-UBERON:0002597 a owl:Class ;
-    rdfs:label "principal sensory nucleus of trigeminal nerve" ;
-    NIFRID:synonym "chief sensory nucleus",
-        "chief sensory trigeminal nucleus",
-        "chief trigeminal sensory nucleus",
-        "main sensory nucleus",
-        "main sensory nucleus of cranial nerve v",
-        "nucleus pontinus nervi trigeminalis",
-        "nucleus pontinus nervi trigemini",
-        "nucleus principalis nervi trigemini",
-        "nucleus sensibilis superior nervi trigemini",
-        "nucleus sensorius principalis nervi trigemini",
-        "nucleus sensorius superior nervi trigemini",
-        "pontine nucleus",
-        "pontine nucleus of the trigeminal nerve",
-        "primary nucleus of the trigeminal nerve",
-        "principal sensory nucleus",
-        "principal sensory nucleus of the trigeminal",
-        "principal sensory nucleus of the trigeminal nerve",
-        "principal sensory nucleus of trigeminal nerve",
-        "principal sensory trigeminal nucleus",
-        "principal trigeminal nucleus",
-        "superior trigeminal nucleus",
-        "superior trigeminal sensory nucleus",
-        "trigeminal nerve superior sensory nucleus",
-        "trigeminal V chief sensory nucleus",
-        "trigeminal V principal sensory nucleus" ;
-    rdfs:subClassOf UBERON:0004132,
-        UBERON:0006331,
-        UBERON:0009662,
+UBERON:0002591 a owl:Class ;
+    rdfs:label "oral part of spinal trigeminal nucleus" ;
+    NIFRID:synonym "nucleus oralis tractus spinalis nervi trigemini",
+        "nucleus spinalis nervi trigemini, pars oralis",
+        "oral part of the spinal trigeminal nucleus",
+        "spinal nucleus of the trigeminal oral part",
+        "spinal nucleus of the trigeminal, oral part",
+        "spinal trigeminal nucleus oral part",
+        "spinal trigeminal nucleus, oral part" ;
+    rdfs:subClassOf UBERON:0019263,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0003023 ] .
+            owl:someValuesFrom UBERON:0001717 ] .
+
+UBERON:0002596 a owl:Class ;
+    rdfs:label "ventral posterior nucleus of thalamus" ;
+    NIFRID:synonym "nuclei ventrales posteriores",
+        "nucleus ventrales posteriores",
+        "nucleus ventralis posterior",
+        "ventral posterior",
+        "ventral posterior complex of the thalamus",
+        "ventral posterior nucleus",
+        "ventral posterior nucleus of thalamus",
+        "ventral posterior thalamic nucleus",
+        "ventrobasal complex",
+        "ventrobasal nucleus",
+        "ventroposterior inferior nucleus",
+        "ventroposterior nucleus",
+        "ventroposterior nucleus of thalamus",
+        "VP",
+        "VPN" ;
+    rdfs:subClassOf UBERON:0002308,
+        UBERON:0015233,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002776 ] .
 
 UBERON:0002600 a owl:Class ;
     rdfs:label "limbic lobe" ;
@@ -12342,25 +15435,10 @@ UBERON:0002600 a owl:Class ;
         "fornicate lobe",
         "grande lobe limbique of Broca",
         "gyrus fornicatus",
+        "limbic lobe",
         "limbic lobe (carpenter)",
         "lobus limbicus" ;
     rdfs:subClassOf UBERON:0016526 .
-
-UBERON:0002601 a owl:Class ;
-    rdfs:label "fasciolar gyrus" ;
-    NIFRID:synonym "fasciola cinerea",
-        "fasciola cinerea (Reil, Arnold)",
-        "fasciola cinereum",
-        "FC",
-        "gyrus fasciolaris",
-        "gyrus retrosplenialis hippocampi",
-        "retrosplenial gyrus of hippocampus",
-        "splenial gyrus" ;
-    rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002600 ] .
 
 UBERON:0002604 a owl:Class ;
     rdfs:label "ventral nucleus of lateral lemniscus" ;
@@ -12380,7 +15458,8 @@ UBERON:0002604 a owl:Class ;
 
 UBERON:0002610 a owl:Class ;
     rdfs:label "cochlear nuclear complex" ;
-    NIFRID:synonym "cochlear nuclei",
+    NIFRID:synonym "cochlear nuclear complex",
+        "cochlear nuclei",
         "nuclei cochleares" ;
     rdfs:subClassOf UBERON:0019263,
         [ a owl:Restriction ;
@@ -12397,9 +15476,9 @@ UBERON:0002616 a owl:Class ;
         "brain part",
         "neuraxis segment",
         "neuroanatomical region",
+        "regional part of brain",
         "segment of brain" ;
     rdfs:subClassOf UBERON:0000073,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000955 ] ;
@@ -12413,26 +15492,10 @@ UBERON:0002616 a owl:Class ;
     ilxtr:hasIlxId ILX:0109835 ;
     ilxtr:hasIlxPreferredId UBERON:0002616 .
 
-UBERON:0002623 a owl:Class ;
-    rdfs:label "cerebral peduncle" ;
-    NIFRID:synonym "cerebal peduncle",
-        "cerebral peduncle",
-        "cerebral peduncle (archaic)",
-        "CP",
-        "peduncle of midbrain",
-        "pedunculi cerebri",
-        "pedunculus cerebralis",
-        "pedunculus cerebri",
-        "tegmentum" ;
-    rdfs:subClassOf UBERON:0007417,
-        UBERON:0016554,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001891 ] .
-
 UBERON:0002625 a owl:Class ;
     rdfs:label "median preoptic nucleus" ;
-    NIFRID:synonym "median preoptic nucleus (Loo)",
+    NIFRID:synonym "median preoptic nucleus",
+        "median preoptic nucleus (Loo)",
         "MnPO",
         "nucleus praeopticus medianus",
         "nucleus preopticus medianus",
@@ -12442,45 +15505,13 @@ UBERON:0002625 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001928 ] .
 
-UBERON:0002633 a owl:Class ;
-    rdfs:label "motor nucleus of trigeminal nerve" ;
-    NIFRID:synonym "motor nucleus",
-        "motor nucleus of cranial nerve v",
-        "motor nucleus of the trigeminal",
-        "motor nucleus of the trigeminal nerve",
-        "motor nucleus of trigeminal",
-        "motor nucleus of trigeminal nerve",
-        "motor nucleus V",
-        "motor trigeminal nucleus",
-        "nucleus motorius nervi trigeminalis",
-        "nucleus motorius nervi trigemini",
-        "nucleus motorius trigeminalis",
-        "nV",
-        "trigeminal motor nuclei",
-        "trigeminal motor nucleus",
-        "trigeminal V motor nucleus" ;
-    rdfs:subClassOf UBERON:0002925,
-        UBERON:0006331,
-        UBERON:0009662,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000988 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002925 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0003023 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0000988 ] .
-
 UBERON:0002639 a owl:Class ;
     rdfs:label "midbrain reticular formation" ;
     NIFRID:synonym "formatio reticularis mesencephali",
         "formatio reticularis tegmentalis",
         "formatio reticularis tegmenti mesencephali",
         "MBRF",
+        "midbrain reticular formation",
         "reticular formation of midbrain",
         "substantia reticularis mesencephali",
         "tegmental reticular formation" ;
@@ -12497,6 +15528,7 @@ UBERON:0002663 a owl:Class ;
     rdfs:label "septal nuclear complex" ;
     NIFRID:synonym "nuclei septales",
         "parolfactory nuclei",
+        "septal nuclear complex",
         "septal nuclei",
         "septal nucleus" ;
     rdfs:subClassOf UBERON:0005401,
@@ -12507,17 +15539,6 @@ UBERON:0002663 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002743 ] .
-
-UBERON:0002665 a owl:Class ;
-    rdfs:label "supracallosal gyrus" ;
-    NIFRID:synonym "gyrus supracallosus",
-        "hippocampus supracommissuralis",
-        "supracommissural hippocampal rudiment",
-        "supracommissural hippocampus" ;
-    rdfs:subClassOf UBERON:0000200,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002600 ] .
 
 UBERON:0002682 a owl:Class ;
     rdfs:label "abducens nucleus" ;
@@ -12548,6 +15569,7 @@ UBERON:0002691 a owl:Class ;
         "area tegmentalis ventralis (Tsai)",
         "tegmentum ventrale",
         "ventral brain stem",
+        "ventral tegmental area",
         "ventral tegmental area (Tsai)",
         "ventral tegmental area of tsai",
         "ventral tegmental nucleus (Rioch)",
@@ -12555,7 +15577,8 @@ UBERON:0002691 a owl:Class ;
         "ventral tegmental nucleus of tsai",
         "ventromedial mesencephalic tegmentum",
         "VTA" ;
-    rdfs:subClassOf UBERON:0002616,
+    rdfs:subClassOf UBERON:0000481,
+        UBERON:0002616,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001943 ] .
@@ -12567,42 +15590,13 @@ UBERON:0002704 a owl:Class ;
         "geniculate group of the dorsal thalamus",
         "geniculate thalamic group",
         "geniculate thalamic nuclear group (metathalamus)",
+        "metathalamus",
         "MTh",
         "nuclei metathalami" ;
     rdfs:subClassOf UBERON:0015233,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004703 ] .
-
-UBERON:0002711 a owl:Class ;
-    rdfs:label "nucleus of posterior commissure" ;
-    NIFRID:synonym "Darkshevich nucleus",
-        "Darkshevich's nucleus",
-        "nucleus commissura posterior",
-        "nucleus commissuralis posterioris",
-        "nucleus interstitialis of posterior commissure",
-        "nucleus of Darkschewitsch",
-        "nucleus of the posterior commissure",
-        "PCom",
-        "posterior commissure nucleus" ;
-    rdfs:subClassOf UBERON:0006331,
-        UBERON:0007414,
-        UBERON:0009661,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001943 ] .
-
-UBERON:0002712 a owl:Class ;
-    rdfs:label "premammillary nucleus" ;
-    NIFRID:synonym "nuclei premamillaris",
-        "nucleus premamillaris hypothalami",
-        "PMm",
-        "premamillary nucleus",
-        "premammillary nuclei" ;
-    rdfs:subClassOf UBERON:0006568,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002770 ] .
 
 UBERON:0002722 a owl:Class ;
     rdfs:label "trochlear nucleus" ;
@@ -12639,7 +15633,6 @@ UBERON:0002728 a owl:Class ;
         "entorhinal area",
         "entorhinal cortex" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002973 ],
@@ -12663,54 +15656,21 @@ UBERON:0002736 a owl:Class ;
         "LNG",
         "nuclei laterales thalami",
         "nucleus lateralis thalami" ;
-    rdfs:subClassOf UBERON:0015233,
+    rdfs:subClassOf UBERON:0000125,
+        UBERON:0015233,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004703 ] .
 
-UBERON:0002742 a owl:Class ;
-    rdfs:label "lamina of septum pellucidum" ;
-    NIFRID:synonym "lamina of the septum pellucidum",
-        "lamina septi pellucidi",
-        "laminae septi pellucidi",
-        "septum pellucidum lamina" ;
-    rdfs:subClassOf UBERON:0011215,
-        UBERON:0022303,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004714 ] .
-
 UBERON:0002743 a owl:Class ;
     rdfs:label "basal forebrain" ;
-    NIFRID:synonym "basal forebrain area",
+    NIFRID:synonym "basal forebrain",
+        "basal forebrain area",
         "pars basalis telencephali" ;
     rdfs:subClassOf UBERON:0002616,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001890 ] .
-
-UBERON:0002753 a owl:Class ;
-    rdfs:label "posterior spinocerebellar tract" ;
-    NIFRID:synonym "dorsal spinocerebellar tract",
-        "dorsal spinocerebellar tract of the medulla",
-        "flechsig's tract" ;
-    rdfs:subClassOf UBERON:0001018,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005413 ] .
-
-UBERON:0002770 a owl:Class ;
-    rdfs:label "posterior hypothalamic region" ;
-    NIFRID:synonym "hypothalamus posterior",
-        "mammillary level of hypothalamus",
-        "mammillary region",
-        "PHR",
-        "posterior hypothalamus",
-        "regio hypothalamica posterior" ;
-    rdfs:subClassOf UBERON:0002616,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001898 ] .
 
 UBERON:0002776 a owl:Class ;
     rdfs:label "ventral nuclear group" ;
@@ -12730,22 +15690,6 @@ UBERON:0002776 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004703 ] .
-
-UBERON:0002778 a owl:Class ;
-    rdfs:label "ventral pallidum" ;
-    NIFRID:synonym "fibrae nervi vagi",
-        "globus pallidus ventral part",
-        "pallidum ventral region",
-        "ventral globus pallidus",
-        "ventral pallidum" ;
-    rdfs:subClassOf UBERON:0005401,
-        UBERON:0006514,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001875 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002743 ] .
 
 UBERON:0002779 a owl:Class ;
     rdfs:label "lateral superior olivary nucleus" ;
@@ -12811,24 +15755,26 @@ UBERON:0002792 a owl:Class ;
 
 UBERON:0002812 a owl:Class ;
     rdfs:label "left cerebral hemisphere" ;
-    NIFRID:synonym "left hemisphere" ;
+    NIFRID:synonym "left cerebral hemisphere",
+        "left hemisphere" ;
     rdfs:subClassOf UBERON:0001869 .
 
 UBERON:0002813 a owl:Class ;
     rdfs:label "right cerebral hemisphere" ;
-    NIFRID:synonym "right hemisphere" ;
+    NIFRID:synonym "right cerebral hemisphere",
+        "right hemisphere" ;
     rdfs:subClassOf UBERON:0001869 .
 
 UBERON:0002824 a owl:Class ;
     rdfs:label "vestibular ganglion" ;
     NIFRID:synonym "nucleus nervi oculomotorii, pars medialis",
         "Scarpa's ganglion",
+        "vestibular ganglion",
         "vestibular part of vestibulocochlear ganglion",
         "vestibulocochlear ganglion vestibular component",
         "vestibulocochlear VIII ganglion vestibular component" ;
     rdfs:subClassOf UBERON:0001714,
         UBERON:0001800,
-        UBERON:0010313,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001862 ],
@@ -12855,6 +15801,7 @@ UBERON:0002827 a owl:Class ;
         "statoacoustic ganglion",
         "statoacoustic VIII ganglion",
         "vestibulocochlear ganglia",
+        "vestibulocochlear ganglion",
         "vestibulocochlear VIII ganglion" ;
     rdfs:subClassOf UBERON:0001714,
         UBERON:0010313,
@@ -12920,8 +15867,7 @@ UBERON:0002834 a owl:Class ;
     rdfs:subClassOf UBERON:0000044 .
 
 UBERON:0002835 a owl:Class ;
-    rdfs:label "Thoracic dorsal root ganglion",
-        "thoracic dorsal root ganglion" ;
+    rdfs:label "thoracic dorsal root ganglion" ;
     NIFRID:synonym "dorsal root ganglion of thorax",
         "ganglion of dorsal root of thorax",
         "ganglion spinalis of thorax",
@@ -12930,12 +15876,10 @@ UBERON:0002835 a owl:Class ;
         "thorax dorsal root ganglion",
         "thorax ganglion of dorsal root",
         "thorax ganglion spinalis" ;
-    rdfs:subClassOf UBERON:0000044,
-        UBERON:0000961 .
+    rdfs:subClassOf UBERON:0000044 .
 
 UBERON:0002836 a owl:Class ;
-    rdfs:label "Lumbar dorsal root ganglion",
-        "lumbar dorsal root ganglion" ;
+    rdfs:label "lumbar dorsal root ganglion" ;
     NIFRID:synonym "lumbar dorsal root ganglion",
         "lumbar spinal ganglion" ;
     rdfs:subClassOf UBERON:0000044 .
@@ -12945,6 +15889,13 @@ UBERON:0002837 a owl:Class ;
     NIFRID:synonym "sacral dorsal root ganglion",
         "sacral spinal ganglion" ;
     rdfs:subClassOf UBERON:0000044 .
+
+UBERON:0002842 a owl:Class ;
+    rdfs:label "fifth cervical dorsal root ganglion" ;
+    NIFRID:synonym "C5 dorsal root ganglion",
+        "fifth cervical dorsal root ganglion",
+        "fifth cervical spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002834 .
 
 UBERON:0002843 a owl:Class ;
     rdfs:label "seventh cervical dorsal root ganglion" ;
@@ -12987,6 +15938,24 @@ UBERON:0002849 a owl:Class ;
     rdfs:label "sixth thoracic dorsal root ganglion" ;
     NIFRID:synonym "sixth thoracic dorsal root ganglion",
         "sixth thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002835 .
+
+UBERON:0002850 a owl:Class ;
+    rdfs:label "seventh thoracic dorsal root ganglion" ;
+    NIFRID:synonym "seventh thoracic dorsal root ganglion",
+        "seventh thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002835 .
+
+UBERON:0002851 a owl:Class ;
+    rdfs:label "eighth thoracic dorsal root ganglion" ;
+    NIFRID:synonym "eighth thoracic dorsal root ganglion",
+        "eighth thoracic spinal ganglion" ;
+    rdfs:subClassOf UBERON:0002835 .
+
+UBERON:0002852 a owl:Class ;
+    rdfs:label "ninth thoracic dorsal root ganglion" ;
+    NIFRID:synonym "ninth thoracic dorsal root ganglion",
+        "ninth thoracic spinal ganglion" ;
     rdfs:subClassOf UBERON:0002835 .
 
 UBERON:0002853 a owl:Class ;
@@ -13051,38 +16020,24 @@ UBERON:0002862 a owl:Class ;
         "third sacral spinal ganglion" ;
     rdfs:subClassOf UBERON:0002837 .
 
-UBERON:0002865 a owl:Class ;
-    rdfs:label "arcuate nucleus of medulla" ;
-    NIFRID:synonym "ArcM",
-        "arcuate hypothalamic nucleus medial part",
-        "arcuate hypothalamic nucleus of medulla",
-        "arcuate nucleus (medulla)",
-        "arcuate nucleus of hypothalamus of medulla",
-        "arcuate nucleus of the medulla",
-        "arcuate nucleus, medial part",
-        "arcuate nucleus-1",
-        "arcuate nucleus-2 of medulla",
-        "arcuate periventricular nucleus of medulla",
-        "infundibular hypothalamic nucleus of medulla",
-        "infundibular nucleus of medulla",
-        "infundibular periventricular nucleus of medulla",
-        "medial arcuate nucleus",
-        "medulla arcuate hypothalamic nucleus",
-        "medulla arcuate nucleus",
-        "medulla arcuate nucleus of hypothalamus",
-        "medulla arcuate nucleus-2",
-        "medulla arcuate periventricular nucleus",
-        "medulla infundibular hypothalamic nucleus",
-        "medulla infundibular nucleus",
-        "medulla infundibular periventricular nucleus",
-        "nuclei arcuati",
-        "nucleus arciformis pyramidalis",
-        "nucleus arcuatus myelencephali",
-        "nucleus arcuatus pyramidalis" ;
-    rdfs:subClassOf UBERON:0007635,
+UBERON:0002866 a owl:Class ;
+    rdfs:label "caudal part of spinal trigeminal nucleus" ;
+    NIFRID:synonym "caudal nucleus",
+        "caudal nucleus (kandell)",
+        "caudal part of the spinal trigeminal nucleus",
+        "CSp5",
+        "nucleus caudalis tractus spinalis nervi trigemini",
+        "nucleus spinalis nervi trigemini, pars caudalis",
+        "spinal nucleus of the trigeminal caudal part",
+        "spinal nucleus of the trigeminal nerve caudal part",
+        "spinal nucleus of the trigeminal, caudal part",
+        "spinal trigeminal nucleus caudal part",
+        "spinal trigeminal nucleus, caudal part",
+        "subnucleus caudalis" ;
+    rdfs:subClassOf UBERON:0019263,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001896 ] .
+            owl:someValuesFrom UBERON:0001717 ] .
 
 UBERON:0002870 a owl:Class ;
     rdfs:label "dorsal motor nucleus of vagus nerve" ;
@@ -13136,25 +16091,27 @@ UBERON:0002872 a owl:Class ;
         "nucleus salivatorius inferior",
         "nucleus salivatorius inferior nervi glossopharyngei" ;
     rdfs:subClassOf UBERON:0000126,
+        UBERON:0004121,
         UBERON:0004133,
         UBERON:0007635,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001896 ] .
 
-UBERON:0002881 a owl:Class ;
-    rdfs:label "sublingual nucleus" ;
-    NIFRID:synonym "inferior central nucleus",
-        "nucleus of roller",
-        "nucleus parvocellularis nervi hypoglossi",
-        "nucleus Roller",
-        "nucleus sublingualis",
-        "Roller's nucleus",
-        "SLg" ;
-    rdfs:subClassOf UBERON:0007635,
+UBERON:0002873 a owl:Class ;
+    rdfs:label "interpolar part of spinal trigeminal nucleus" ;
+    NIFRID:synonym "interpolar part of the spinal trigeminal nucleus",
+        "nucleus interpolaris tractus spinalis nervi trigemini",
+        "nucleus of spinal tract of N. V (subnucleus interpolaris)",
+        "nucleus spinalis nervi trigemini, pars interpolaris",
+        "spinal nucleus of the trigeminal interpolar part",
+        "spinal nucleus of the trigeminal nerve interpolar part",
+        "spinal nucleus of the trigeminal, interpolar part",
+        "spinal trigeminal nucleus, interpolar part" ;
+    rdfs:subClassOf UBERON:0019263,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001896 ] .
+            owl:someValuesFrom UBERON:0001717 ] .
 
 UBERON:0002883 a owl:Class ;
     rdfs:label "central amygdaloid nucleus" ;
@@ -13174,49 +16131,12 @@ UBERON:0002883 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001876 ] .
 
-UBERON:0002886 a owl:Class ;
-    rdfs:label "lateral amygdaloid nucleus" ;
-    NIFRID:synonym "lateral amygdala",
-        "lateral amygdalar nucleus",
-        "lateral nucleus of amygdala",
-        "lateral nucleus of the amygdala",
-        "lateral principal nucleus of amygdala",
-        "medial principal nucleus",
-        "nucleus amygdalae lateralis",
-        "nucleus amygdaloideus lateralis",
-        "nucleus lateralis amygdalae" ;
-    rdfs:subClassOf UBERON:0009663,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001876 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0006107 ] .
-
-UBERON:0002892 a owl:Class ;
-    rdfs:label "medial amygdaloid nucleus" ;
-    NIFRID:synonym "medial amygalar nucleus",
-        "medial amygdala",
-        "medial amygdalar nucleus",
-        "medial amygdaloid nucleus principal part",
-        "medial nucleus of amygdala",
-        "medial nucleus of the amygdala",
-        "nucleus amygdalae medialis",
-        "nucleus amygdaloideus medialis",
-        "nucleus medialis amygdalae" ;
-    rdfs:subClassOf UBERON:0009663,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001876 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0006108 ] .
-
 UBERON:0002894 a owl:Class ;
     rdfs:label "olfactory cortex" ;
     NIFRID:synonym "archaeocortex",
         "archeocortex",
         "olfactory areas",
+        "olfactory cortex",
         "olfactory lobe" ;
     rdfs:subClassOf UBERON:0002616,
         [ a owl:Restriction ;
@@ -13239,6 +16159,7 @@ UBERON:0002925 a owl:Class ;
         "trigeminal nucleus",
         "trigeminal V nucleus" ;
     rdfs:subClassOf UBERON:0000126,
+        UBERON:0002308,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0007641 ] .
@@ -13268,6 +16189,40 @@ UBERON:0002934 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001715 ] .
 
+UBERON:0002945 a owl:Class ;
+    rdfs:label "ventral posteromedial nucleus of thalamus" ;
+    NIFRID:synonym "arcuate nucleus of thalamus",
+        "arcuate nucleus of the thalamus",
+        "arcuate nucleus-3",
+        "nucleus arcuatus thalami",
+        "nucleus semilunaris thalami",
+        "nucleus ventralis posterior medialis thalami",
+        "nucleus ventralis posteromedialis",
+        "nucleus ventralis posteromedialis thalami",
+        "nucleus ventrocaudalis anterior internus (hassler)",
+        "posteromedial ventral nucleus",
+        "posteromedial ventral nucleus of thalamus",
+        "posteromedial ventral nucleus of the thalamus",
+        "semilunar nucleus",
+        "thalamic gustatory nucleus",
+        "ventral posterior medial nucleus",
+        "ventral posterior medial nucleus of dorsal thalamus",
+        "ventral posterior medial nucleus of thalamus",
+        "ventral posteromedial nucleus of thalamus",
+        "ventral posteromedial nucleus of the thalamus",
+        "ventral posteromedial nucleus of the thalamus principal part",
+        "ventral posteromedial nucleus of the thalamus, general",
+        "ventral posteromedial nucleus of the thalamus, principal part",
+        "ventral posteromedial thalamic nucleus",
+        "ventroposterior medial thalamic nucleus",
+        "ventroposteromedial nucleus of the thalamus",
+        "VPM" ;
+    rdfs:subClassOf UBERON:0007692,
+        UBERON:0015233,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002596 ] .
+
 UBERON:0002952 a owl:Class ;
     rdfs:label "intermediate acoustic stria" ;
     NIFRID:synonym "commissure of held",
@@ -13296,26 +16251,12 @@ UBERON:0002956 a owl:Class ;
         "cerebellar granule layer",
         "cerebellum granule cell layer",
         "cerebellum granule layer",
+        "granular layer of cerebellar cortex",
         "granular layer of cerebellum",
         "granule cell layer of cerebellar cortex",
         "stratum granulosum cerebelli",
         "stratum granulosum corticis cerebelli" ;
     rdfs:subClassOf UBERON:0004130 .
-
-UBERON:0002968 a owl:Class ;
-    rdfs:label "central gray substance of pons" ;
-    NIFRID:synonym "central gray of pons",
-        "central gray of the pons",
-        "griseum centrale pontis",
-        "pontine central gray" ;
-    rdfs:subClassOf UBERON:0019263,
-        UBERON:0035011,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000988 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002573 ] .
 
 UBERON:0002971 a owl:Class ;
     rdfs:label "periolivary nucleus" ;
@@ -13356,6 +16297,7 @@ UBERON:0002974 a owl:Class ;
         "cerebellum molecular cell layer",
         "cerebellum molecular layer",
         "fasciculi thalami",
+        "molecular layer of cerebellar cortex",
         "stratum moleculare corticis cerebelli",
         "thalamic fiber tracts" ;
     rdfs:subClassOf UBERON:0004130 .
@@ -13370,6 +16312,7 @@ UBERON:0002979 a owl:Class ;
         "nucleus reticulatus (thalami)",
         "nucleus thalamicus reticularis",
         "Purkinje cell layer",
+        "Purkinje cell layer of cerebellar cortex",
         "reticular nucleus thalamus (Arnold)",
         "reticulatum thalami (Hassler)" ;
     rdfs:subClassOf UBERON:0004130 .
@@ -13385,7 +16328,8 @@ UBERON:0002981 a owl:Class ;
         "pulvinar nuclei",
         "pulvinar thalami",
         "pulvinar thalamus" ;
-    rdfs:subClassOf UBERON:0015233,
+    rdfs:subClassOf UBERON:0007692,
+        UBERON:0015233,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002736 ] .
@@ -13410,21 +16354,14 @@ UBERON:0002983 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002736 ] .
 
-UBERON:0002987 a owl:Class ;
-    rdfs:label "anterior spinocerebellar tract" ;
-    NIFRID:synonym "Gower's tract",
-        "Gowers' tract",
-        "tractus spinocerebellaris anterior",
-        "tractus spinocerebellaris ventralis",
-        "ventral spinocerebellar tract",
-        "ventral spinocerebellar tract (Gowers)" ;
-    rdfs:subClassOf UBERON:0007702,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001896 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005413 ] .
+UBERON:0002989 a owl:Class ;
+    rdfs:label "anconeus muscle" ;
+    NIFRID:synonym "aconeus",
+        "anconeus",
+        "m. anconeus",
+        "musculus anconaeus",
+        "musculus anconeus" ;
+    rdfs:subClassOf UBERON:0004255 .
 
 UBERON:0003001 a owl:Class ;
     rdfs:label "nervous system lemniscus" ;
@@ -13435,25 +16372,6 @@ UBERON:0003001 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002316 ] .
-
-UBERON:0003004 a owl:Class ;
-    rdfs:label "median raphe nucleus" ;
-    NIFRID:synonym "cell group b8",
-        "medial raphe nucleus",
-        "median nucleus of the raphe",
-        "MRN",
-        "nucleus centralis superior",
-        "nucleus raphes medianus",
-        "superior central nucleus",
-        "superior central nucleus raphe",
-        "superior central tegmental nucleus" ;
-    rdfs:subClassOf UBERON:0007415,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002639 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004684 ] .
 
 UBERON:0003011 a owl:Class ;
     rdfs:label "facial motor nucleus" ;
@@ -13471,34 +16389,17 @@ UBERON:0003011 a owl:Class ;
         "nVII" ;
     rdfs:subClassOf UBERON:0000127 .
 
-UBERON:0003017 a owl:Class ;
-    rdfs:label "substantia innominata" ;
-    NIFRID:synonym "innominate substance",
-        "nucleus of substantia innominata",
-        "substantia innominata (Reil, Reichert)",
-        "substantia innominata of Meynert",
-        "substantia innominata of Reichert",
-        "substantia innominata of Reil",
-        "substriatal gray" ;
-    rdfs:subClassOf UBERON:0009663,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002743 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002778 ] .
-
 UBERON:0003023 a owl:Class ;
     rdfs:label "pontine tegmentum" ;
     NIFRID:synonym "dorsal pons",
         "dorsal portion of pons",
         "pars dorsalis pontis",
         "pars posterior pontis",
+        "pontine tegmentum",
         "tegmental portion of pons",
         "tegmentum of pons",
         "tegmentum pontis" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000988 ] .
@@ -13520,8 +16421,7 @@ UBERON:0003038 a owl:Class ;
             owl:someValuesFrom UBERON:0008231 ] .
 
 UBERON:0003040 a owl:Class ;
-    rdfs:label "central gray substance of midbrain",
-        "Periaqueductal gray of midbrain" ;
+    rdfs:label "central gray substance of midbrain" ;
     NIFRID:synonym "anulus aquaeductus",
         "anulus aqueductus cerebri",
         "anulus of cerebral aqueduct",
@@ -13568,29 +16468,11 @@ UBERON:0003041 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001645 ] .
 
-UBERON:0003092 a owl:Class ;
-    rdfs:label "ultimobranchial body" ;
-    NIFRID:synonym "corpus ultimopharyngeum",
-        "postbranchial body",
-        "telobranchial body",
-        "telopharyngeal body",
-        "ultimobranchial",
-        "ultimobranchial bodies",
-        "ultimobranchial gland",
-        "ultimopharyngeal body",
-        "ultimopharyngeal gland" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0002368,
-        UBERON:0004119,
-        UBERON:0010314,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000949 ] .
-
 UBERON:0003100 a owl:Class ;
     rdfs:label "female organism" ;
     NIFRID:synonym "female",
-        "female human body" ;
+        "female human body",
+        "female organism" ;
     rdfs:subClassOf UBERON:0000468 .
 
 UBERON:0003101 a owl:Class ;
@@ -13599,14 +16481,25 @@ UBERON:0003101 a owl:Class ;
         "male human body" ;
     rdfs:subClassOf UBERON:0000468 .
 
+UBERON:0003102 a owl:Class ;
+    rdfs:label "surface structure" ;
+    NIFRID:synonym "anatomical surface feature",
+        "surface feature",
+        "surface region",
+        "surface structure",
+        "surface structures" ;
+    rdfs:subClassOf UBERON:0000061 .
+
 UBERON:0003103 a owl:Class ;
     rdfs:label "compound organ" ;
-    NIFRID:synonym "organ" ;
+    NIFRID:synonym "compound organ",
+        "organ" ;
     rdfs:subClassOf UBERON:0000062 .
 
 UBERON:0003126 a owl:Class ;
     rdfs:label "trachea" ;
     NIFRID:synonym "cartilaginous trachea",
+        "trachea",
         "tracheal tubule",
         "vertebrate trachea",
         "windpipe" ;
@@ -13618,37 +16511,25 @@ UBERON:0003126 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001004 ] .
 
-UBERON:0003127 a owl:Class ;
-    rdfs:label "open tracheal system trachea" ;
-    NIFRID:synonym "invertebrate trachea",
-        "trachea" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0001005,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005155 ] .
-
 UBERON:0003128 a owl:Class ;
     rdfs:label "cranium" ;
     NIFRID:synonym "bones of cranium",
         "calvarium",
+        "cranium",
         "epicranial plate",
         "ossa cranii",
         "set of bones of cranium",
         "skeletal system of head",
         "skull minus mandible",
         "upper part of skull" ;
-    rdfs:subClassOf UBERON:0000075,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0003129 ] .
+    rdfs:subClassOf UBERON:0000075 .
 
 UBERON:0003129 a owl:Class ;
     rdfs:label "skull" ;
     NIFRID:synonym "cranial skeleton",
-        "skeletal system of head" ;
+        "skeletal system of head",
+        "skull" ;
     rdfs:subClassOf UBERON:0000075,
-        UBERON:0010314,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000033 ],
@@ -13660,6 +16541,7 @@ UBERON:0003133 a owl:Class ;
     rdfs:label "reproductive organ" ;
     NIFRID:synonym "genital organ",
         "genitalia",
+        "reproductive organ",
         "reproductive system organ",
         "sex organ" ;
     rdfs:subClassOf UBERON:0000062,
@@ -13675,6 +16557,7 @@ UBERON:0003134 a owl:Class ;
         "female organism reproductive system organ",
         "female organism sex organ",
         "female reproductive gland/organ",
+        "female reproductive organ",
         "female reproductive system organ",
         "female sex organ",
         "reproductive organ of female organism",
@@ -13711,15 +16594,36 @@ UBERON:0003135 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0003101 ] .
 
-UBERON:0003296 a owl:Class ;
-    rdfs:label "gland of diencephalon" ;
-    NIFRID:synonym "diencephalon gland",
-        "interbrain gland" ;
+UBERON:0003222 a owl:Class ;
+    rdfs:label "flexor digitorum superficialis" ;
+    NIFRID:synonym "flexor digitorum superficialis muscle",
+        "musculus flexor digitorum superficialis" ;
+    rdfs:subClassOf UBERON:0004254 .
+
+UBERON:0003228 a owl:Class ;
+    rdfs:label "supinator muscle" ;
+    NIFRID:synonym "musculus supinator",
+        "supinator",
+        "supinator brevus" ;
+    rdfs:subClassOf UBERON:0004254 .
+
+UBERON:0003234 a owl:Class ;
+    rdfs:label "extensor pollicis longus muscle" ;
+    NIFRID:synonym "extensor pollicis longis",
+        "extensor pollicis longus",
+        "musculus extensor pollicis longus" ;
+    rdfs:subClassOf UBERON:0011024 .
+
+UBERON:0003297 a owl:Class ;
+    rdfs:label "gland of integumental system" ;
+    NIFRID:synonym "gland of integumental system",
+        "integumental gland",
+        "integumental system gland",
+        "integumentary gland" ;
     rdfs:subClassOf UBERON:0002530,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001894 ] .
+            owl:someValuesFrom UBERON:0002416 ] .
 
 UBERON:0003335 a owl:Class ;
     rdfs:label "serosa of colon" ;
@@ -13728,6 +16632,7 @@ UBERON:0003335 a owl:Class ;
         "colonic serosa",
         "large bowel serosa",
         "large bowel serous membrane",
+        "serosa of colon",
         "serosa of large bowel",
         "serous membrane of colon",
         "serous membrane of large bowel",
@@ -13739,7 +16644,8 @@ UBERON:0003335 a owl:Class ;
 
 UBERON:0003338 a owl:Class ;
     rdfs:label "ganglion of peripheral nervous system" ;
-    NIFRID:synonym "peripheral nervous system ganglion" ;
+    NIFRID:synonym "ganglion of peripheral nervous system",
+        "peripheral nervous system ganglion" ;
     rdfs:subClassOf UBERON:0000045,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -13747,24 +16653,107 @@ UBERON:0003338 a owl:Class ;
 
 UBERON:0003350 a owl:Class ;
     rdfs:label "epithelium of mucosa" ;
-    NIFRID:synonym "lamina epithelialis mucosa",
+    NIFRID:synonym "epithelium of mucosa",
+        "lamina epithelialis mucosa",
         "lamina epithelialis mucosae" ;
     rdfs:subClassOf UBERON:0000483,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000344 ] .
 
+UBERON:0003354 a owl:Class ;
+    rdfs:label "epithelium of rectum" ;
+    NIFRID:synonym "epithelial tissue of rectum",
+        "epithelium of rectum",
+        "rectal epithelium",
+        "rectum epithelial tissue",
+        "rectum epithelium" ;
+    rdfs:subClassOf UBERON:0001278,
+        UBERON:0016885,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001052 ] .
+
+UBERON:0003379 a owl:Class ;
+    rdfs:label "cardiac muscle of right atrium" ;
+    NIFRID:synonym "cardiac muscle of cardiac right atrium",
+        "cardiac muscle of heart right atrium",
+        "cardiac muscle of right atrium",
+        "cardiac muscle tissue of heart right atrium",
+        "cardiac muscle tissue of right atrium",
+        "cardiac muscle tissue of right atrium of heart",
+        "myocardium of right atrium",
+        "right atrium heart muscle",
+        "right atrium myocardium",
+        "textus muscularis of myocardium of right atrium",
+        "textus muscularis of myocardium of right atrium of heart",
+        "textus muscularis of myocardium of right cardiac atrium" ;
+    rdfs:subClassOf UBERON:0004490,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002078 ] .
+
+UBERON:0003380 a owl:Class ;
+    rdfs:label "cardiac muscle of left atrium" ;
+    NIFRID:synonym "cardiac left atrium cardiac muscle",
+        "cardiac left atrium cardiac muscle tissue",
+        "cardiac muscle of cardiac left atrium",
+        "cardiac muscle of heart left atrium",
+        "cardiac muscle of left atrium",
+        "cardiac muscle of left atrium of heart",
+        "left atrium heart muscle",
+        "left atrium myocardium",
+        "myocardium of left atrium",
+        "textus muscularis of myocardium of cardiac left atrium",
+        "textus muscularis of myocardium of heart left atrium",
+        "textus muscularis of myocardium of left atrium",
+        "textus muscularis of myocardium of left atrium of heart",
+        "textus muscularis of myocardium of left cardiac atrium" ;
+    rdfs:subClassOf UBERON:0004490,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002079 ] .
+
 UBERON:0003386 a owl:Class ;
     rdfs:label "smooth muscle of eye" ;
-    NIFRID:synonym "ocular smooth muscle" ;
+    NIFRID:synonym "ocular smooth muscle",
+        "smooth muscle of eye" ;
     rdfs:subClassOf UBERON:0001135,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000019 ],
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001015 ] .
+
+UBERON:0003388 a owl:Class ;
+    rdfs:label "mesothelium of pericardial cavity" ;
+    NIFRID:synonym "cavity of pericardial sac meso-epithelium",
+        "cavity of pericardial sac mesothelium",
+        "meso-epithelium of cavity of pericardial sac",
+        "meso-epithelium of pericardial cavity",
+        "mesothelium of cavity of pericardial sac",
+        "mesothelium of pericardial cavity",
+        "pericardial cavity meso-epithelium",
+        "pericardial cavity mesothelium" ;
+    rdfs:subClassOf UBERON:0001136,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002407 ] .
+
+UBERON:0003403 a owl:Class ;
+    rdfs:label "skin of forearm" ;
+    NIFRID:synonym "forearm skin",
+        "lower arm skin",
+        "lower segment of arm skin",
+        "skin of antebrachial region",
+        "skin of lower arm",
+        "skin of lower segment of arm",
+        "skin of zeugopod of arm" ;
+    rdfs:subClassOf UBERON:0002427,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002386 ] .
 
 UBERON:0003408 a owl:Class ;
     rdfs:label "gland of digestive tract" ;
@@ -13779,9 +16768,28 @@ UBERON:0003408 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001555 ] .
 
+UBERON:0003431 a owl:Class ;
+    rdfs:label "leg nerve" ;
+    NIFRID:synonym "nerve of leg" ;
+    rdfs:subClassOf UBERON:0003442,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000978 ] .
+
+UBERON:0003433 a owl:Class ;
+    rdfs:label "arm nerve" ;
+    NIFRID:synonym "brachial region nerve",
+        "nerve of arm",
+        "nerve of brachial region" ;
+    rdfs:subClassOf UBERON:0003441,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ] .
+
 UBERON:0003438 a owl:Class ;
     rdfs:label "iris nerve" ;
     NIFRID:synonym "ciliary nerve",
+        "iris nerve",
         "nerve of iris" ;
     rdfs:subClassOf UBERON:0001021 .
 
@@ -13789,12 +16797,46 @@ UBERON:0003439 a owl:Class ;
     rdfs:label "nerve of trunk region" ;
     NIFRID:synonym "nerve of torso",
         "nerve of trunk",
+        "nerve of trunk region",
         "torso nerve",
         "trunk nerve" ;
     rdfs:subClassOf UBERON:0001021,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002100 ] .
+
+UBERON:0003440 a owl:Class ;
+    rdfs:label "limb nerve" ;
+    NIFRID:synonym "nerve of limb" ;
+    rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002101 ] .
+
+UBERON:0003441 a owl:Class ;
+    rdfs:label "forelimb nerve" ;
+    NIFRID:synonym "fore limb nerve",
+        "nerve of fore limb",
+        "nerve of forelimb",
+        "nerve of superior member",
+        "nerve of upper extremity",
+        "wing nerve" ;
+    rdfs:subClassOf UBERON:0003440,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
+
+UBERON:0003442 a owl:Class ;
+    rdfs:label "hindlimb nerve" ;
+    NIFRID:synonym "hind limb nerve",
+        "nerve of hind limb",
+        "nerve of hindlimb",
+        "nerve of inferior member",
+        "nerve of lower extremity" ;
+    rdfs:subClassOf UBERON:0003440,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002103 ] .
 
 UBERON:0003443 a owl:Class ;
     rdfs:label "thoracic cavity nerve" ;
@@ -13806,7 +16848,8 @@ UBERON:0003443 a owl:Class ;
         "nerve of chest cavity",
         "nerve of pectoral cavity",
         "nerve of thoracic cavity",
-        "pectoral cavity nerve" ;
+        "pectoral cavity nerve",
+        "thoracic cavity nerve" ;
     rdfs:subClassOf UBERON:0001021 .
 
 UBERON:0003444 a owl:Class ;
@@ -13817,12 +16860,75 @@ UBERON:0003444 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002355 ] .
 
+UBERON:0003463 a owl:Class ;
+    rdfs:label "trunk bone" ;
+    NIFRID:synonym "bone of torso",
+        "bone of trunk",
+        "bone organ of torso",
+        "bone organ of trunk",
+        "torso bone",
+        "torso bone organ",
+        "trunk bone",
+        "trunk bone organ" ;
+    rdfs:subClassOf UBERON:0001474,
+        UBERON:0005177,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002100 ] .
+
+UBERON:0003496 a owl:Class ;
+    rdfs:label "head blood vessel" ;
+    NIFRID:synonym "adult head blood vessel",
+        "blood vessel of adult head",
+        "blood vessel of head",
+        "head blood vessel" ;
+    rdfs:subClassOf UBERON:0001981,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000033 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0011362 ] .
+
+UBERON:0003497 a owl:Class ;
+    rdfs:label "abdomen blood vessel" ;
+    NIFRID:synonym "abdomen blood vessel",
+        "blood vessel of abdomen" ;
+    rdfs:subClassOf UBERON:0003835,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000916 ] .
+
 UBERON:0003509 a owl:Class ;
     rdfs:label "arterial blood vessel" ;
+    NIFRID:synonym "arterial blood vessel" ;
     rdfs:subClassOf UBERON:0001981,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004572 ] .
+
+UBERON:0003513 a owl:Class ;
+    rdfs:label "trunk blood vessel" ;
+    NIFRID:synonym "blood vessel of torso",
+        "blood vessel of trunk",
+        "torso blood vessel",
+        "trunk blood vessel" ;
+    rdfs:subClassOf UBERON:0001981,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002100 ] .
+
+UBERON:0003517 a owl:Class ;
+    rdfs:label "kidney blood vessel" ;
+    NIFRID:synonym "blood vessel of kidney",
+        "renal blood vessel" ;
+    rdfs:subClassOf UBERON:0003497,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002113 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006544 ] .
 
 UBERON:0003519 a owl:Class ;
     rdfs:label "thoracic cavity blood vessel" ;
@@ -13834,12 +16940,31 @@ UBERON:0003519 a owl:Class ;
         "cavity of chest blood vessel",
         "cavity of thorax blood vessel",
         "chest cavity blood vessel",
-        "pectoral cavity blood vessel" ;
+        "pectoral cavity blood vessel",
+        "thoracic cavity blood vessel" ;
     rdfs:subClassOf UBERON:0001981 .
+
+UBERON:0003527 a owl:Class ;
+    rdfs:label "kidney capillary" ;
+    NIFRID:synonym "blood capillary of kidney",
+        "capillary of kidney",
+        "capillary vessel of kidney",
+        "kidney blood capillary",
+        "kidney capillary vessel",
+        "renal capillary" ;
+    rdfs:subClassOf UBERON:0001982,
+        UBERON:0003517,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002113 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006544 ] .
 
 UBERON:0003528 a owl:Class ;
     rdfs:label "brain gray matter" ;
-    NIFRID:synonym "brain grey matter",
+    NIFRID:synonym "brain gray matter",
+        "brain grey matter",
         "brain grey substance",
         "gray matter of brain",
         "grey matter of brain",
@@ -13849,9 +16974,71 @@ UBERON:0003528 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000955 ] .
 
+UBERON:0003531 a owl:Class ;
+    rdfs:label "forelimb skin" ;
+    NIFRID:synonym "anteriormost limb skin",
+        "fore limb skin",
+        "skin of fore limb",
+        "skin of forelimb",
+        "skin of upper limb",
+        "upper limb skin",
+        "wing skin" ;
+    rdfs:subClassOf UBERON:0001419,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
+
+UBERON:0003532 a owl:Class ;
+    rdfs:label "hindlimb skin" ;
+    NIFRID:synonym "hind limb skin",
+        "lower limb skin",
+        "skin of hind limb",
+        "skin of hindlimb",
+        "skin of lower extremity",
+        "skin of lower limb" ;
+    rdfs:subClassOf UBERON:0001419,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002103 ] .
+
+UBERON:0003533 a owl:Class ;
+    rdfs:label "manual digit skin" ;
+    NIFRID:synonym "digit of hand skin",
+        "digit of terminal segment of free upper limb skin",
+        "digitus manus skin",
+        "finger skin",
+        "fore limb digit skin",
+        "hand digit skin",
+        "skin of digit of hand",
+        "skin of digit of terminal segment of free upper limb",
+        "skin of digitus manus",
+        "skin of finger",
+        "skin of hand digit",
+        "skin of terminal segment of free upper limb digit",
+        "terminal segment of free upper limb digit skin" ;
+    rdfs:subClassOf UBERON:0001519,
+        UBERON:0015249,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002389 ] .
+
+UBERON:0003535 a owl:Class ;
+    rdfs:label "vagus X nerve trunk" ;
+    NIFRID:synonym "trunk of vagal nerve",
+        "trunk of vagus nerve",
+        "vagal nerve trunk",
+        "vagal X nerve trunk",
+        "vagus nerve trunk",
+        "vagus neural trunk" ;
+    rdfs:subClassOf UBERON:0002464,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001759 ] .
+
 UBERON:0003544 a owl:Class ;
     rdfs:label "brain white matter" ;
-    NIFRID:synonym "brain white matter of neuraxis",
+    NIFRID:synonym "brain white matter",
+        "brain white matter of neuraxis",
         "brain white substance",
         "white matter of brain",
         "white matter of neuraxis of brain",
@@ -13864,36 +17051,6 @@ UBERON:0003544 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000955 ] .
 
-UBERON:0003567 a owl:Class ;
-    rdfs:label "abdomen connective tissue" ;
-    NIFRID:synonym "abdomen portion of connective tissue",
-        "abdomen textus connectivus",
-        "connective tissue of abdomen",
-        "portion of connective tissue of abdomen",
-        "textus connectivus of abdomen" ;
-    rdfs:subClassOf UBERON:0003838,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000916 ] .
-
-UBERON:0003568 a owl:Class ;
-    rdfs:label "neck connective tissue" ;
-    NIFRID:synonym "connective tissue of neck",
-        "connective tissue of neck (volume)",
-        "neck (volume) connective tissue",
-        "neck (volume) portion of connective tissue",
-        "neck (volume) textus connectivus",
-        "neck portion of connective tissue",
-        "neck textus connectivus",
-        "portion of connective tissue of neck",
-        "portion of connective tissue of neck (volume)",
-        "textus connectivus of neck",
-        "textus connectivus of neck (volume)" ;
-    rdfs:subClassOf UBERON:0002384,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000974 ] .
-
 UBERON:0003586 a owl:Class ;
     rdfs:label "trunk connective tissue" ;
     NIFRID:synonym "connective tissue of torso",
@@ -13905,6 +17062,7 @@ UBERON:0003586 a owl:Class ;
         "torso connective tissue",
         "torso portion of connective tissue",
         "torso textus connectivus",
+        "trunk connective tissue",
         "trunk portion of connective tissue",
         "trunk textus connectivus" ;
     rdfs:subClassOf UBERON:0002384,
@@ -13912,9 +17070,178 @@ UBERON:0003586 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002100 ] .
 
+UBERON:0003622 a owl:Class ;
+    rdfs:label "manual digit 2" ;
+    NIFRID:synonym "2nd digit of hand",
+        "2nd finger",
+        "digit 2 of fore-paw",
+        "finger 2",
+        "fore digit II",
+        "fore limb digit 2",
+        "hand digit 2",
+        "index finger",
+        "manual digit II",
+        "second digit of hand",
+        "second finger" ;
+    rdfs:subClassOf UBERON:0006049,
+        UBERON:0019232,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012141 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:5003622 ] .
+
+UBERON:0003623 a owl:Class ;
+    rdfs:label "manual digit 3" ;
+    NIFRID:synonym "3rd digit of hand",
+        "3rd finger",
+        "digit 3 of fore-paw",
+        "digitus medius",
+        "finger 3",
+        "fore digit III",
+        "fore limb digit 3",
+        "hand digit 3",
+        "long finger",
+        "manual digit III",
+        "middle finger",
+        "third digit of hand",
+        "third finger" ;
+    rdfs:subClassOf UBERON:0006050,
+        UBERON:0019232,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012141 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:5003623 ] .
+
+UBERON:0003644 a owl:Class ;
+    rdfs:label "kidney arterial blood vessel" ;
+    NIFRID:synonym "kidney arterial system" ;
+    rdfs:subClassOf UBERON:0003509,
+        UBERON:0003517,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002113 ] .
+
+UBERON:0003657 a owl:Class ;
+    rdfs:label "limb joint" ;
+    NIFRID:synonym "joint of limb",
+        "joint of limb skeletal system",
+        "skeletal limb joint" ;
+    rdfs:subClassOf UBERON:0000982,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002101 ] .
+
+UBERON:0003658 a owl:Class ;
+    rdfs:label "hip muscle" ;
+    NIFRID:synonym "hip muscle organ",
+        "hip region muscle organ",
+        "muscle organ of hip",
+        "muscle organ of hip region",
+        "muscle organ of regio coxae",
+        "regio coxae muscle organ" ;
+    rdfs:subClassOf UBERON:0010890,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001464 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004475 ] .
+
+UBERON:0003661 a owl:Class ;
+    rdfs:label "limb muscle" ;
+    NIFRID:synonym "limb muscle organ",
+        "limb skeletal muscle",
+        "muscle organ of limb" ;
+    rdfs:subClassOf UBERON:0014892,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002101 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004480 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001015 ] .
+
+UBERON:0003662 a owl:Class ;
+    rdfs:label "forelimb muscle" ;
+    NIFRID:synonym "arm muscle system",
+        "fore limb muscle organ",
+        "forelimb muscle organ",
+        "free upper limb muscle",
+        "muscle of free upper limb",
+        "muscle of upper limb",
+        "musculature of arm",
+        "musculature of the arm",
+        "upper limb skeletal muscle",
+        "wing muscle" ;
+    rdfs:subClassOf UBERON:0003661,
+        UBERON:0014794,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004481 ] .
+
+UBERON:0003663 a owl:Class ;
+    rdfs:label "hindlimb muscle" ;
+    NIFRID:synonym "free lower limb muscle",
+        "hind limb muscle organ",
+        "hindlimb muscle organ",
+        "inferior member muscle organ",
+        "lower extremity muscle organ",
+        "lower limb skeletal muscle",
+        "muscle of free lower limb",
+        "muscle of posterior limb",
+        "muscle organ of hind limb",
+        "muscle organ of hindlimb",
+        "muscle organ of inferior member",
+        "muscle organ of lower extremity" ;
+    rdfs:subClassOf UBERON:0003661,
+        UBERON:0014795,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002103 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004482 ] .
+
+UBERON:0003683 a owl:Class ;
+    rdfs:label "rotator cuff" ;
+    NIFRID:synonym "musculotendinous cuff",
+        "rotator cuff",
+        "tendinous cuff" ;
+    rdfs:subClassOf UBERON:0000477,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001467 ] .
+
+UBERON:0003692 a owl:Class ;
+    rdfs:label "acromioclavicular joint" ;
+    NIFRID:synonym "acromioclavicular articulation",
+        "articulatio acromioclavicularis",
+        "scapuloclavicular articulation" ;
+    rdfs:subClassOf UBERON:0011108,
+        UBERON:0016884,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001467 ] .
+
 UBERON:0003697 a owl:Class ;
     rdfs:label "abdominal wall" ;
-    NIFRID:synonym "abdominal wall proper",
+    NIFRID:synonym "abdominal wall",
+        "abdominal wall proper",
         "layers of the abdominal wall",
         "paries abdominalis",
         "wall of abdomen",
@@ -13924,6 +17251,13 @@ UBERON:0003697 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000916 ] .
 
+UBERON:0003703 a owl:Class ;
+    rdfs:label "extrahepatic bile duct" ;
+    NIFRID:synonym "bile duct extrahepatic part",
+        "extrahepatic bile duct",
+        "extrahepatic biliary system" ;
+    rdfs:subClassOf UBERON:0002394 .
+
 UBERON:0003708 a owl:Class ;
     rdfs:label "carotid sinus" ;
     NIFRID:synonym "carotid bulb",
@@ -13932,7 +17266,8 @@ UBERON:0003708 a owl:Class ;
 
 UBERON:0003711 a owl:Class ;
     rdfs:label "brachiocephalic vein" ;
-    NIFRID:synonym "brachiocephalic venous tree",
+    NIFRID:synonym "brachiocephalic vein",
+        "brachiocephalic venous tree",
         "innomiate vein",
         "innominate trunk",
         "innominate vein",
@@ -13940,6 +17275,9 @@ UBERON:0003711 a owl:Class ;
         "vena brachiocephalica",
         "venae anonyma" ;
     rdfs:subClassOf UBERON:0001638,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0007204 ] .
@@ -13954,9 +17292,21 @@ UBERON:0003712 a owl:Class ;
         "sinus cavernosus" ;
     rdfs:subClassOf UBERON:0005486 .
 
+UBERON:0003714 a owl:Class ;
+    rdfs:label "neural tissue" ;
+    NIFRID:synonym "nerve tissue",
+        "nervous tissue",
+        "neural tissue",
+        "portion of neural tissue" ;
+    rdfs:subClassOf UBERON:0000479,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001016 ] .
+
 UBERON:0003715 a owl:Class ;
     rdfs:label "splanchnic nerve" ;
-    NIFRID:synonym "splanchnic nerves",
+    NIFRID:synonym "splanchnic nerve",
+        "splanchnic nerves",
         "visceral nerve" ;
     rdfs:subClassOf UBERON:0034729,
         [ a owl:Restriction ;
@@ -13967,23 +17317,59 @@ UBERON:0003715 a owl:Class ;
             owl:someValuesFrom UBERON:0000013 ] .
 
 UBERON:0003716 a owl:Class ;
-    rdfs:label "Recurrent Laryngeal Nerve",
-        "recurrent laryngeal nerve" ;
+    rdfs:label "recurrent laryngeal nerve" ;
     NIFRID:synonym "inferior laryngeal nerve",
         "nervus laryngeus recurrens",
         "ramus recurrens",
+        "recurrent laryngeal nerve",
         "recurrent laryngeal nerve from vagus nerve",
         "recurrent nerve",
         "vagus X nerve recurrent laryngeal branch" ;
     rdfs:subClassOf UBERON:0011779,
-        UBERON:0035642 .
+        UBERON:0035642,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001759 ] .
 
 UBERON:0003721 a owl:Class ;
     rdfs:label "lingual nerve" ;
     NIFRID:synonym "lingual branch of trigeminal nerve",
+        "lingual nerve",
         "trigeminal nerve lingual branch",
         "trigeminal V nerve lingual branch" ;
-    rdfs:subClassOf UBERON:0011779 .
+    rdfs:subClassOf UBERON:0011779,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000375 ] .
+
+UBERON:0003724 a owl:Class ;
+    rdfs:label "musculocutaneous nerve" ;
+    NIFRID:synonym "casserio's nerve",
+        "nervus musculocutaneus" ;
+    rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001814 ] .
+
+UBERON:0003726 a owl:Class ;
+    rdfs:label "thoracic nerve" ;
+    NIFRID:synonym "nervi thoracici",
+        "nervus thoracis",
+        "pectoral nerve",
+        "thoracic nerve",
+        "thoracic spinal nerve" ;
+    rdfs:subClassOf UBERON:0001780 .
+
+UBERON:0003727 a owl:Class ;
+    rdfs:label "intercostal nerve" ;
+    NIFRID:synonym "anterior ramus of thoracic nerve",
+        "anterior ramus of thoracic spinal nerve",
+        "intercostal nerve",
+        "nervi intercostales",
+        "ramus anterior, nervus thoracicus",
+        "thoracic anterior ramus",
+        "ventral ramus of thoracic spinal nerve" ;
+    rdfs:subClassOf UBERON:0001780 .
 
 UBERON:0003729 a owl:Class ;
     rdfs:label "mouth mucosa" ;
@@ -14006,9 +17392,72 @@ UBERON:0003729 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001007 ] .
 
+UBERON:0003822 a owl:Class ;
+    rdfs:label "forelimb stylopod" ;
+    NIFRID:synonym "arm",
+        "brachial region",
+        "brachium",
+        "fore propodium",
+        "forelimb propodium",
+        "forelimb stylopodial element",
+        "forelimb stylopodium",
+        "proximal segment of free upper limb",
+        "regio brachialis",
+        "stylopod of arm",
+        "stylopod of forelimb",
+        "upper arm",
+        "wing stylopod" ;
+    rdfs:subClassOf UBERON:0002472,
+        UBERON:0008785,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002102 ] .
+
+UBERON:0003823 a owl:Class ;
+    rdfs:label "hindlimb zeugopod" ;
+    NIFRID:synonym "crus",
+        "crus of hindlimb",
+        "hind epipodium",
+        "hind limb middle limb segment",
+        "hind limb zeudopodium",
+        "hind limb zeugopod",
+        "hindlimb epipodium",
+        "hindlimb middle limb segment",
+        "hindlimb zeudopodium",
+        "hindlimb zeugopod",
+        "hindlimb zeugopodium",
+        "intermediate segment of free lower limb",
+        "leg",
+        "lower extremity middle limb segment",
+        "lower extremity zeugopod",
+        "lower leg",
+        "middle limb segment of hind limb",
+        "middle limb segment of hindlimb",
+        "shank",
+        "zeugopod of hind limb",
+        "zeugopod of hindlimb" ;
+    rdfs:subClassOf UBERON:0002471,
+        UBERON:0008784,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000978 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002103 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002103 ] .
+
 UBERON:0003824 a owl:Class ;
     rdfs:label "nerve of thoracic segment" ;
-    NIFRID:synonym "nerve of thorax",
+    NIFRID:synonym "nerve of thoracic segment",
+        "nerve of thorax",
         "thoracic segment nerve",
         "thorax nerve",
         "upper body nerve" ;
@@ -14019,8 +17468,22 @@ UBERON:0003824 a owl:Class ;
 
 UBERON:0003825 a owl:Class ;
     rdfs:label "nerve of abdominal segment" ;
-    NIFRID:synonym "abdominal segment nerve" ;
+    NIFRID:synonym "abdominal segment nerve",
+        "nerve of abdominal segment" ;
     rdfs:subClassOf UBERON:0003439,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002417 ] .
+
+UBERON:0003828 a owl:Class ;
+    rdfs:label "abdominal segment bone" ;
+    NIFRID:synonym "abdominal segment bone",
+        "abdominal segment of trunk bone",
+        "abdominal segment of trunk bone organ",
+        "bone of abdominal segment of trunk",
+        "bone organ of abdominal segment of trunk" ;
+    rdfs:subClassOf UBERON:0003463,
+        UBERON:0005173,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002417 ] .
@@ -14028,8 +17491,7 @@ UBERON:0003825 a owl:Class ;
 UBERON:0003829 a owl:Class ;
     rdfs:label "urethra muscle tissue" ;
     NIFRID:synonym "urethral muscle layer" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0005090,
+    rdfs:subClassOf UBERON:0005090,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000057 ] .
@@ -14037,6 +17499,7 @@ UBERON:0003829 a owl:Class ;
 UBERON:0003830 a owl:Class ;
     rdfs:label "thoracic segment muscle" ;
     NIFRID:synonym "muscle organ of thorax",
+        "thoracic segment muscle",
         "thorax muscle organ",
         "upper body muscle" ;
     rdfs:subClassOf UBERON:0001774,
@@ -14053,6 +17516,7 @@ UBERON:0003831 a owl:Class ;
     NIFRID:synonym "apparatus respiratorius muscle organ",
         "muscle organ of apparatus respiratorius",
         "muscle organ of respiratory system",
+        "respiratory system muscle",
         "respiratory system muscle organ" ;
     rdfs:subClassOf UBERON:0001630,
         [ a owl:Restriction ;
@@ -14062,6 +17526,7 @@ UBERON:0003831 a owl:Class ;
 UBERON:0003832 a owl:Class ;
     rdfs:label "esophagus muscle" ;
     NIFRID:synonym "esophageal muscle",
+        "esophagus muscle",
         "esophagus muscle organ",
         "gullet muscle organ",
         "muscle organ of esophagus",
@@ -14078,22 +17543,91 @@ UBERON:0003832 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001096 ] .
 
-UBERON:0003838 a owl:Class ;
-    rdfs:label "abdominal segment connective tissue" ;
-    NIFRID:synonym "abdominal segment of trunk connective tissue",
-        "abdominal segment of trunk portion of connective tissue",
-        "abdominal segment of trunk textus connectivus",
-        "connective tissue of abdominal segment of trunk",
-        "portion of connective tissue of abdominal segment of trunk",
-        "textus connectivus of abdominal segment of trunk" ;
-    rdfs:subClassOf UBERON:0003586,
+UBERON:0003833 a owl:Class ;
+    rdfs:label "abdominal segment muscle" ;
+    NIFRID:synonym "abdominal segment muscle",
+        "abdominal segment of trunk muscle organ",
+        "muscle organ of abdominal segment of trunk" ;
+    rdfs:subClassOf UBERON:0001774,
+        UBERON:0005173,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002417 ] .
 
+UBERON:0003835 a owl:Class ;
+    rdfs:label "abdominal segment blood vessel" ;
+    NIFRID:synonym "abdominal segment blood vessel",
+        "abdominal segment of trunk blood vessel",
+        "blood vessel of abdominal segment of trunk" ;
+    rdfs:subClassOf UBERON:0003513,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002417 ] .
+
+UBERON:0003837 a owl:Class ;
+    rdfs:label "thoracic segment connective tissue" ;
+    NIFRID:synonym "connective tissue of thorax",
+        "portion of connective tissue of thorax",
+        "textus connectivus of thorax",
+        "thoracic segment connective tissue",
+        "thorax connective tissue",
+        "thorax portion of connective tissue",
+        "thorax textus connectivus",
+        "upper body connective tissue" ;
+    rdfs:subClassOf UBERON:0003586,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000915 ] .
+
+UBERON:0003839 a owl:Class ;
+    rdfs:label "forelimb joint" ;
+    NIFRID:synonym "anteriormost limb joint of limb",
+        "anteriormost limb limb joint",
+        "fore limb joint of limb",
+        "fore limb limb joint",
+        "forelimb joint of limb",
+        "forelimb limb joint",
+        "joint of free upper limb",
+        "joint of limb of anteriormost limb",
+        "joint of limb of fore limb",
+        "joint of limb of forelimb",
+        "joint of limb of superior member",
+        "joint of limb of upper extremity",
+        "limb joint of anteriormost limb",
+        "limb joint of fore limb",
+        "limb joint of forelimb",
+        "limb joint of superior member",
+        "limb joint of upper extremity",
+        "superior member joint of limb",
+        "superior member limb joint",
+        "upper extremity joint of limb",
+        "upper extremity limb joint",
+        "wing joint" ;
+    rdfs:subClassOf UBERON:0003657,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
+
+UBERON:0003841 a owl:Class ;
+    rdfs:label "autopod joint" ;
+    NIFRID:synonym "autopod joint of limb",
+        "autopod limb joint",
+        "distal free limb segment joint of limb",
+        "distal free limb segment limb joint",
+        "joint of limb of autopod",
+        "joint of limb of distal free limb segment",
+        "limb joint of autopod",
+        "limb joint of distal free limb segment",
+        "paw joint" ;
+    rdfs:subClassOf UBERON:0003657,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002470 ] .
+
 UBERON:0003876 a owl:Class ;
     rdfs:label "hippocampal field" ;
-    NIFRID:synonym "hippocampal region",
+    NIFRID:synonym "hippocampal field",
+        "hippocampal region",
         "hippocampus region",
         "hippocampus subdivision",
         "subdivision of hippocampus" ;
@@ -14200,10 +17734,10 @@ UBERON:0003889 a owl:Class ;
         UBERON:0015212,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000993 ],
+            owl:someValuesFrom UBERON:0002355 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002355 ] .
+            owl:someValuesFrom UBERON:0003975 ] .
 
 UBERON:0003891 a owl:Class ;
     rdfs:label "stroma" ;
@@ -14214,44 +17748,81 @@ UBERON:0003893 a owl:Class ;
     rdfs:label "capsule" ;
     rdfs:subClassOf UBERON:0000158 .
 
+UBERON:0003898 a owl:Class ;
+    rdfs:label "skeletal muscle tissue of trunk" ;
+    NIFRID:synonym "skeletal muscle of torso",
+        "skeletal muscle tissue of torso",
+        "skeletal muscle tissue of trunk",
+        "torso skeletal muscle",
+        "torso skeletal muscle tissue",
+        "trunk skeletal muscle",
+        "trunk skeletal muscle tissue" ;
+    rdfs:subClassOf UBERON:0001134,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002100 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004479 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0013700 ] .
+
 UBERON:0003902 a owl:Class ;
     rdfs:label "retinal neural layer" ;
     NIFRID:synonym "neural layer of retina",
         "neural retina",
         "neural retinal epithelium",
         "neuroretina",
+        "retinal neural layer",
         "stratum nervosum (retina)",
         "stratum nervosum retinae" ;
-    rdfs:subClassOf UBERON:0001781 .
+    rdfs:subClassOf UBERON:0001781,
+        UBERON:0004121 .
+
+UBERON:0003909 a owl:Class ;
+    rdfs:label "sinusoid" ;
+    NIFRID:synonym "endothelium of irregular blood filled space",
+        "sinusoidal blood vessel",
+        "sinusoidal blood vessel endothelium",
+        "sinusoidal capillary",
+        "sinusoidal endothelium" ;
+    rdfs:subClassOf UBERON:0001982,
+        UBERON:2005260 .
 
 UBERON:0003914 a owl:Class ;
     rdfs:label "epithelial tube" ;
-    NIFRID:synonym "epithelial or endothelial tube" ;
+    NIFRID:synonym "epithelial or endothelial tube",
+        "epithelial tube" ;
     rdfs:subClassOf UBERON:0000025,
-        UBERON:0000483,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0003127 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007501 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007502 ] .
+        UBERON:0000483 .
 
 UBERON:0003920 a owl:Class ;
     rdfs:label "venous blood vessel" ;
     NIFRID:synonym "segment of venous tree organ",
+        "venous blood vessel",
         "venous tree organ segment" ;
     rdfs:subClassOf UBERON:0001981,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004582 ] .
 
+UBERON:0003928 a owl:Class ;
+    rdfs:label "digestive system duct" ;
+    NIFRID:synonym "digestive system duct",
+        "duct of digestive system",
+        "duct of gastrointestinal system",
+        "gastrointestinal system duct" ;
+    rdfs:subClassOf UBERON:0000058,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001007 ] .
+
 UBERON:0003929 a owl:Class ;
     rdfs:label "digestive tract epithelium" ;
     NIFRID:synonym "alimentary tract epithelium",
         "digestive tract epithelial tissue",
+        "digestive tract epithelium",
         "epithelial tissue of digestive tract",
         "epithelial tissue of gut",
         "epithelium of digestive tract",
@@ -14278,6 +17849,13 @@ UBERON:0003937 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000990 ] .
 
+UBERON:0003942 a owl:Class ;
+    rdfs:label "somatosensory system" ;
+    NIFRID:synonym "somatic sensory system",
+        "somatosensory system",
+        "system for detection of somatic senses" ;
+    rdfs:subClassOf UBERON:0001032 .
+
 UBERON:0003943 a owl:Class ;
     rdfs:label "fourth lumbar dorsal root ganglion" ;
     NIFRID:synonym "forth lumbar dorsal root ganglion",
@@ -14286,17 +17864,6 @@ UBERON:0003943 a owl:Class ;
         "L4 dorsal root ganglion",
         "L4 ganglion" ;
     rdfs:subClassOf UBERON:0002836 .
-
-UBERON:0003947 a owl:Class ;
-    rdfs:label "brain ventricle/choroid plexus" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0010000,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000955 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0000955 ] .
 
 UBERON:0003962 a owl:Class ;
     rdfs:label "pterygopalatine ganglion" ;
@@ -14334,6 +17901,7 @@ UBERON:0003975 a owl:Class ;
     rdfs:label "internal female genitalia" ;
     NIFRID:synonym "female internal genitalia",
         "internal female genital organ",
+        "internal female genitalia",
         "internal genitalia of female reproductive system",
         "organa genitalia feminina interna" ;
     rdfs:subClassOf UBERON:0003134,
@@ -14351,29 +17919,10 @@ UBERON:0003984 a owl:Class ;
         "infundibulum tubae uterinae" ;
     rdfs:subClassOf UBERON:0013515 .
 
-UBERON:0003988 a owl:Class ;
-    rdfs:label "thymus corticomedullary boundary" ;
-    NIFRID:synonym "thymic cortico-medullary boundary",
-        "thymic corticomedullary boundary",
-        "thymic corticomedullary junction",
-        "thymic corticomedullary zone",
-        "thymus CMZ",
-        "thymus cortico-medullary boundary",
-        "thymus corticomedullary junction",
-        "thymus corticomedullary zone" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000077,
-        UBERON:0007651,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002125 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0002125 ] .
-
 UBERON:0004001 a owl:Class ;
     rdfs:label "olfactory bulb layer" ;
-    NIFRID:synonym "cytoarchitectural part of olfactory bulb" ;
+    NIFRID:synonym "cytoarchitectural part of olfactory bulb",
+        "olfactory bulb layer" ;
     rdfs:subClassOf UBERON:0011215,
         UBERON:0022303,
         [ a owl:Restriction ;
@@ -14382,20 +17931,6 @@ UBERON:0004001 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0002264 ] .
-
-UBERON:0004053 a owl:Class ;
-    rdfs:label "external male genitalia" ;
-    NIFRID:synonym "external male genital organ",
-        "male external genitalia",
-        "organa genitalia masculina externa" ;
-    rdfs:subClassOf UBERON:0003135,
-        UBERON:0004176,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000079 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0000079 ] .
 
 UBERON:0004054 a owl:Class ;
     rdfs:label "internal male genitalia" ;
@@ -14420,6 +17955,9 @@ UBERON:0004069 a owl:Class ;
     rdfs:subClassOf UBERON:0002616,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002264 ],
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
@@ -14434,16 +17972,28 @@ UBERON:0004069 a owl:Class ;
     ilxtr:hasIlxId ILX:0107936 ;
     ilxtr:hasIlxPreferredId UBERON:0004069 .
 
-UBERON:0004086 a owl:Class ;
-    rdfs:label "brain ventricle" ;
-    NIFRID:synonym "brain ventricles",
-        "cerebral ventricle",
-        "region of ventricular system of brain" ;
-    rdfs:subClassOf UBERON:0003947,
-        UBERON:0005358,
+UBERON:0004084 a owl:Class ;
+    rdfs:label "genital labium" ;
+    NIFRID:synonym "genital labia",
+        "labia",
+        "labium" ;
+    rdfs:subClassOf UBERON:0015212,
+        UBERON:8480029,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005282 ] .
+            owl:someValuesFrom UBERON:0000997 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0005056 ] .
+
+UBERON:0004085 a owl:Class ;
+    rdfs:label "labium majora" ;
+    NIFRID:synonym "labia majorum",
+        "labium majora",
+        "labium majorum",
+        "labium majus",
+        "labium majus pudendi" ;
+    rdfs:subClassOf UBERON:0004084 .
 
 UBERON:0004088 a owl:Class ;
     rdfs:label "orbital region" ;
@@ -14453,7 +18003,8 @@ UBERON:0004088 a owl:Class ;
         "ocular region",
         "orbital content",
         "orbital part of eye",
-        "orbital part of face" ;
+        "orbital part of face",
+        "orbital region" ;
     rdfs:subClassOf UBERON:0001444,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -14462,6 +18013,7 @@ UBERON:0004088 a owl:Class ;
 UBERON:0004089 a owl:Class ;
     rdfs:label "midface" ;
     NIFRID:synonym "lower face",
+        "midface",
         "midface/lower face",
         "snout" ;
     rdfs:subClassOf UBERON:0001444,
@@ -14472,9 +18024,17 @@ UBERON:0004089 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001456 ] .
 
+UBERON:0004105 a owl:Class ;
+    rdfs:label "subungual region" ;
+    rdfs:subClassOf UBERON:0000477,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001705 ] .
+
 UBERON:0004111 a owl:Class ;
     rdfs:label "anatomical conduit" ;
-    NIFRID:synonym "foramen",
+    NIFRID:synonym "anatomical conduit",
+        "foramen",
         "foramina",
         "opening",
         "ostia",
@@ -14483,32 +18043,25 @@ UBERON:0004111 a owl:Class ;
 
 UBERON:0004119 a owl:Class ;
     rdfs:label "endoderm-derived structure" ;
+    NIFRID:synonym "endoderm-derived structure" ;
     rdfs:subClassOf UBERON:0000061 .
 
 UBERON:0004120 a owl:Class ;
     rdfs:label "mesoderm-derived structure" ;
-    NIFRID:synonym "mesodermal derivative" ;
+    NIFRID:synonym "mesoderm-derived structure",
+        "mesodermal derivative" ;
     rdfs:subClassOf UBERON:0000061 .
 
 UBERON:0004121 a owl:Class ;
     rdfs:label "ectoderm-derived structure" ;
-    NIFRID:synonym "ectodermal deriviative" ;
+    NIFRID:synonym "ectoderm-derived structure",
+        "ectodermal deriviative" ;
     rdfs:subClassOf UBERON:0000061 .
-
-UBERON:0004122 a owl:Class ;
-    rdfs:label "genitourinary system" ;
-    NIFRID:synonym "genito-urinary system",
-        "genitourinary tract",
-        "GU tract",
-        "UG tract",
-        "urogenital system",
-        "urogenital tract",
-        "Urogenitalsystem" ;
-    rdfs:subClassOf UBERON:0000467 .
 
 UBERON:0004130 a owl:Class ;
     rdfs:label "cerebellar layer" ;
     NIFRID:synonym "cell layer of cerebellar cortex",
+        "cerebellar layer",
         "cytoarchitectural part of the cerebellar cortex",
         "gray matter layer of cerebellum",
         "layer of cerebellar cortex",
@@ -14532,14 +18085,16 @@ UBERON:0004132 a owl:Class ;
         "sensory trigeminal V nucleus",
         "trigeminal sensory nucleus",
         "trigeminal V sensory nucleus" ;
-    rdfs:subClassOf UBERON:0002925,
+    rdfs:subClassOf UBERON:0000126,
+        UBERON:0002925,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002925 ] .
 
 UBERON:0004133 a owl:Class ;
     rdfs:label "salivatory nucleus" ;
-    NIFRID:synonym "salivary nucleus" ;
+    NIFRID:synonym "salivary nucleus",
+        "salivatory nucleus" ;
     rdfs:subClassOf UBERON:0006331,
         UBERON:0009662,
         [ a owl:Restriction ;
@@ -14548,13 +18103,37 @@ UBERON:0004133 a owl:Class ;
 
 UBERON:0004151 a owl:Class ;
     rdfs:label "cardiac chamber" ;
-    NIFRID:synonym "chamber of heart",
+    NIFRID:synonym "cardiac chamber",
+        "chamber of heart",
         "heart chamber" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004120,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000948 ] .
+
+UBERON:0004170 a owl:Class ;
+    rdfs:label "spinal cord ventral commissure" ;
+    NIFRID:synonym "alba anterior medullae spinalis",
+        "anterior commissure",
+        "anterior white commissure",
+        "anterior white commissure of spinal cord",
+        "commissura alba anterior medullae spinalis",
+        "spinal cord anterior commissure",
+        "ventral commissure of the spinal cord",
+        "ventral spinal commissure",
+        "ventral white column",
+        "ventral white commissure of spinal cord",
+        "white commissure" ;
+    rdfs:subClassOf UBERON:0007838 .
+
+UBERON:0004171 a owl:Class ;
+    rdfs:label "trigeminothalamic tract" ;
+    NIFRID:synonym "tractus trigeminothalamicus",
+        "trigeminal tract" ;
+    rdfs:subClassOf UBERON:0001018,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003942 ] .
 
 UBERON:0004175 a owl:Class ;
     rdfs:label "internal genitalia" ;
@@ -14581,6 +18160,7 @@ UBERON:0004177 a owl:Class ;
         "hematopoeitic or lymphoid organ",
         "hematopoeitic organ",
         "hematopoietic system organ",
+        "hemopoietic organ",
         "lymph organ",
         "lymphoid organ",
         "organ of haematological system",
@@ -14589,7 +18169,6 @@ UBERON:0004177 a owl:Class ;
         "organ of organa haemopoietica",
         "organa haemopoietica organ" ;
     rdfs:subClassOf UBERON:0000062,
-        UBERON:0004120,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002390 ] .
@@ -14600,14 +18179,26 @@ UBERON:0004186 a owl:Class ;
         "mitral cell layer",
         "mitral cell layer of the olfactory bulb",
         "OB mitral cell layer",
-        "olfactory bulb main mitral cell body layer" ;
+        "olfactory bulb main mitral cell body layer",
+        "olfactory bulb mitral cell layer" ;
     rdfs:subClassOf UBERON:0004001 .
+
+UBERON:0004211 a owl:Class ;
+    rdfs:label "nephron epithelium" ;
+    NIFRID:synonym "epithelial tissue of nephron",
+        "epithelium of nephron",
+        "nephron epithelial tissue" ;
+    rdfs:subClassOf UBERON:0004819,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001285 ] .
 
 UBERON:0004220 a owl:Class ;
     rdfs:label "large intestine smooth muscle" ;
     NIFRID:synonym "involuntary muscle of large intestine",
         "large intestine involuntary muscle",
         "large intestine non-striated muscle",
+        "large intestine smooth muscle",
         "large intestine smooth muscle tissue",
         "non-striated muscle of large intestine",
         "smooth muscle of large intestine",
@@ -14630,6 +18221,7 @@ UBERON:0004221 a owl:Class ;
         "intestinal smooth muscle",
         "intestine involuntary muscle",
         "intestine non-striated muscle",
+        "intestine smooth muscle",
         "intestine smooth muscle tissue",
         "involuntary muscle of bowel",
         "involuntary muscle of intestine",
@@ -14665,6 +18257,7 @@ UBERON:0004222 a owl:Class ;
         "stomach involuntary muscle",
         "stomach muscle",
         "stomach non-striated muscle",
+        "stomach smooth muscle",
         "stomach smooth muscle tissue",
         "ventriculus involuntary muscle",
         "ventriculus non-striated muscle",
@@ -14697,7 +18290,8 @@ UBERON:0004223 a owl:Class ;
 
 UBERON:0004226 a owl:Class ;
     rdfs:label "gastrointestinal system smooth muscle" ;
-    NIFRID:synonym "smooth muscle tissue of gastrointestinal system" ;
+    NIFRID:synonym "gastrointestinal system smooth muscle",
+        "smooth muscle tissue of gastrointestinal system" ;
     rdfs:subClassOf UBERON:0001135,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -14709,6 +18303,7 @@ UBERON:0004234 a owl:Class ;
         "iridial smooth muscle",
         "iris involuntary muscle",
         "iris non-striated muscle",
+        "iris smooth muscle",
         "iris smooth muscle tissue",
         "non-striated muscle of iris",
         "smooth muscle of iris",
@@ -14720,6 +18315,32 @@ UBERON:0004234 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001769 ] .
+
+UBERON:0004239 a owl:Class ;
+    rdfs:label "small intestine smooth muscle" ;
+    NIFRID:synonym "involuntary muscle of small bowel",
+        "involuntary muscle of small intestine",
+        "non-striated muscle of small bowel",
+        "non-striated muscle of small intestine",
+        "small bowel involuntary muscle",
+        "small bowel non-striated muscle",
+        "small bowel smooth muscle",
+        "small bowel smooth muscle tissue",
+        "small intestine involuntary muscle",
+        "small intestine non-striated muscle",
+        "small intestine smooth muscle",
+        "small intestine smooth muscle tissue",
+        "smooth muscle of small bowel",
+        "smooth muscle of small intestine",
+        "smooth muscle tissue of small bowel",
+        "smooth muscle tissue of small intestine" ;
+    rdfs:subClassOf UBERON:0004221,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001168 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002108 ] .
 
 UBERON:0004243 a owl:Class ;
     rdfs:label "prostate gland smooth muscle" ;
@@ -14746,10 +18367,87 @@ UBERON:0004243 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002367 ] .
 
+UBERON:0004252 a owl:Class ;
+    rdfs:label "hindlimb stylopod muscle" ;
+    NIFRID:synonym "muscle of thigh",
+        "thigh muscle",
+        "upper leg muscle" ;
+    rdfs:subClassOf UBERON:0001383,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000376 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004463 ] .
+
+UBERON:0004254 a owl:Class ;
+    rdfs:label "forelimb zeugopod muscle" ;
+    NIFRID:synonym "forearm muscle",
+        "lower arm muscle",
+        "muscle of forearm",
+        "wing zeugopod muscle" ;
+    rdfs:subClassOf UBERON:0001499,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002386 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004487 ] .
+
+UBERON:0004255 a owl:Class ;
+    rdfs:label "forelimb stylopod muscle" ;
+    NIFRID:synonym "muscle of arm",
+        "muscle of upper arm",
+        "skeletal muscle of upper arm",
+        "upper arm muscle",
+        "wing stylopod muscle" ;
+    rdfs:subClassOf UBERON:0001499,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003822 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0014791 ] .
+
+UBERON:0004256 a owl:Class ;
+    rdfs:label "hindlimb zeugopod muscle" ;
+    NIFRID:synonym "calf muscle",
+        "lower leg muscle",
+        "muscle of leg" ;
+    rdfs:subClassOf UBERON:0001383,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003823 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006067 ] .
+
+UBERON:0004262 a owl:Class ;
+    rdfs:label "upper leg skin" ;
+    NIFRID:synonym "hind limb stylopod skin",
+        "hindlimb stylopod skin",
+        "skin of thigh",
+        "skin of upper leg",
+        "thigh skin" ;
+    rdfs:subClassOf UBERON:0001511,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000376 ] .
+
+UBERON:0004263 a owl:Class ;
+    rdfs:label "upper arm skin" ;
+    NIFRID:synonym "arm stylopod skin",
+        "skin of arm stylopod",
+        "skin of upper arm" ;
+    rdfs:subClassOf UBERON:0002427,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003822 ] .
+
 UBERON:0004277 a owl:Class ;
     rdfs:label "eye muscle" ;
+    NIFRID:synonym "eye muscle" ;
     rdfs:subClassOf UBERON:0001630,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000019 ],
@@ -14757,10 +18455,24 @@ UBERON:0004277 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000019 ] .
 
+UBERON:0004288 a owl:Class ;
+    rdfs:label "skeleton" ;
+    NIFRID:synonym "set of all bones",
+        "set of bones of body",
+        "skeleton" ;
+    rdfs:subClassOf UBERON:0034925,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001434 ] .
+
 UBERON:0004293 a owl:Class ;
     rdfs:label "parasympathetic nerve" ;
-    NIFRID:synonym "nerve of parasympathetic nervous system" ;
+    NIFRID:synonym "nerve of parasympathetic nervous system",
+        "parasympathetic nerve" ;
     rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000011 ] .
@@ -14775,15 +18487,48 @@ UBERON:0004295 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000013 ] .
 
+UBERON:0004452 a owl:Class ;
+    rdfs:label "carpal region" ;
+    NIFRID:synonym "articulatio radiocarpea",
+        "carpal limb segment",
+        "carpal segment",
+        "carpus",
+        "carpus of fore-paw",
+        "fore basipodium",
+        "fore mesopodium",
+        "hand mesopodium",
+        "manus mesopodium",
+        "regio carpalis",
+        "wrist",
+        "wrist region" ;
+    rdfs:subClassOf UBERON:0006716,
+        UBERON:0008785,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
+
 UBERON:0004456 a owl:Class ;
     rdfs:label "entire sense organ system" ;
-    NIFRID:synonym "sense organ system" ;
+    NIFRID:synonym "entire sense organ system",
+        "sense organ system" ;
     rdfs:subClassOf UBERON:0000467 .
+
+UBERON:0004463 a owl:Class ;
+    rdfs:label "musculature of hindlimb stylopod" ;
+    NIFRID:synonym "muscle group of thigh",
+        "musculature of thigh",
+        "set of muscles of thigh",
+        "thigh musculature" ;
+    rdfs:subClassOf UBERON:0004466,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000376 ] .
 
 UBERON:0004464 a owl:Class ;
     rdfs:label "musculature of thorax" ;
     NIFRID:synonym "muscle group of thorax",
         "muscles of thorax",
+        "musculature of thorax",
         "musculi thoracis",
         "set of muscles of thorax",
         "thoracic musculature" ;
@@ -14792,22 +18537,261 @@ UBERON:0004464 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000915 ] .
 
+UBERON:0004465 a owl:Class ;
+    rdfs:label "musculature of neck" ;
+    NIFRID:synonym "cervical muscles",
+        "muscle group of neck",
+        "muscles of neck",
+        "musculature of neck",
+        "musculi cervicis",
+        "musculi colli",
+        "neck musculature",
+        "set of muscles of neck" ;
+    rdfs:subClassOf UBERON:0001015,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000974 ] .
+
+UBERON:0004466 a owl:Class ;
+    rdfs:label "musculature of leg" ;
+    NIFRID:synonym "leg muscle system" ;
+    rdfs:subClassOf UBERON:0004482,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000978 ] .
+
+UBERON:0004469 a owl:Class ;
+    rdfs:label "musculature of back" ;
+    NIFRID:synonym "muscle group of back",
+        "muscles of back",
+        "musculature of back",
+        "musculi dorsi",
+        "set of muscles of back" ;
+    rdfs:subClassOf UBERON:0001015,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001137 ] .
+
+UBERON:0004470 a owl:Class ;
+    rdfs:label "musculature of pelvic girdle" ;
+    NIFRID:synonym "muscle group of pelvic girdle",
+        "muscle group of pelvis",
+        "muscular system of pelvis",
+        "pelvic girdle muscle system",
+        "pelvic girdle muscles",
+        "pelvic girdle musculature",
+        "set of muscles of pelvic girdle",
+        "set of muscles of pelvis" ;
+    rdfs:subClassOf UBERON:0004479,
+        UBERON:0014792,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001271 ] .
+
+UBERON:0004471 a owl:Class ;
+    rdfs:label "musculature of pectoral girdle" ;
+    NIFRID:synonym "muscle group of pectoral girdle",
+        "musculature of pectoral girdle",
+        "pectoral girdle muscles",
+        "pectoral girdle musculature",
+        "set of muscles of pectoral girdle" ;
+    rdfs:subClassOf UBERON:0014793,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001421 ] .
+
+UBERON:0004474 a owl:Class ;
+    rdfs:label "musculature of arm" ;
+    NIFRID:synonym "arm muscle system",
+        "arm musculature",
+        "muscle group of arm",
+        "set of muscles of arm" ;
+    rdfs:subClassOf UBERON:0004481,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ] .
+
+UBERON:0004475 a owl:Class ;
+    rdfs:label "musculature of hip" ;
+    NIFRID:synonym "hip musculature",
+        "muscle group of hip",
+        "set of muscles of hip" ;
+    rdfs:subClassOf UBERON:0001015,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
+
+UBERON:0004476 a owl:Class ;
+    rdfs:label "musculature of shoulder" ;
+    NIFRID:synonym "muscle group of shoulder",
+        "set of muscles of shoulder" ;
+    rdfs:subClassOf UBERON:0001015,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
+
 UBERON:0004479 a owl:Class ;
     rdfs:label "musculature of trunk" ;
     NIFRID:synonym "muscle group of trunk",
         "muscular system of trunk",
+        "musculature of trunk",
         "set of muscles of trunk" ;
     rdfs:subClassOf UBERON:0001015,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002100 ] .
 
+UBERON:0004480 a owl:Class ;
+    rdfs:label "musculature of limb" ;
+    NIFRID:synonym "limb muscle system",
+        "limb musculature",
+        "muscle group of limb",
+        "set of muscles of limb" ;
+    rdfs:subClassOf UBERON:0007271,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002101 ] .
+
+UBERON:0004481 a owl:Class ;
+    rdfs:label "musculature of upper limb" ;
+    NIFRID:synonym "free upper limb musculature",
+        "muscle group of free upper limb",
+        "musculature of free upper limb",
+        "set of muscles of free upper limb" ;
+    rdfs:subClassOf UBERON:0004480,
+        UBERON:0007269,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
+
+UBERON:0004482 a owl:Class ;
+    rdfs:label "musculature of lower limb" ;
+    NIFRID:synonym "free lower limb musculature",
+        "muscle group of free lower limb",
+        "musculature of free lower limb",
+        "set of muscles of free lower limb" ;
+    rdfs:subClassOf UBERON:0004480,
+        UBERON:0007270,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002103 ] .
+
+UBERON:0004486 a owl:Class ;
+    rdfs:label "musculature of perineum" ;
+    NIFRID:synonym "musculi perinei",
+        "perineal muscles",
+        "perineal muscles set",
+        "set of perineal muscles" ;
+    rdfs:subClassOf UBERON:0004479,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002356 ] .
+
+UBERON:0004487 a owl:Class ;
+    rdfs:label "musculature of forelimb zeugopod" ;
+    NIFRID:synonym "muscle group of forearm",
+        "musculature of forearm",
+        "set of muscles of forearm" ;
+    rdfs:subClassOf UBERON:0004474,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002386 ] .
+
+UBERON:0004488 a owl:Class ;
+    rdfs:label "musculature of pes" ;
+    NIFRID:synonym "foot musculature",
+        "muscle group of foot",
+        "musculature of foot",
+        "set of muscles of foot" ;
+    rdfs:subClassOf UBERON:0004482,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002387 ] .
+
+UBERON:0004489 a owl:Class ;
+    rdfs:label "musculature of manus" ;
+    NIFRID:synonym "hand musculature",
+        "muscle group of hand",
+        "musculature of hand",
+        "set of muscles of hand" ;
+    rdfs:subClassOf UBERON:0004481,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
+
+UBERON:0004490 a owl:Class ;
+    rdfs:label "cardiac muscle tissue of atrium" ;
+    NIFRID:synonym "atrial cardiac muscle tissue",
+        "atrial heart muscle",
+        "atrial myocardium",
+        "cardiac atrium muscle",
+        "cardiac muscle tissue of atrium" ;
+    rdfs:subClassOf UBERON:0004493,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002081 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002302 ] .
+
+UBERON:0004493 a owl:Class ;
+    rdfs:label "cardiac muscle tissue of myocardium" ;
+    NIFRID:synonym "cardiac muscle tissue of myocardium" ;
+    rdfs:subClassOf UBERON:0001133,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002349 ] .
+
+UBERON:0004518 a owl:Class ;
+    rdfs:label "muscle of vertebral column" ;
+    NIFRID:synonym "muscle of vertebral column",
+        "vertebral column muscle" ;
+    rdfs:subClassOf UBERON:0014892 .
+
+UBERON:0004519 a owl:Class ;
+    rdfs:label "muscle of anal triangle" ;
+    NIFRID:synonym "anal triangle muscle" ;
+    rdfs:subClassOf UBERON:0002379,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006867 ] .
+
+UBERON:0004529 a owl:Class ;
+    rdfs:label "anatomical projection" ;
+    NIFRID:synonym "anatomical process",
+        "anatomical protrusion",
+        "flange",
+        "flanges",
+        "lamella",
+        "lamellae",
+        "lamina",
+        "laminae",
+        "organ process",
+        "papilla",
+        "process",
+        "process of organ",
+        "processes",
+        "processus",
+        "projection",
+        "projections",
+        "protrusion",
+        "ridge",
+        "ridges",
+        "shelf",
+        "shelves",
+        "spine" ;
+    rdfs:subClassOf UBERON:0034768,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000062 ] .
+
 UBERON:0004535 a owl:Class ;
     rdfs:label "cardiovascular system" ;
-    NIFRID:synonym "CV system",
+    NIFRID:synonym "cardiovascular system",
+        "CV system",
         "Herz und Gefaesssystem" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000467,
+    rdfs:subClassOf UBERON:0000467,
+        UBERON:0010314,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001009 ] .
@@ -14816,18 +18800,27 @@ UBERON:0004537 a owl:Class ;
     rdfs:label "blood vasculature" ;
     NIFRID:synonym "blood system",
         "blood vascular network",
+        "blood vasculature",
         "blood vessel system",
         "blood vessels",
         "set of blood vessels" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0002049,
+    rdfs:subClassOf UBERON:0002049,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004535 ] .
 
+UBERON:0004538 a owl:Class ;
+    rdfs:label "left kidney" ;
+    rdfs:subClassOf UBERON:0002113 .
+
+UBERON:0004539 a owl:Class ;
+    rdfs:label "right kidney" ;
+    rdfs:subClassOf UBERON:0002113 .
+
 UBERON:0004571 a owl:Class ;
     rdfs:label "systemic arterial system" ;
-    NIFRID:synonym "systemic arterial circulatory system" ;
+    NIFRID:synonym "systemic arterial circulatory system",
+        "systemic arterial system" ;
     rdfs:subClassOf UBERON:0007798,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -14835,15 +18828,16 @@ UBERON:0004571 a owl:Class ;
 
 UBERON:0004572 a owl:Class ;
     rdfs:label "arterial system" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0007798,
+    NIFRID:synonym "arterial system" ;
+    rdfs:subClassOf UBERON:0007798,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004535 ] .
 
 UBERON:0004573 a owl:Class ;
     rdfs:label "systemic artery" ;
-    NIFRID:synonym "systemic arterial subtree" ;
+    NIFRID:synonym "systemic arterial subtree",
+        "systemic artery" ;
     rdfs:subClassOf UBERON:0001637,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -14851,15 +18845,64 @@ UBERON:0004573 a owl:Class ;
 
 UBERON:0004582 a owl:Class ;
     rdfs:label "venous system" ;
-    NIFRID:synonym "vein system" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0007798 .
+    NIFRID:synonym "vein system",
+        "venous system" ;
+    rdfs:subClassOf UBERON:0007798 .
 
 UBERON:0004590 a owl:Class ;
     rdfs:label "sphincter muscle" ;
     NIFRID:synonym "circular muscle",
-        "sphincter" ;
+        "sphincter",
+        "sphincter muscle" ;
     rdfs:subClassOf UBERON:0001630 .
+
+UBERON:0004638 a owl:Class ;
+    rdfs:label "blood vessel endothelium" ;
+    NIFRID:synonym "blood vessel endothelium" ;
+    rdfs:subClassOf UBERON:0004852,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001981 ] .
+
+UBERON:0004639 a owl:Class ;
+    rdfs:label "renal afferent arteriole" ;
+    NIFRID:synonym "afferent arteriole",
+        "afferent glomerular arteriole",
+        "afferent glomerular arteriole of kidney",
+        "arteriola glomerularis afferens",
+        "arteriola glomerularis afferens renis",
+        "kidney afferent arteriole" ;
+    rdfs:subClassOf UBERON:0001980,
+        UBERON:0003644,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001229 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001229 ] .
+
+UBERON:0004640 a owl:Class ;
+    rdfs:label "renal efferent arteriole" ;
+    NIFRID:synonym "arteriola glomerularis efferens capsulae renalis",
+        "arteriola glomerularis efferens renis",
+        "efferent arteriole",
+        "efferent glomerular arteriole",
+        "efferent glomerular arteriole of kidney",
+        "kidney efferent arteriole" ;
+    rdfs:subClassOf UBERON:0001980,
+        UBERON:0003644,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001229 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001229 ] .
 
 UBERON:0004641 a owl:Class ;
     rdfs:label "spleen capsule" ;
@@ -14872,13 +18915,56 @@ UBERON:0004641 a owl:Class ;
         "tunica fibrosa (splen)(lien)",
         "tunica fibrosa splenica" ;
     rdfs:subClassOf UBERON:0003893,
-        UBERON:0004120,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002106 ],
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0002106 ] .
+
+UBERON:0004647 a owl:Class ;
+    rdfs:label "liver lobule" ;
+    NIFRID:synonym "hepatic lobule",
+        "liver lobule",
+        "lobules of liver",
+        "lobuli hepatici",
+        "lobuli hepatis",
+        "lobulus hepaticus" ;
+    rdfs:subClassOf UBERON:0000064,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001280 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001280 ] .
+
+UBERON:0004663 a owl:Class ;
+    rdfs:label "aorta wall" ;
+    NIFRID:synonym "aorta wall",
+        "aortic wall",
+        "wall of aorta" ;
+    rdfs:subClassOf UBERON:0035965,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000947 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0000947 ] .
+
+UBERON:0004664 a owl:Class ;
+    rdfs:label "aorta tunica adventitia" ;
+    NIFRID:synonym "aorta tunica adventitia",
+        "tunica adventitia of aorta" ;
+    rdfs:subClassOf UBERON:0005734,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000947 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004663 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0004663 ] .
 
 UBERON:0004665 a owl:Class ;
     rdfs:label "muscular coat of seminal vesicle" ;
@@ -14887,8 +18973,7 @@ UBERON:0004665 a owl:Class ;
         "muscular layer of seminal gland",
         "tunica muscularis (vesicula seminalis)",
         "tunica muscularis glandulae vesiculosae" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0005156,
+    rdfs:subClassOf UBERON:0005156,
         UBERON:0006660,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -14957,20 +19042,6 @@ UBERON:0004681 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002105 ] .
 
-UBERON:0004684 a owl:Class ;
-    rdfs:label "raphe nuclei" ;
-    NIFRID:synonym "nuclei raphes",
-        "raphe cluster",
-        "raphe nuclei",
-        "raphe nuclei set",
-        "raphe nucleus",
-        "raphe of mesenchephalon",
-        "set of raphe nuclei" ;
-    rdfs:subClassOf UBERON:0002616,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002275 ] .
-
 UBERON:0004703 a owl:Class ;
     rdfs:label "dorsal thalamus" ;
     NIFRID:synonym "dorsal thalamus",
@@ -14991,13 +19062,45 @@ UBERON:0004708 a owl:Class ;
         "limb or fin",
         "limb/fin",
         "paired appendage",
+        "paired limb/fin",
         "pectoral or pelvic appendage",
         "pelvic/pectoral appendage" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000026,
+    rdfs:subClassOf UBERON:0000026,
+        UBERON:0010314,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0010707 ] .
+
+UBERON:0004709 a owl:Class ;
+    rdfs:label "pelvic appendage" ;
+    NIFRID:synonym "hindlimb/pelvic fin",
+        "pelvic appendage",
+        "pelvic limb/fin",
+        "posterior appendage",
+        "posterior limb/fin",
+        "posterior paired appendage" ;
+    rdfs:subClassOf UBERON:0004708,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010709 ] .
+
+UBERON:0004710 a owl:Class ;
+    rdfs:label "pectoral appendage" ;
+    NIFRID:synonym "anterior appendage",
+        "anterior limb/fin",
+        "anterior paired appendage",
+        "forelimb - pectoral fin",
+        "forelimb or pectoral fin",
+        "forelimb/pectoral fin",
+        "pectoral appendage",
+        "pectoral limb/fin" ;
+    rdfs:subClassOf UBERON:0004708,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010708 ] .
 
 UBERON:0004713 a owl:Class ;
     rdfs:label "corpus cavernosum penis" ;
@@ -15010,38 +19113,11 @@ UBERON:0004713 a owl:Class ;
         "penis erectile tissue",
         "spongy body of male urethra",
         "spongy body of penis" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0005156,
+    rdfs:subClassOf UBERON:0005156,
         UBERON:0006609,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000989 ] .
-
-UBERON:0004714 a owl:Class ;
-    rdfs:label "septum pellucidum" ;
-    NIFRID:synonym "lateral septum",
-        "pellucidum",
-        "septal pellucidum",
-        "septum gliosum",
-        "septum lucidum",
-        "septum pellucidum of telencephalic ventricle",
-        "supracommissural septum" ;
-    rdfs:subClassOf UBERON:0000119,
-        UBERON:0004121,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000446 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002285 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0000446 ] .
-
-UBERON:0004716 a owl:Class ;
-    rdfs:label "conceptus" ;
-    NIFRID:synonym "embryo plus adnexa" ;
-    rdfs:subClassOf UBERON:0000061 .
 
 UBERON:0004725 a owl:Class ;
     rdfs:label "piriform cortex" ;
@@ -15052,6 +19128,7 @@ UBERON:0004725 a owl:Class ;
         "palaeocortex II",
         "paleopallium",
         "piriform area",
+        "piriform cortex",
         "piriform lobe",
         "primary olfactory areas",
         "primary olfactory cortex",
@@ -15068,7 +19145,8 @@ UBERON:0004725 a owl:Class ;
 
 UBERON:0004732 a owl:Class ;
     rdfs:label "segmental subdivision of nervous system" ;
-    NIFRID:synonym "neuromere" ;
+    NIFRID:synonym "neuromere",
+        "segmental subdivision of nervous system" ;
     rdfs:subClassOf UBERON:0000063,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15077,15 +19155,27 @@ UBERON:0004732 a owl:Class ;
 UBERON:0004733 a owl:Class ;
     rdfs:label "segmental subdivision of hindbrain" ;
     NIFRID:synonym "hindbrain segment",
-        "segment of hindbrain" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0004732,
+        "segment of hindbrain",
+        "segmental subdivision of hindbrain" ;
+    rdfs:subClassOf UBERON:0004732,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002028 ] .
 
+UBERON:0004753 a owl:Class ;
+    rdfs:label "scapulocoracoid" ;
+    NIFRID:synonym "coraco-scapular cartilage",
+        "scapulo-coracoid cartilage",
+        "scapulocoracoid cartilage",
+        "scapulocoracoideum" ;
+    rdfs:subClassOf UBERON:0004765,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007831 ] .
+
 UBERON:0004765 a owl:Class ;
     rdfs:label "skeletal element" ;
+    NIFRID:synonym "skeletal element" ;
     rdfs:subClassOf UBERON:0000062,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15093,7 +19183,8 @@ UBERON:0004765 a owl:Class ;
 
 UBERON:0004770 a owl:Class ;
     rdfs:label "articular system" ;
-    NIFRID:synonym "joint system",
+    NIFRID:synonym "articular system",
+        "joint system",
         "set of all joints",
         "set of all joints of body",
         "set of joints of body" ;
@@ -15104,6 +19195,7 @@ UBERON:0004770 a owl:Class ;
 
 UBERON:0004780 a owl:Class ;
     rdfs:label "gastrointestinal system lamina propria" ;
+    NIFRID:synonym "gastrointestinal system lamina propria" ;
     rdfs:subClassOf UBERON:0000030,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15116,6 +19208,7 @@ UBERON:0004782 a owl:Class ;
     rdfs:label "gastrointestinal system serosa" ;
     NIFRID:synonym "digestive system serosa",
         "digestive system serous membrane",
+        "gastrointestinal system serosa",
         "gastrointestinal system serous membrane",
         "serosa of digestive system",
         "serosa of gastrointestinal system",
@@ -15139,6 +19232,7 @@ UBERON:0004785 a owl:Class ;
         "mucous membrane of apparatus respiratorius",
         "mucous membrane of respiratory system",
         "respiratory mucosa",
+        "respiratory system mucosa",
         "respiratory system mucosa of organ",
         "respiratory system mucous membrane",
         "respiratory tract mucosa" ;
@@ -15150,6 +19244,7 @@ UBERON:0004785 a owl:Class ;
 UBERON:0004786 a owl:Class ;
     rdfs:label "gastrointestinal system mucosa" ;
     NIFRID:synonym "digestive tract mucosa",
+        "gastrointestinal system mucosa",
         "gut mucosa",
         "gut mucuous membrane",
         "mucosa of gut" ;
@@ -15163,8 +19258,8 @@ UBERON:0004786 a owl:Class ;
 
 UBERON:0004797 a owl:Class ;
     rdfs:label "blood vessel layer" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0004923,
+    NIFRID:synonym "blood vessel layer" ;
+    rdfs:subClassOf UBERON:0004923,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001981 ],
@@ -15178,9 +19273,9 @@ UBERON:0004802 a owl:Class ;
         "epithelial tissue of respiratory tract",
         "epithelium of respiratory tract",
         "respiratory epithelium",
-        "respiratory tract epithelial tissue" ;
+        "respiratory tract epithelial tissue",
+        "respiratory tract epithelium" ;
     rdfs:subClassOf UBERON:0004807,
-        UBERON:0005911,
         UBERON:0010499,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15202,14 +19297,11 @@ UBERON:0004804 a owl:Class ;
         "epithelium of uterine tube",
         "fallopian tube epithelium",
         "oviduct epithelial tissue" ;
-    rdfs:subClassOf UBERON:0005156,
-        UBERON:0012275,
+    rdfs:subClassOf UBERON:0000483,
+        UBERON:0005156,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000993 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0003889 ] .
+            owl:someValuesFrom UBERON:0000993 ] .
 
 UBERON:0004805 a owl:Class ;
     rdfs:label "seminal vesicle epithelium" ;
@@ -15221,7 +19313,6 @@ UBERON:0004805 a owl:Class ;
         "seminal gland epithelium",
         "seminal vesicle epithelial tissue" ;
     rdfs:subClassOf UBERON:0004910,
-        UBERON:0012275,
         UBERON:0034969,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15235,7 +19326,8 @@ UBERON:0004807 a owl:Class ;
         "epithelial tissue of respiratory system",
         "epithelium of apparatus respiratorius",
         "epithelium of respiratory system",
-        "respiratory system epithelial tissue" ;
+        "respiratory system epithelial tissue",
+        "respiratory system epithelium" ;
     rdfs:subClassOf UBERON:0000483,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15249,7 +19341,8 @@ UBERON:0004808 a owl:Class ;
         "epithelial tissue of gastrointestinal system",
         "epithelium of digestive system",
         "epithelium of gastrointestinal system",
-        "gastrointestinal system epithelial tissue" ;
+        "gastrointestinal system epithelial tissue",
+        "gastrointestinal system epithelium" ;
     rdfs:subClassOf UBERON:0000483,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15259,15 +19352,72 @@ UBERON:0004814 a owl:Class ;
     rdfs:label "upper respiratory tract epithelium" ;
     NIFRID:synonym "epithelial tissue of upper respiratory tract",
         "epithelium of upper respiratory tract",
-        "upper respiratory tract epithelial tissue" ;
+        "upper respiratory tract epithelial tissue",
+        "upper respiratory tract epithelium" ;
     rdfs:subClassOf UBERON:0004802,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001557 ] .
 
+UBERON:0004819 a owl:Class ;
+    rdfs:label "kidney epithelium" ;
+    NIFRID:synonym "epithelial tissue of kidney",
+        "epithelium of kidney",
+        "kidney epithelial tissue",
+        "renal epithelium" ;
+    rdfs:subClassOf UBERON:0000483,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002113 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002113 ] .
+
+UBERON:0004820 a owl:Class ;
+    rdfs:label "bile duct epithelium" ;
+    NIFRID:synonym "bile duct epithelium",
+        "biliary duct epithelium",
+        "epithelium of bile duct",
+        "epithelium of biliary duct" ;
+    rdfs:subClassOf UBERON:0034932,
+        UBERON:0034969,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002394 ] .
+
+UBERON:0004832 a owl:Class ;
+    rdfs:label "anal region skeletal muscle" ;
+    NIFRID:synonym "anal part of perineum skeletal muscle",
+        "anal part of perineum skeletal muscle tissue",
+        "anal region skeletal muscle",
+        "anal region skeletal muscle tissue",
+        "anal triangle skeletal muscle",
+        "anal triangle skeletal muscle tissue",
+        "skeletal muscle of anal part of perineum",
+        "skeletal muscle of anal region",
+        "skeletal muscle of anal triangle",
+        "skeletal muscle tissue of anal part of perineum",
+        "skeletal muscle tissue of anal region",
+        "skeletal muscle tissue of anal triangle" ;
+    rdfs:subClassOf UBERON:0001134,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001353 ] .
+
+UBERON:0004852 a owl:Class ;
+    rdfs:label "cardiovascular system endothelium" ;
+    NIFRID:synonym "cardiovascular system endothelium",
+        "endothelia",
+        "vascular endothelia" ;
+    rdfs:subClassOf UBERON:0001986,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004535 ] .
+
 UBERON:0004859 a owl:Class ;
     rdfs:label "eye gland" ;
-    NIFRID:synonym "eye-associated gland",
+    NIFRID:synonym "eye gland",
+        "eye-associated gland",
         "gland of eye" ;
     rdfs:subClassOf UBERON:0002530,
         [ a owl:Restriction ;
@@ -15294,7 +19444,8 @@ UBERON:0004863 a owl:Class ;
 
 UBERON:0004905 a owl:Class ;
     rdfs:label "articulation" ;
-    NIFRID:synonym "joint" ;
+    NIFRID:synonym "articulation",
+        "joint" ;
     rdfs:subClassOf UBERON:0034921,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15303,6 +19454,7 @@ UBERON:0004905 a owl:Class ;
 UBERON:0004907 a owl:Class ;
     rdfs:label "lower digestive tract" ;
     NIFRID:synonym "gut",
+        "lower digestive tract",
         "lower gastrointestinal tract",
         "lower GI tract" ;
     rdfs:subClassOf UBERON:0004921,
@@ -15312,13 +19464,15 @@ UBERON:0004907 a owl:Class ;
 
 UBERON:0004908 a owl:Class ;
     rdfs:label "upper digestive tract" ;
-    NIFRID:synonym "upper gastrointestinal tract",
+    NIFRID:synonym "upper digestive tract",
+        "upper gastrointestinal tract",
         "upper GI tract" ;
     rdfs:subClassOf UBERON:0004921 .
 
 UBERON:0004909 a owl:Class ;
     rdfs:label "epithelium of gonad" ;
-    NIFRID:synonym "gonad epithelium",
+    NIFRID:synonym "epithelium of gonad",
+        "gonad epithelium",
         "gonadal epithelium",
         "gonadal sheath" ;
     rdfs:subClassOf UBERON:0000483,
@@ -15335,6 +19489,16 @@ UBERON:0004910 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000473 ] .
 
+UBERON:0004916 a owl:Class ;
+    rdfs:label "anal sphincter" ;
+    NIFRID:synonym "anal region sphincter",
+        "anal sphincter",
+        "sphincter analia" ;
+    rdfs:subClassOf UBERON:0004590,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001353 ] .
+
 UBERON:0004917 a owl:Class ;
     rdfs:label "urethral sphincter" ;
     NIFRID:synonym "sphincter muscle of urethra",
@@ -15350,13 +19514,32 @@ UBERON:0004917 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001556 ] .
 
+UBERON:0004919 a owl:Class ;
+    rdfs:label "external urethral sphincter" ;
+    NIFRID:synonym "annulus urethralis",
+        "external sphincter muscle of urethra",
+        "external sphincter of urethra",
+        "external urethral sphincter muscle",
+        "m. urethralis",
+        "musculus sphincter urethrae membranaceae",
+        "urethralis",
+        "urethralis muscle" ;
+    rdfs:subClassOf UBERON:0004917,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000057 ] .
+
 UBERON:0004921 a owl:Class ;
     rdfs:label "subdivision of digestive tract" ;
     NIFRID:synonym "alimentary system subdivision",
         "gut section",
         "intestinal tract",
         "segment of intestinal tract",
-        "subdivision of alimentary system" ;
+        "subdivision of alimentary system",
+        "subdivision of digestive tract" ;
     rdfs:subClassOf UBERON:0013522,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15364,28 +19547,139 @@ UBERON:0004921 a owl:Class ;
 
 UBERON:0004923 a owl:Class ;
     rdfs:label "organ component layer" ;
+    NIFRID:synonym "organ component layer" ;
     rdfs:subClassOf UBERON:0000064,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000060 ] .
 
-UBERON:0005051 a owl:Class ;
-    rdfs:label "mediastinum testis" ;
-    NIFRID:synonym "body of highmore",
-        "hilum of testicle",
-        "mediastinum of testis",
-        "testis mediastinum" ;
-    rdfs:subClassOf UBERON:0002050,
+UBERON:0004982 a owl:Class ;
+    rdfs:label "mucosa of epiglottis" ;
+    NIFRID:synonym "epiglottis mucosa",
+        "epiglottis mucosa of organ",
+        "epiglottis mucous membrane",
+        "epiglottis organ mucosa",
+        "mucosa of organ of epiglottis",
+        "mucous membrane of epiglottis",
+        "organ mucosa of epiglottis" ;
+    rdfs:subClassOf UBERON:0004987,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000473 ],
+            owl:someValuesFrom UBERON:0000388 ] .
+
+UBERON:0004987 a owl:Class ;
+    rdfs:label "mucosa of laryngopharynx" ;
+    NIFRID:synonym "hypopharynx mucosa",
+        "hypopharynx mucosa of organ",
+        "hypopharynx mucous membrane",
+        "hypopharynx organ mucosa",
+        "laryngeal pharynx mucosa",
+        "laryngeal pharynx mucosa of organ",
+        "laryngeal pharynx mucous membrane",
+        "laryngeal pharynx organ mucosa",
+        "laryngopharynx mucosa",
+        "laryngopharynx mucosa of organ",
+        "laryngopharynx mucous membrane",
+        "laryngopharynx organ mucosa",
+        "mucosa of hypopharynx",
+        "mucosa of laryngeal pharynx",
+        "mucosa of organ of hypopharynx",
+        "mucosa of organ of laryngeal pharynx",
+        "mucosa of organ of laryngopharynx",
+        "mucous membrane of hypopharynx",
+        "mucous membrane of laryngeal pharynx",
+        "mucous membrane of laryngopharynx",
+        "organ mucosa of hypopharynx",
+        "organ mucosa of laryngeal pharynx",
+        "organ mucosa of laryngopharynx" ;
+    rdfs:subClassOf UBERON:0000355,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000922 ] .
+            owl:someValuesFrom UBERON:0001051 ] .
+
+UBERON:0004994 a owl:Class ;
+    rdfs:label "mucosa of fundus of stomach" ;
+    NIFRID:synonym "fundus gastricus (ventricularis) mucosa",
+        "fundus gastricus (ventricularis) mucosa of organ",
+        "fundus gastricus (ventricularis) mucous membrane",
+        "fundus gastricus (ventricularis) organ mucosa",
+        "fundus of stomach mucosa",
+        "fundus of stomach mucosa of organ",
+        "fundus of stomach mucous membrane",
+        "fundus of stomach organ mucosa",
+        "mucosa of fundus gastricus (ventricularis)",
+        "mucosa of organ of fundus gastricus (ventricularis)",
+        "mucosa of organ of fundus of stomach",
+        "mucosa of organ of stomach fundus",
+        "mucosa of stomach fundus",
+        "mucous membrane of fundus gastricus (ventricularis)",
+        "mucous membrane of fundus of stomach",
+        "mucous membrane of stomach fundus",
+        "organ mucosa of fundus gastricus (ventricularis)",
+        "organ mucosa of fundus of stomach",
+        "organ mucosa of stomach fundus",
+        "stomach fundus mucosa",
+        "stomach fundus mucosa of organ",
+        "stomach fundus mucous membrane",
+        "stomach fundus organ mucosa" ;
+    rdfs:subClassOf UBERON:0001199,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001160 ] .
+
+UBERON:0005006 a owl:Class ;
+    rdfs:label "mucosa of renal pelvis" ;
+    NIFRID:synonym "kidney pelvis mucosa",
+        "kidney pelvis mucosa of organ",
+        "kidney pelvis mucous membrane",
+        "kidney pelvis organ mucosa",
+        "mucosa of kidney pelvis",
+        "mucosa of organ of kidney pelvis",
+        "mucosa of organ of pelvis of ureter",
+        "mucosa of organ of renal pelvis",
+        "mucosa of pelvis of ureter",
+        "mucous membrane of kidney pelvis",
+        "mucous membrane of pelvis of ureter",
+        "mucous membrane of renal pelvis",
+        "organ mucosa of kidney pelvis",
+        "organ mucosa of pelvis of ureter",
+        "organ mucosa of renal pelvis",
+        "pelvis of ureter mucosa",
+        "pelvis of ureter mucosa of organ",
+        "pelvis of ureter mucous membrane",
+        "pelvis of ureter organ mucosa",
+        "renal pelvic mucosa",
+        "renal pelvis mucosa",
+        "renal pelvis mucosa of organ",
+        "renal pelvis mucous membrane",
+        "renal pelvis organ mucosa",
+        "tunica mucosa pelvis renalis" ;
+    rdfs:subClassOf UBERON:0000344,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001224 ] .
+
+UBERON:0005020 a owl:Class ;
+    rdfs:label "mucosa of tongue" ;
+    NIFRID:synonym "lingual mucosa",
+        "mucosa of organ of tongue",
+        "mucosa of tongue",
+        "mucous membrane of tongue",
+        "organ mucosa of tongue",
+        "tongue mucosa",
+        "tongue mucosa of organ",
+        "tongue mucous membrane",
+        "tongue organ mucosa",
+        "tunica mucosa linguae" ;
+    rdfs:subClassOf UBERON:0003729,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001723 ] .
 
 UBERON:0005056 a owl:Class ;
     rdfs:label "external female genitalia" ;
     NIFRID:synonym "external female genital organ",
+        "external female genitalia",
         "external genitalia of female reproductive system",
         "female external genitalia",
         "organa genitalia feminina externa" ;
@@ -15397,7 +19691,8 @@ UBERON:0005056 a owl:Class ;
 
 UBERON:0005057 a owl:Class ;
     rdfs:label "immune organ" ;
-    NIFRID:synonym "immune system organ" ;
+    NIFRID:synonym "immune organ",
+        "immune system organ" ;
     rdfs:subClassOf UBERON:0000062,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15406,6 +19701,7 @@ UBERON:0005057 a owl:Class ;
 UBERON:0005058 a owl:Class ;
     rdfs:label "hemolymphoid system gland" ;
     NIFRID:synonym "haemolymphoid system gland",
+        "hemolymphoid system gland",
         "hemopoietic or lymphoid gland",
         "hemopoietic or lymphoid organ" ;
     rdfs:subClassOf UBERON:0002530,
@@ -15417,19 +19713,14 @@ UBERON:0005090 a owl:Class ;
     rdfs:label "muscle structure" ;
     NIFRID:synonym "muscle",
         "muscle element",
+        "muscle structure",
         "musculus" ;
     rdfs:subClassOf UBERON:0000061 .
 
-UBERON:0005155 a owl:Class ;
-    rdfs:label "open tracheal system" ;
-    NIFRID:synonym "invertebrate tracheal system",
-        "open tracheal system",
-        "tracheal system" ;
-    rdfs:subClassOf UBERON:0001004 .
-
 UBERON:0005156 a owl:Class ;
     rdfs:label "reproductive structure" ;
-    NIFRID:synonym "reproductive system element",
+    NIFRID:synonym "reproductive structure",
+        "reproductive system element",
         "reproductive system structure" ;
     rdfs:subClassOf UBERON:0010000,
         [ a owl:Restriction ;
@@ -15439,13 +19730,23 @@ UBERON:0005156 a owl:Class ;
 UBERON:0005162 a owl:Class ;
     rdfs:label "multi cell part structure" ;
     NIFRID:synonym "cell part cluster",
+        "multi cell part structure",
         "multi-cell-component structure",
         "multi-cell-part structure" ;
     rdfs:subClassOf UBERON:0000061 .
 
+UBERON:0005171 a owl:Class ;
+    rdfs:label "hepatic duct" ;
+    NIFRID:synonym "hepatic duct" ;
+    rdfs:subClassOf UBERON:0002394,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001173 ] .
+
 UBERON:0005172 a owl:Class ;
     rdfs:label "abdomen element" ;
-    NIFRID:synonym "abdomen organ" ;
+    NIFRID:synonym "abdomen element",
+        "abdomen organ" ;
     rdfs:subClassOf UBERON:0005173,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15453,7 +19754,8 @@ UBERON:0005172 a owl:Class ;
 
 UBERON:0005173 a owl:Class ;
     rdfs:label "abdominal segment element" ;
-    NIFRID:synonym "abdominal segment organ" ;
+    NIFRID:synonym "abdominal segment element",
+        "abdominal segment organ" ;
     rdfs:subClassOf UBERON:0005177,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15462,15 +19764,24 @@ UBERON:0005173 a owl:Class ;
 UBERON:0005174 a owl:Class ;
     rdfs:label "dorsal region element" ;
     NIFRID:synonym "back organ",
+        "dorsal region element",
         "dorsal region organ" ;
     rdfs:subClassOf UBERON:0000062,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001137 ] .
 
+UBERON:0005175 a owl:Class ;
+    rdfs:label "chest organ" ;
+    rdfs:subClassOf UBERON:0005181,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001443 ] .
+
 UBERON:0005177 a owl:Class ;
     rdfs:label "trunk region element" ;
-    NIFRID:synonym "trunk organ" ;
+    NIFRID:synonym "trunk organ",
+        "trunk region element" ;
     rdfs:subClassOf UBERON:0000062,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15478,7 +19789,8 @@ UBERON:0005177 a owl:Class ;
 
 UBERON:0005178 a owl:Class ;
     rdfs:label "thoracic cavity element" ;
-    NIFRID:synonym "thoracic cavity organ" ;
+    NIFRID:synonym "thoracic cavity element",
+        "thoracic cavity organ" ;
     rdfs:subClassOf UBERON:0002075,
         UBERON:0005181,
         [ a owl:Restriction ;
@@ -15497,44 +19809,83 @@ UBERON:0005179 a owl:Class ;
 
 UBERON:0005181 a owl:Class ;
     rdfs:label "thoracic segment organ" ;
-    NIFRID:synonym "upper body organ" ;
+    NIFRID:synonym "thoracic segment organ",
+        "upper body organ" ;
     rdfs:subClassOf UBERON:0005177,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000915 ] .
 
-UBERON:0005281 a owl:Class ;
-    rdfs:label "ventricular system of central nervous system" ;
-    NIFRID:synonym "CNS ventricular system",
-        "ventricle system",
-        "ventricular system",
-        "ventricular system of neuraxis",
-        "ventriculi cerebri" ;
-    rdfs:subClassOf UBERON:0000467,
-        UBERON:0004121,
+UBERON:0005272 a owl:Class ;
+    rdfs:label "peritubular capillary" ;
+    rdfs:subClassOf UBERON:0003527,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001017 ] .
+            owl:someValuesFrom RO:0002577 ] .
 
-UBERON:0005282 a owl:Class ;
-    rdfs:label "ventricular system of brain" ;
-    NIFRID:synonym "brain ventricular system" ;
-    rdfs:subClassOf UBERON:0000467,
-        UBERON:0004121,
+UBERON:0005273 a owl:Class ;
+    rdfs:label "nail bed" ;
+    NIFRID:synonym "nailbed" ;
+    rdfs:subClassOf UBERON:0005275,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000955 ],
+            owl:someValuesFrom UBERON:0001705 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0005281 ] .
+            owl:someValuesFrom UBERON:0004105 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001705 ] .
+
+UBERON:0005275 a owl:Class ;
+    rdfs:label "dorsal skin of digit" ;
+    NIFRID:synonym "dorsal digit skin",
+        "skin of dorsal part of digit" ;
+    rdfs:subClassOf UBERON:0015249,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002544 ] .
+
+UBERON:0005276 a owl:Class ;
+    rdfs:label "dorsal skin of finger" ;
+    NIFRID:synonym "dorsal finger skin",
+        "skin of dorsal part of finger",
+        "subdivision of skin of dorsal part of finger" ;
+    rdfs:subClassOf UBERON:0003533,
+        UBERON:0005275,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002389 ] .
+
+UBERON:0005278 a owl:Class ;
+    rdfs:label "nail bed of finger" ;
+    NIFRID:synonym "nail bed of finger" ;
+    rdfs:subClassOf UBERON:0005273,
+        UBERON:0005276,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002389 ] .
 
 UBERON:0005290 a owl:Class ;
     rdfs:label "myelencephalon" ;
-    NIFRID:synonym "myelencephalon (medulla oblongata)" ;
-    rdfs:subClassOf UBERON:0004733,
+    NIFRID:synonym "myelencephalon",
+        "myelencephalon (medulla oblongata)" ;
+    rdfs:subClassOf UBERON:0004121,
+        UBERON:0004733,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002028 ] .
+
+UBERON:0005298 a owl:Class ;
+    rdfs:label "skin of clitoris" ;
+    NIFRID:synonym "clitoris skin" ;
+    rdfs:subClassOf UBERON:8480029,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002411 ] .
 
 UBERON:0005303 a owl:Class ;
     rdfs:label "hypogastric nerve" ;
@@ -15553,15 +19904,6 @@ UBERON:0005304 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0002005 ] .
-
-UBERON:0005358 a owl:Class ;
-    rdfs:label "ventricle of nervous system" ;
-    NIFRID:synonym "region of wall of ventricular system of neuraxis",
-        "ventricular layer" ;
-    rdfs:subClassOf UBERON:0004923,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001016 ] .
 
 UBERON:0005360 a owl:Class ;
     rdfs:label "inferior glossopharyngeal IX ganglion" ;
@@ -15591,7 +19933,8 @@ UBERON:0005362 a owl:Class ;
         "vagal ganglion",
         "vagus ganglion",
         "vagus neural ganglion",
-        "vagus X" ;
+        "vagus X",
+        "vagus X ganglion" ;
     rdfs:subClassOf UBERON:0009127 .
 
 UBERON:0005363 a owl:Class ;
@@ -15615,6 +19958,7 @@ UBERON:0005363 a owl:Class ;
 
 UBERON:0005366 a owl:Class ;
     rdfs:label "olfactory lobe" ;
+    NIFRID:synonym "olfactory lobe" ;
     rdfs:subClassOf UBERON:0016526,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15631,6 +19975,7 @@ UBERON:0005370 a owl:Class ;
 UBERON:0005371 a owl:Class ;
     rdfs:label "hippocampus stratum oriens" ;
     NIFRID:synonym "gyrus cuneus",
+        "hippocampus stratum oriens",
         "oriens layer of hippocampus",
         "oriens layer of the hippocampus",
         "polymorphic layer of hippocampus",
@@ -15641,7 +19986,8 @@ UBERON:0005371 a owl:Class ;
 
 UBERON:0005372 a owl:Class ;
     rdfs:label "hippocampus stratum radiatum" ;
-    NIFRID:synonym "radiate layer of hippocampus",
+    NIFRID:synonym "hippocampus stratum radiatum",
+        "radiate layer of hippocampus",
         "stratum radiatum",
         "stratum radiatum hippocampi",
         "stratum radiatum of the hippocampus" ;
@@ -15666,6 +20012,7 @@ UBERON:0005376 a owl:Class ;
         "external plexiform layer",
         "external plexiform layer of the olfactory bulb",
         "OB outer plexiform layer",
+        "olfactory bulb external plexiform layer",
         "olfactory bulb main external plexiform layer" ;
     rdfs:subClassOf UBERON:0009950 .
 
@@ -15673,6 +20020,7 @@ UBERON:0005377 a owl:Class ;
     rdfs:label "olfactory bulb glomerular layer" ;
     NIFRID:synonym "glomerular layer",
         "glomerular layer of the olfactory bulb",
+        "olfactory bulb glomerular layer",
         "olfactory bulb main glomerulus",
         "stratum glomerulosum bulbi olfactorii" ;
     rdfs:subClassOf UBERON:0004001 .
@@ -15684,12 +20032,14 @@ UBERON:0005378 a owl:Class ;
         "granule layer of main olfactory bulb",
         "main olfactory bulb granule cell layer",
         "main olfactory bulb, granule layer",
+        "olfactory bulb granule cell layer",
         "olfactory bulb main granule cell layer" ;
     rdfs:subClassOf UBERON:0004001 .
 
 UBERON:0005381 a owl:Class ;
     rdfs:label "dentate gyrus granule cell layer" ;
-    NIFRID:synonym "dentate gyrus, granule cell layer",
+    NIFRID:synonym "dentate gyrus granule cell layer",
+        "dentate gyrus, granule cell layer",
         "DG granule cell layer",
         "granular layer of dentate gyrus",
         "granular layer of the dentate gyrus",
@@ -15698,7 +20048,8 @@ UBERON:0005381 a owl:Class ;
 
 UBERON:0005384 a owl:Class ;
     rdfs:label "nasal cavity epithelium" ;
-    NIFRID:synonym "nasal epithelium",
+    NIFRID:synonym "nasal cavity epithelium",
+        "nasal epithelium",
         "nasal mucosa" ;
     rdfs:subClassOf UBERON:0003350,
         UBERON:0004814,
@@ -15718,6 +20069,7 @@ UBERON:0005386 a owl:Class ;
     NIFRID:synonym "olfactory area of nasal mucosa",
         "olfactory mucosa",
         "olfactory part of nasal mucosa",
+        "olfactory segment of nasal mucosa",
         "olfactory zone of nasal mucosa",
         "pars olfactoria tunicae mucosae nasi" ;
     rdfs:subClassOf UBERON:0001826,
@@ -15727,7 +20079,8 @@ UBERON:0005386 a owl:Class ;
 
 UBERON:0005388 a owl:Class ;
     rdfs:label "photoreceptor array" ;
-    NIFRID:synonym "light-sensitive tissue" ;
+    NIFRID:synonym "light-sensitive tissue",
+        "photoreceptor array" ;
     rdfs:subClassOf UBERON:0004923,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -15739,6 +20092,7 @@ UBERON:0005388 a owl:Class ;
 UBERON:0005390 a owl:Class ;
     rdfs:label "cortical layer I" ;
     NIFRID:synonym "cerebral cortex, layer 1",
+        "cortical layer I",
         "lamina molecularis isocorticis [lamina I]",
         "layer 1 of neocortex",
         "layer I of neocortex",
@@ -15757,6 +20111,7 @@ UBERON:0005390 a owl:Class ;
 UBERON:0005391 a owl:Class ;
     rdfs:label "cortical layer II" ;
     NIFRID:synonym "cerebral cortex, layer 2",
+        "cortical layer II",
         "EGL",
         "external granular cell layer",
         "external granular layer",
@@ -15775,6 +20130,7 @@ UBERON:0005391 a owl:Class ;
 UBERON:0005392 a owl:Class ;
     rdfs:label "cortical layer III" ;
     NIFRID:synonym "cerebral cortex, layer 3",
+        "cortical layer III",
         "external pyramidal cell layer",
         "external pyramidal cell layer of neocortex",
         "external pyramidal layer of cerebral cortex",
@@ -15795,6 +20151,7 @@ UBERON:0005392 a owl:Class ;
 UBERON:0005393 a owl:Class ;
     rdfs:label "cortical layer IV" ;
     NIFRID:synonym "cerebral cortex, layer 4",
+        "cortical layer IV",
         "internal granular layer",
         "internal granular layer of isocortex [layer iv]",
         "internal granular layer of neocortex",
@@ -15813,6 +20170,7 @@ UBERON:0005394 a owl:Class ;
     rdfs:label "cortical layer V" ;
     NIFRID:synonym "betz' cells",
         "cerebral cortex, layer 5",
+        "cortical layer V",
         "deep layer of large pyramidal cells",
         "ganglionic layer",
         "ganglionic layer of cerebral cortex",
@@ -15837,6 +20195,7 @@ UBERON:0005394 a owl:Class ;
 UBERON:0005395 a owl:Class ;
     rdfs:label "cortical layer VI" ;
     NIFRID:synonym "cerebral cortex, layer 6",
+        "cortical layer VI",
         "fusiform layer",
         "isocortex, polymorph layer",
         "lamina multiformis",
@@ -15854,6 +20213,15 @@ UBERON:0005395 a owl:Class ;
         "spindle cell layer" ;
     rdfs:subClassOf UBERON:0002301 .
 
+UBERON:0005396 a owl:Class ;
+    rdfs:label "carotid artery segment" ;
+    NIFRID:synonym "carotid",
+        "carotid artery",
+        "carotid artery segment",
+        "common carotid arterial subdivision",
+        "subdivision of common carotid artery" ;
+    rdfs:subClassOf UBERON:0004573 .
+
 UBERON:0005399 a owl:Class ;
     rdfs:label "male reproductive gland" ;
     NIFRID:synonym "accessory sex gland" ;
@@ -15866,37 +20234,17 @@ UBERON:0005401 a owl:Class ;
     rdfs:label "cerebral hemisphere gray matter" ;
     NIFRID:synonym "cerebral gray matter",
         "cerebral grey matter",
+        "cerebral hemisphere gray matter",
         "cerebral hemisphere grey matter" ;
     rdfs:subClassOf UBERON:0011300,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001869 ] .
 
-UBERON:0005403 a owl:Class ;
-    rdfs:label "ventral striatum" ;
-    NIFRID:synonym "striatum ventral region",
-        "striatum ventrale" ;
-    rdfs:subClassOf UBERON:0011300,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002435 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0002435 ] .
-
-UBERON:0005408 a owl:Class ;
-    rdfs:label "circumventricular organ" ;
-    NIFRID:synonym "circumventricular organ",
-        "circumventricular organ of neuraxis",
-        "CVO" ;
-    rdfs:subClassOf UBERON:0002616,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000955 ] .
-
 UBERON:0005409 a owl:Class ;
     rdfs:label "alimentary part of gastrointestinal system" ;
-    NIFRID:synonym "alimentary system",
+    NIFRID:synonym "alimentary part of gastrointestinal system",
+        "alimentary system",
         "alimentary tract",
         "gastro-intestinal system",
         "gastroenterological system",
@@ -15909,19 +20257,88 @@ UBERON:0005409 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001007 ] .
 
-UBERON:0005413 a owl:Class ;
-    rdfs:label "spinocerebellar tract" ;
-    rdfs:subClassOf UBERON:0001018,
+UBERON:0005434 a owl:Class ;
+    rdfs:label "cervical region" ;
+    NIFRID:synonym "cervical region",
+        "neck subdivision",
+        "region of neck",
+        "subdivision of neck" ;
+    rdfs:subClassOf UBERON:0011676,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002316 ] .
+            owl:someValuesFrom UBERON:0000974 ] .
 
-UBERON:0005423 a owl:Class ;
-    rdfs:label "developing anatomical structure" ;
-    NIFRID:synonym "developing structure",
-        "developmental structure",
-        "developmental tissue" ;
-    rdfs:subClassOf UBERON:0000465 .
+UBERON:0005436 a owl:Class ;
+    rdfs:label "common hepatic artery" ;
+    NIFRID:synonym "arteria hepatica communis",
+        "common hepatic",
+        "common hepatic artery" ;
+    rdfs:subClassOf UBERON:0004573,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
+
+UBERON:0005441 a owl:Class ;
+    rdfs:label "external intercostal muscle" ;
+    NIFRID:synonym "external intercostal muscle",
+        "external intercostals",
+        "intercostal muscle external layer",
+        "intercostales externi",
+        "intercostales externi muscle",
+        "intercostales externi muscles",
+        "intercostales externus",
+        "intercostalis externus",
+        "intercostals external",
+        "intercostals external muscle",
+        "musculi intercostales externi" ;
+    rdfs:subClassOf UBERON:0001111 .
+
+UBERON:0005442 a owl:Class ;
+    rdfs:label "abdominal external oblique muscle" ;
+    NIFRID:synonym "abdominal external oblique muscle",
+        "external abdominal oblique",
+        "external abdominal oblique muscle",
+        "external oblique",
+        "external oblique abdominal muscles",
+        "external oblique abdominis",
+        "external oblique abdominis muscle",
+        "external oblique muscle",
+        "m. obliquus externus abdominis",
+        "oblique strength",
+        "obliquus abdominis externus",
+        "obliquus externus",
+        "obliquus externus abdominis",
+        "obliquus externus abdominis muscle" ;
+    rdfs:subClassOf UBERON:0035032,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006635 ] .
+
+UBERON:0005445 a owl:Class ;
+    rdfs:label "segment of pes" ;
+    NIFRID:synonym "foot region",
+        "foot subdivision",
+        "regio pedis",
+        "segment of foot",
+        "subdivision of foot" ;
+    rdfs:subClassOf UBERON:0008784,
+        UBERON:0012139,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002387 ] .
+
+UBERON:0005451 a owl:Class ;
+    rdfs:label "segment of manus" ;
+    NIFRID:synonym "hand region",
+        "hand subdivision",
+        "regio manus",
+        "segment of hand",
+        "subdivision of hand" ;
+    rdfs:subClassOf UBERON:0008785,
+        UBERON:0012139,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
 
 UBERON:0005453 a owl:Class ;
     rdfs:label "inferior mesenteric ganglion" ;
@@ -15930,6 +20347,44 @@ UBERON:0005453 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0035770 ] .
+
+UBERON:0005454 a owl:Class ;
+    rdfs:label "abdominal internal oblique muscle" ;
+    NIFRID:synonym "abdominal internal oblique",
+        "abdominal internal oblique muscle",
+        "internal abdominal oblique",
+        "internal abdominal oblique muscle",
+        "internal oblique",
+        "internal oblique abdominal",
+        "internal oblique abdominis",
+        "internal oblique abdominis muscle",
+        "internal oblique muscle",
+        "musculus obliquus internus abdominis",
+        "obliqui internus",
+        "obliquus internus",
+        "obliquus internus abdominis",
+        "obliquus internus abdominis muscle" ;
+    rdfs:subClassOf UBERON:0035032,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006635 ] .
+
+UBERON:0005461 a owl:Class ;
+    rdfs:label "levator scapulae muscle" ;
+    NIFRID:synonym "levator scapula",
+        "levator scapulae",
+        "levator scapulae muscle",
+        "levator scapulæ",
+        "musculus levator scapulae" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0004518,
+        UBERON:0034908,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0008713 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0013700 ] .
 
 UBERON:0005462 a owl:Class ;
     rdfs:label "lower back" ;
@@ -15953,6 +20408,52 @@ UBERON:0005462 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002417 ] .
 
+UBERON:0005465 a owl:Class ;
+    rdfs:label "obturator nerve" ;
+    NIFRID:synonym "nervus obturatorius" ;
+    rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001815 ] .
+
+UBERON:0005473 a owl:Class ;
+    rdfs:label "sacral region" ;
+    NIFRID:synonym "back of pelvis",
+        "croup",
+        "hindquarter",
+        "pelvic back",
+        "posterior part of pelvis",
+        "regio sacralis",
+        "rump",
+        "sacral part of pelvis" ;
+    rdfs:subClassOf UBERON:0011676,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002355 ] .
+
+UBERON:0005476 a owl:Class ;
+    rdfs:label "spinal nerve trunk" ;
+    NIFRID:synonym "spinal nerve (trunk)",
+        "spinal neural trunk",
+        "trunk of spinal nerve" ;
+    rdfs:subClassOf UBERON:0002464,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001780 ] .
+
+UBERON:0005477 a owl:Class ;
+    rdfs:label "stomach fundus epithelium" ;
+    NIFRID:synonym "epithelium of fundus of stomach",
+        "gastric epithelium of fundus",
+        "gastric fundus epithelium" ;
+    rdfs:subClassOf UBERON:0001276,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001160 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004994 ] .
+
 UBERON:0005479 a owl:Class ;
     rdfs:label "superior mesenteric ganglion" ;
     NIFRID:synonym "ganglion mesentericum superius",
@@ -15961,17 +20462,6 @@ UBERON:0005479 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0005488 ] .
-
-UBERON:0005483 a owl:Class ;
-    rdfs:label "thymus lobe" ;
-    NIFRID:synonym "lateral lobe of thymus",
-        "lobe of thymus" ;
-    rdfs:subClassOf UBERON:0000077,
-        UBERON:0009912,
-        UBERON:0015212,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002370 ] .
 
 UBERON:0005486 a owl:Class ;
     rdfs:label "venous dural sinus" ;
@@ -15982,8 +20472,7 @@ UBERON:0005486 a owl:Class ;
         "s. durae matris",
         "venous dural",
         "venous dural sinus" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0006615,
+    rdfs:subClassOf UBERON:0006615,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0003711 ],
@@ -15996,27 +20485,37 @@ UBERON:0005488 a owl:Class ;
     NIFRID:synonym "plexus mesentericus superior",
         "superior mesenteric nerve plexus" ;
     rdfs:subClassOf UBERON:0000122,
-        UBERON:0035771 .
+        UBERON:0035771,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
+
+UBERON:0005604 a owl:Class ;
+    rdfs:label "extrahepatic part of hepatic duct" ;
+    NIFRID:synonym "extrahepatic part of hepatic duct",
+        "extrahepatic part of the hepatic duct",
+        "hepatic duct extrahepatic part" ;
+    rdfs:subClassOf UBERON:0002394,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003703 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0005171 ] .
 
 UBERON:0005616 a owl:Class ;
     rdfs:label "mesenteric artery" ;
+    NIFRID:synonym "mesenteric artery" ;
     rdfs:subClassOf UBERON:0012254 .
-
-UBERON:0005629 a owl:Class ;
-    rdfs:label "vascular plexus" ;
-    NIFRID:synonym "plexus vasculosus" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0002049,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001009 ] .
 
 UBERON:0005725 a owl:Class ;
     rdfs:label "olfactory system" ;
+    NIFRID:synonym "olfactory system" ;
     rdfs:subClassOf UBERON:0005726 .
 
 UBERON:0005726 a owl:Class ;
     rdfs:label "chemosensory system" ;
+    NIFRID:synonym "chemosensory system" ;
     rdfs:subClassOf UBERON:0001032 .
 
 UBERON:0005734 a owl:Class ;
@@ -16024,33 +20523,35 @@ UBERON:0005734 a owl:Class ;
     NIFRID:synonym "adventitia externa",
         "external coat",
         "tunica adventitia",
+        "tunica adventitia of blood vessel",
         "tunica adventitia of vessel",
         "tunica adventitia vasorum",
         "tunica externa vasorum" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0004797,
+    rdfs:subClassOf UBERON:0004797,
         UBERON:0005742 .
 
 UBERON:0005742 a owl:Class ;
     rdfs:label "adventitia" ;
-    NIFRID:synonym "tunica advetitia",
+    NIFRID:synonym "adventitia",
+        "tunica advetitia",
         "tunica externa" ;
-    rdfs:subClassOf UBERON:0004923,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0009916 ] .
+    rdfs:subClassOf UBERON:0004923 .
 
 UBERON:0005764 a owl:Class ;
     rdfs:label "acellular membrane" ;
-    rdfs:subClassOf UBERON:0000476 .
+    NIFRID:synonym "acellular membrane" ;
+    rdfs:subClassOf UBERON:0000476,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000061 ] .
 
 UBERON:0005769 a owl:Class ;
     rdfs:label "basement membrane of epithelium" ;
     NIFRID:synonym "basement membrane",
         "basement membrane of connective tissue",
+        "basement membrane of epithelium",
         "membrana basalis" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0005764,
+    rdfs:subClassOf UBERON:0005764,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000483 ] .
@@ -16060,12 +20561,21 @@ UBERON:0005800 a owl:Class ;
     NIFRID:synonym "aortic section",
         "aortic segment",
         "portion of aorta",
+        "section of aorta",
         "segment of aorta" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0013522,
+    rdfs:subClassOf UBERON:0013522,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000947 ] .
+
+UBERON:0005806 a owl:Class ;
+    rdfs:label "portal system" ;
+    NIFRID:synonym "portal system",
+        "portal venous system" ;
+    rdfs:subClassOf UBERON:0002049,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004535 ] .
 
 UBERON:0005807 a owl:Class ;
     rdfs:label "rostral ventrolateral medulla" ;
@@ -16078,7 +20588,8 @@ UBERON:0005807 a owl:Class ;
 
 UBERON:0005838 a owl:Class ;
     rdfs:label "fasciculus of brain" ;
-    NIFRID:synonym "brain fasciculus" ;
+    NIFRID:synonym "brain fasciculus",
+        "fasciculus of brain" ;
     rdfs:subClassOf UBERON:0001019,
         UBERON:0011215,
         [ a owl:Restriction ;
@@ -16101,6 +20612,7 @@ UBERON:0005844 a owl:Class ;
     NIFRID:synonym "axial part of spinal cord",
         "axial regional part of spinal cord",
         "segment of spinal cord",
+        "spinal cord segment",
         "spinal neuromeres" ;
     rdfs:subClassOf UBERON:0001948,
         [ a owl:Restriction ;
@@ -16114,6 +20626,15 @@ UBERON:0005853 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0005843 ] .
 
+UBERON:0005881 a owl:Class ;
+    rdfs:label "autopodial extension" ;
+    NIFRID:synonym "digit or predigit",
+        "limb outgrowth" ;
+    rdfs:subClassOf UBERON:0000475,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002470 ] .
+
 UBERON:0005904 a owl:Class ;
     rdfs:label "duct of male reproductive system" ;
     rdfs:subClassOf UBERON:0000058,
@@ -16124,19 +20645,21 @@ UBERON:0005904 a owl:Class ;
 
 UBERON:0005906 a owl:Class ;
     rdfs:label "serous sac" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000062 .
+    NIFRID:synonym "serous sac" ;
+    rdfs:subClassOf UBERON:0000062 .
 
 UBERON:0005911 a owl:Class ;
     rdfs:label "endo-epithelium" ;
-    NIFRID:synonym "endoderm-derived epithelium",
+    NIFRID:synonym "endo-epithelium",
+        "endoderm-derived epithelium",
         "endoepithelium" ;
     rdfs:subClassOf UBERON:0000483,
         UBERON:0004119 .
 
 UBERON:0005913 a owl:Class ;
     rdfs:label "zone of bone organ" ;
-    NIFRID:synonym "bone organ zone" ;
+    NIFRID:synonym "bone organ zone",
+        "zone of bone organ" ;
     rdfs:subClassOf UBERON:0034944,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -16144,8 +20667,8 @@ UBERON:0005913 a owl:Class ;
 
 UBERON:0005983 a owl:Class ;
     rdfs:label "heart layer" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0004923,
+    NIFRID:synonym "heart layer" ;
+    rdfs:subClassOf UBERON:0004923,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000948 ],
@@ -16153,15 +20676,11 @@ UBERON:0005983 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000948 ] .
 
-UBERON:0005984 a owl:Class ;
-    rdfs:label "subendocardium layer" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0005983 .
-
 UBERON:0006003 a owl:Class ;
     rdfs:label "integumentary adnexa" ;
     NIFRID:synonym "adnexae cutis",
         "body hair or bristle",
+        "integumentary adnexa",
         "skin adnexa",
         "skin adnexal structure",
         "skin appendage" ;
@@ -16170,14 +20689,75 @@ UBERON:0006003 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002416 ] .
 
+UBERON:0006048 a owl:Class ;
+    rdfs:label "digit 1" ;
+    NIFRID:synonym "autopod digit 1",
+        "dewclaw",
+        "digit I",
+        "limb digit 1" ;
+    rdfs:subClassOf UBERON:0019221,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:5006048 ] .
+
+UBERON:0006049 a owl:Class ;
+    rdfs:label "digit 2" ;
+    NIFRID:synonym "autopod digit 2",
+        "digit II",
+        "limb digit 2",
+        "second digit" ;
+    rdfs:subClassOf UBERON:0019222,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:5006049 ] .
+
+UBERON:0006050 a owl:Class ;
+    rdfs:label "digit 3" ;
+    NIFRID:synonym "autopod digit 3",
+        "digit III",
+        "limb digit 3",
+        "third digit" ;
+    rdfs:subClassOf UBERON:0019222,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:5006050 ] .
+
 UBERON:0006058 a owl:Class ;
     rdfs:label "multi-limb segment region" ;
     rdfs:subClassOf UBERON:0010758 .
+
+UBERON:0006067 a owl:Class ;
+    rdfs:label "musculature of hindlimb zeugopod" ;
+    NIFRID:synonym "leg musculature",
+        "muscle group of leg",
+        "set of muscles of leg" ;
+    rdfs:subClassOf UBERON:0004466,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003823 ] .
+
+UBERON:0006082 a owl:Class ;
+    rdfs:label "fundus of urinary bladder" ;
+    NIFRID:synonym "base of urinary bladder",
+        "bladder dome",
+        "fundus of bladder",
+        "fundus vesicae",
+        "urinary bladder base",
+        "urinary bladder fundus",
+        "urinary bladder fundus region" ;
+    rdfs:subClassOf UBERON:0000064,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001255 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0001255 ] .
 
 UBERON:0006098 a owl:Class ;
     rdfs:label "basal nuclear complex" ;
     NIFRID:synonym "basal ganglia",
         "basal ganglia (anatomic)",
+        "basal nuclear complex",
         "basal nuclei",
         "basal nuclei of the forebrain",
         "corpus striatum (Savel'ev)",
@@ -16187,44 +20767,6 @@ UBERON:0006098 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002743 ] .
-
-UBERON:0006107 a owl:Class ;
-    rdfs:label "basolateral amygdaloid nuclear complex" ;
-    NIFRID:synonym "amygdalar basolateral nucleus",
-        "amygdaloid basolateral complex",
-        "basolateral amygdala",
-        "basolateral amygdaloid nuclear complex",
-        "basolateral complex",
-        "basolateral nuclear complex",
-        "basolateral nuclear group",
-        "basolateral nuclei of amygdala",
-        "basolateral subdivision of amygdala",
-        "BL",
-        "pars basolateralis (Corpus amygdaloideum)",
-        "set of basolateral nuclei of amygdala",
-        "vicarious cortex" ;
-    rdfs:subClassOf UBERON:0005401,
-        UBERON:0007245,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001876 ] .
-
-UBERON:0006108 a owl:Class ;
-    rdfs:label "corticomedial nuclear complex" ;
-    NIFRID:synonym "amygdalar corticomedial nucleus",
-        "CMA",
-        "corpus amygdaloideum pars corticomedialis",
-        "corpus amygdaloideum pars olfactoria",
-        "corticomedial nuclear complex",
-        "corticomedial nuclear group",
-        "corticomedial nuclei of amygdala",
-        "pars corticomedialis (Corpus amygdaloideum)",
-        "set of corticomedial nuclei of amygdala" ;
-    rdfs:subClassOf UBERON:0005401,
-        UBERON:0007245,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001876 ] .
 
 UBERON:0006118 a owl:Class ;
     rdfs:label "lamina I of gray matter of spinal cord" ;
@@ -16245,7 +20787,8 @@ UBERON:0006118 a owl:Class ;
 
 UBERON:0006127 a owl:Class ;
     rdfs:label "funiculus of spinal cord" ;
-    NIFRID:synonym "spinal cord funiculus",
+    NIFRID:synonym "funiculus of spinal cord",
+        "spinal cord funiculus",
         "white column of spinal cord" ;
     rdfs:subClassOf UBERON:0006133,
         [ a owl:Restriction ;
@@ -16257,6 +20800,7 @@ UBERON:0006127 a owl:Class ;
 
 UBERON:0006133 a owl:Class ;
     rdfs:label "funiculus of neuraxis" ;
+    NIFRID:synonym "funiculus of neuraxis" ;
     rdfs:subClassOf UBERON:0000122,
         UBERON:0011215,
         [ a owl:Restriction ;
@@ -16265,24 +20809,34 @@ UBERON:0006133 a owl:Class ;
 
 UBERON:0006134 a owl:Class ;
     rdfs:label "nerve fiber" ;
-    NIFRID:synonym "nerve fibers",
+    NIFRID:synonym "nerve fiber",
+        "nerve fibers",
         "nerve fibre",
         "neurofibra",
         "neurofibrum" ;
     rdfs:subClassOf UBERON:0005162,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001019 ],
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004679 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0022317 ] .
+            owl:someValuesFrom UBERON:0001019 ] .
+
+UBERON:0006135 a owl:Class ;
+    rdfs:label "myelinated nerve fiber" ;
+    NIFRID:synonym "myelinated nerve fiber" ;
+    rdfs:subClassOf UBERON:0006134 .
+
+UBERON:0006136 a owl:Class ;
+    rdfs:label "unmyelinated nerve fiber" ;
+    NIFRID:synonym "non-myelinated nerve fiber",
+        "unmyelinated nerve fiber" ;
+    rdfs:subClassOf UBERON:0006134 .
 
 UBERON:0006331 a owl:Class ;
     rdfs:label "brainstem nucleus" ;
-    NIFRID:synonym "brain stem nucleus" ;
+    NIFRID:synonym "brain stem nucleus",
+        "brainstem nucleus" ;
     rdfs:subClassOf UBERON:0002308,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -16381,32 +20935,28 @@ UBERON:0006459 a owl:Class ;
     rdfs:subClassOf UBERON:0007715 .
 
 UBERON:0006460 a owl:Class ;
-    rdfs:label "S1 segment",
-        "S1 segment of sacral spinal cord" ;
+    rdfs:label "S1 segment of sacral spinal cord" ;
     NIFRID:synonym "first sacral spinal cord segment",
         "S1 segment",
         "S1 spinal cord segment" ;
     rdfs:subClassOf UBERON:0007717 .
 
 UBERON:0006461 a owl:Class ;
-    rdfs:label "S2 segment",
-        "S2 segment of sacral spinal cord" ;
+    rdfs:label "S2 segment of sacral spinal cord" ;
     NIFRID:synonym "S2 segment",
         "S2 spinal cord segment",
         "second sacral spinal cord segment" ;
     rdfs:subClassOf UBERON:0007717 .
 
 UBERON:0006462 a owl:Class ;
-    rdfs:label "S3 segment",
-        "S3 segment of sacral spinal cord" ;
+    rdfs:label "S3 segment of sacral spinal cord" ;
     NIFRID:synonym "S3 segment",
         "S3 spinal cord segment",
         "third sacral spinal cord segment" ;
     rdfs:subClassOf UBERON:0007717 .
 
 UBERON:0006463 a owl:Class ;
-    rdfs:label "S4 segment",
-        "S4 segment of sacral spinal cord" ;
+    rdfs:label "S4 segment of sacral spinal cord" ;
     NIFRID:synonym "fourth sacral spinal cord segment",
         "S4 segment",
         "S4 spinal cord segment" ;
@@ -16470,16 +21020,14 @@ UBERON:0006489 a owl:Class ;
     rdfs:subClassOf UBERON:0007714 .
 
 UBERON:0006490 a owl:Class ;
-    rdfs:label "C4 segment of cervical spinal cord",
-        "C4 spinal segment" ;
+    rdfs:label "C4 segment of cervical spinal cord" ;
     NIFRID:synonym "C4 segment",
         "C4 spinal cord segment",
         "forth cervical spinal cord segment" ;
     rdfs:subClassOf UBERON:0007714 .
 
 UBERON:0006491 a owl:Class ;
-    rdfs:label "C5 segment",
-        "C5 segment of cervical spinal cord" ;
+    rdfs:label "C5 segment of cervical spinal cord" ;
     NIFRID:synonym "C5 segment",
         "C5 spinal cord segment",
         "fifth cervical spinal cord segment" ;
@@ -16499,17 +21047,77 @@ UBERON:0006493 a owl:Class ;
         "seventh cervical spinal cord segment" ;
     rdfs:subClassOf UBERON:0007714 .
 
+UBERON:0006497 a owl:Class ;
+    rdfs:label "interosseous muscle of pes" ;
+    NIFRID:synonym "foot interosseous",
+        "foot interosseus muscle",
+        "interosseous muscle of foot",
+        "interosseous of foot",
+        "pes interosseous muscle" ;
+    rdfs:subClassOf UBERON:0006508,
+        UBERON:0014378,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002387 ] .
+
+UBERON:0006499 a owl:Class ;
+    rdfs:label "dorsal pes interosseous muscle" ;
+    NIFRID:synonym "dorsal foot interosseus muscle",
+        "dorsal interosseous muscle of foot",
+        "dorsal interosseous of foot",
+        "musculi interossei dorsalis pedis" ;
+    rdfs:subClassOf UBERON:0006497 .
+
+UBERON:0006502 a owl:Class ;
+    rdfs:label "plantar interosseous muscle of pes" ;
+    NIFRID:synonym "musculi interossei plantares",
+        "musculi interosseus plantaris",
+        "plantar foot interosseus muscle",
+        "plantar interosseous muscle of foot",
+        "plantar interosseous of foot" ;
+    rdfs:subClassOf UBERON:0006497 .
+
+UBERON:0006505 a owl:Class ;
+    rdfs:label "palmar interosseous muscle of manus" ;
+    NIFRID:synonym "musculi interossei palmares",
+        "palmar hand interosseus muscle",
+        "palmar interosseous muscle of hand",
+        "palmar interosseous of hand" ;
+    rdfs:subClassOf UBERON:0001502 .
+
+UBERON:0006508 a owl:Class ;
+    rdfs:label "interosseous muscle of autopod" ;
+    NIFRID:synonym "interossei",
+        "interosseous",
+        "interosseus muscle",
+        "m. interosseous" ;
+    rdfs:subClassOf UBERON:0003661,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0009877 ] .
+
 UBERON:0006514 a owl:Class ;
     rdfs:label "pallidum" ;
     NIFRID:synonym "neuraxis pallidum",
+        "pallidum",
         "pallidum of neuraxis" ;
-    rdfs:subClassOf UBERON:0003528,
+    rdfs:subClassOf UBERON:0002020,
+        UBERON:0003528,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002420 ] .
 
+UBERON:0006544 a owl:Class ;
+    rdfs:label "kidney vasculature" ;
+    rdfs:subClassOf UBERON:0002201,
+        UBERON:0006876,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002113 ] .
+
 UBERON:0006555 a owl:Class ;
     rdfs:label "excretory tube" ;
+    NIFRID:synonym "excretory tube" ;
     rdfs:subClassOf UBERON:0000025,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -16518,15 +21126,14 @@ UBERON:0006555 a owl:Class ;
 UBERON:0006562 a owl:Class ;
     rdfs:label "pharynx" ;
     NIFRID:synonym "anterior part of foregut",
-        "pharyngeal tube" ;
-    rdfs:subClassOf UBERON:0004921,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007811 ] .
+        "pharyngeal tube",
+        "pharynx" ;
+    rdfs:subClassOf UBERON:0004921 .
 
 UBERON:0006568 a owl:Class ;
     rdfs:label "hypothalamic nucleus" ;
-    NIFRID:synonym "nucleus of hypothalamus" ;
+    NIFRID:synonym "hypothalamic nucleus",
+        "nucleus of hypothalamus" ;
     rdfs:subClassOf UBERON:0006569,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -16534,23 +21141,11 @@ UBERON:0006568 a owl:Class ;
 
 UBERON:0006569 a owl:Class ;
     rdfs:label "diencephalic nucleus" ;
+    NIFRID:synonym "diencephalic nucleus" ;
     rdfs:subClassOf UBERON:0002308,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001894 ] .
-
-UBERON:0006606 a owl:Class ;
-    rdfs:label "mandibular symphysis" ;
-    NIFRID:synonym "dentary symphysis",
-        "inter-dentary joint",
-        "inter-mandibular joint",
-        "mental symphysis",
-        "symphysis mandibulae",
-        "symphysis menti" ;
-    rdfs:subClassOf UBERON:0002216,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001710 ] .
 
 UBERON:0006608 a owl:Class ;
     rdfs:label "corpus cavernosum clitoridis" ;
@@ -16559,8 +21154,7 @@ UBERON:0006608 a owl:Class ;
         "corpus cavernosum",
         "corpus cavernosum clitoridis",
         "corpus cavernosum of clitoris" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0005156,
+    rdfs:subClassOf UBERON:0005156,
         UBERON:0006609,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -16573,10 +21167,7 @@ UBERON:0006609 a owl:Class ;
 UBERON:0006615 a owl:Class ;
     rdfs:label "venous sinus" ;
     NIFRID:synonym "blood sinus" ;
-    rdfs:subClassOf UBERON:0003920,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0011933 ] .
+    rdfs:subClassOf UBERON:0003920 .
 
 UBERON:0006635 a owl:Class ;
     rdfs:label "anterior abdominal wall" ;
@@ -16592,23 +21183,10 @@ UBERON:0006637 a owl:Class ;
         "coeliaco-mesenteric trunk",
         "Haller's tripus",
         "truncus coeliacus" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0013522,
+    rdfs:subClassOf UBERON:0013522,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001640 ] .
-
-UBERON:0006655 a owl:Class ;
-    rdfs:label "septum of scrotum" ;
-    NIFRID:synonym "scrotal septum",
-        "septum scroti" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000060,
-        UBERON:0004120,
-        UBERON:0005156,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001300 ] .
 
 UBERON:0006660 a owl:Class ;
     rdfs:label "muscular coat" ;
@@ -16621,10 +21199,8 @@ UBERON:0006660 a owl:Class ;
         "transverse muscular fibers",
         "tunica externa",
         "tunica muscularis" ;
-    rdfs:subClassOf UBERON:0018260,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0009916 ] .
+    rdfs:subClassOf UBERON:0004923,
+        UBERON:0018260 .
 
 UBERON:0006676 a owl:Class ;
     rdfs:label "muscularis mucosa" ;
@@ -16632,13 +21208,41 @@ UBERON:0006676 a owl:Class ;
         "lamina muscularis mucosa",
         "laminar muscularis mucosa",
         "muscularis mucosae" ;
-    rdfs:subClassOf UBERON:0004226,
+    rdfs:subClassOf UBERON:0001135,
+        UBERON:0004226,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001555 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004786 ] .
+
+UBERON:0006716 a owl:Class ;
+    rdfs:label "mesopodium region" ;
+    NIFRID:synonym "carpus/tarsus",
+        "mesopod",
+        "mesopodial limb segment",
+        "mesopodial segment" ;
+    rdfs:subClassOf UBERON:0002529,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002470 ] .
+
+UBERON:0006729 a owl:Class ;
+    rdfs:label "liver perisinusoidal space" ;
+    NIFRID:synonym "Disse's space",
+        "hepatic perisinusoidal space",
+        "perisinusoidal space",
+        "perisinusoidal space of Disse",
+        "space of Disse",
+        "spatium perisinusoideum" ;
+    rdfs:subClassOf UBERON:0000464,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004647 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0004647 ] .
 
 UBERON:0006783 a owl:Class ;
     rdfs:label "layer of superior colliculus" ;
@@ -16669,6 +21273,19 @@ UBERON:0006794 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001016 ] .
 
+UBERON:0006839 a owl:Class ;
+    rdfs:label "dorsal ramus of spinal nerve" ;
+    NIFRID:synonym "dorsal ramus",
+        "posterior branch of spinal nerve",
+        "posterior primary ramus",
+        "posterior ramus of spinal nerve",
+        "ramus posterior",
+        "ramus posterior nervi spinalis" ;
+    rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0005476 ] .
+
 UBERON:0006840 a owl:Class ;
     rdfs:label "nucleus of lateral lemniscus" ;
     NIFRID:synonym "lateral lemniscus nuclei",
@@ -16679,6 +21296,27 @@ UBERON:0006840 a owl:Class ;
         "set of nuclei of lateral lemniscus" ;
     rdfs:subClassOf UBERON:0002308 .
 
+UBERON:0006845 a owl:Class ;
+    rdfs:label "abductor muscle" ;
+    rdfs:subClassOf UBERON:0014892 .
+
+UBERON:0006851 a owl:Class ;
+    rdfs:label "renal cortex peritubular capillary" ;
+    NIFRID:synonym "kidney cortex peritubular capillary" ;
+    rdfs:subClassOf UBERON:0005272,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001225 ] .
+
+UBERON:0006853 a owl:Class ;
+    rdfs:label "renal cortex tubule" ;
+    NIFRID:synonym "cortical tubule",
+        "kidney cortex tubule" ;
+    rdfs:subClassOf UBERON:0007685,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001225 ] .
+
 UBERON:0006858 a owl:Class ;
     rdfs:label "adrenal/interrenal gland" ;
     NIFRID:synonym "adrenal - interrenal gland",
@@ -16687,10 +21325,30 @@ UBERON:0006858 a owl:Class ;
         "suprarenal gland - interrenal gland" ;
     rdfs:subClassOf UBERON:0002368,
         UBERON:0004120,
-        UBERON:0010313,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0010074 ] .
+
+UBERON:0006866 a owl:Class ;
+    rdfs:label "terminal part of digestive tract" ;
+    NIFRID:synonym "rectal part of digestive tract",
+        "rectum",
+        "terminal part of digestive tract",
+        "terminal section of digestive tract" ;
+    rdfs:subClassOf UBERON:0004921 .
+
+UBERON:0006867 a owl:Class ;
+    rdfs:label "anal part of perineum" ;
+    NIFRID:synonym "anal region",
+        "anal triangle",
+        "regio analis" ;
+    rdfs:subClassOf UBERON:0000064,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001353 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002356 ] .
 
 UBERON:0006868 a owl:Class ;
     rdfs:label "seminal fluid secreting gland" ;
@@ -16699,9 +21357,38 @@ UBERON:0006868 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0006947 ] .
 
+UBERON:0006876 a owl:Class ;
+    rdfs:label "vasculature of organ" ;
+    NIFRID:synonym "organ vasculature",
+        "set of blood vessels of organ",
+        "vasculature of organ" ;
+    rdfs:subClassOf UBERON:0002049,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000062 ] .
+
+UBERON:0006877 a owl:Class ;
+    rdfs:label "vasculature of liver" ;
+    NIFRID:synonym "hepatic vascular element",
+        "hepatic vasculature",
+        "liver vascular element",
+        "liver vascular system",
+        "vasculature of liver" ;
+    rdfs:subClassOf UBERON:0002201,
+        UBERON:0006876,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002107 ] .
+
+UBERON:0006914 a owl:Class ;
+    rdfs:label "squamous epithelium" ;
+    NIFRID:synonym "squamous epithelium" ;
+    rdfs:subClassOf UBERON:0000483 .
+
 UBERON:0006925 a owl:Class ;
     rdfs:label "digestive system gland" ;
-    NIFRID:synonym "digestive gland" ;
+    NIFRID:synonym "digestive gland",
+        "digestive system gland" ;
     rdfs:subClassOf UBERON:0002368,
         UBERON:0013765,
         [ a owl:Restriction ;
@@ -16710,7 +21397,8 @@ UBERON:0006925 a owl:Class ;
 
 UBERON:0006934 a owl:Class ;
     rdfs:label "sensory epithelium" ;
-    NIFRID:synonym "neuroepithelium" ;
+    NIFRID:synonym "neuroepithelium",
+        "sensory epithelium" ;
     rdfs:subClassOf UBERON:0000488,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -16741,27 +21429,29 @@ UBERON:0006960 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000992 ] .
 
-UBERON:0007023 a owl:Class ;
-    rdfs:label "adult organism" ;
-    NIFRID:synonym "adult",
-        "adults" ;
-    rdfs:subClassOf UBERON:0000468 .
+UBERON:0006984 a owl:Class ;
+    rdfs:label "anatomical surface" ;
+    NIFRID:synonym "anatomical surface" ;
+    rdfs:subClassOf UBERON:0010199 .
 
 UBERON:0007037 a owl:Class ;
     rdfs:label "mechanosensory system" ;
+    NIFRID:synonym "mechanosensory system" ;
     rdfs:subClassOf UBERON:0001032 .
 
 UBERON:0007100 a owl:Class ;
     rdfs:label "primary circulatory organ" ;
     NIFRID:synonym "adult heart",
         "dorsal tube",
-        "heart" ;
+        "heart",
+        "primary circulatory organ" ;
     rdfs:subClassOf UBERON:0015228 .
 
 UBERON:0007134 a owl:Class ;
     rdfs:label "trunk ganglion" ;
     NIFRID:synonym "body ganglion",
-        "trunk ganglia" ;
+        "trunk ganglia",
+        "trunk ganglion" ;
     rdfs:subClassOf UBERON:0000045,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -16772,43 +21462,64 @@ UBERON:0007177 a owl:Class ;
     NIFRID:synonym "colonic lamina propria",
         "lamina propria mucosae of colon",
         "lamina propria of colonic mucosa",
-        "lamina propria of colonic mucous membrane" ;
+        "lamina propria of colonic mucous membrane",
+        "lamina propria of mucosa of colon" ;
     rdfs:subClassOf UBERON:0011189,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000317 ] .
 
+UBERON:0007188 a owl:Class ;
+    rdfs:label "mesothelium of serous pericardium" ;
+    NIFRID:synonym "mesothelium of pericardium",
+        "mesothelium of serous pericardium",
+        "pericardial mesothelium",
+        "serous pericardium mesothelium" ;
+    rdfs:subClassOf UBERON:0003388,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002357 ] .
+
 UBERON:0007196 a owl:Class ;
     rdfs:label "tracheobronchial tree" ;
     NIFRID:synonym "arbor tracheobronchialis",
-        "tracheobronchial system" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000062,
-        UBERON:0004119,
+        "tracheobronchial system",
+        "tracheobronchial tree" ;
+    rdfs:subClassOf UBERON:0000062,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001558 ] .
 
-UBERON:0007197 a owl:Class ;
-    rdfs:label "hermaphroditic organism" ;
-    NIFRID:synonym "dioecious organism",
-        "hermaphrodite" ;
-    rdfs:subClassOf UBERON:0000468 .
-
 UBERON:0007204 a owl:Class ;
     rdfs:label "brachiocephalic vasculature" ;
+    NIFRID:synonym "brachiocephalic vasculature" ;
     rdfs:subClassOf UBERON:0002049 .
+
+UBERON:0007240 a owl:Class ;
+    rdfs:label "tunica adventitia of artery" ;
+    NIFRID:synonym "arterial adventitia",
+        "tunica adventitia of artery",
+        "tunica externa (adventitia)(arteriae)" ;
+    rdfs:subClassOf UBERON:0005734,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000415 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001637 ] .
 
 UBERON:0007245 a owl:Class ;
     rdfs:label "nuclear complex of neuraxis" ;
     NIFRID:synonym "cluster of neural nuclei",
         "neural nuclei",
-        "nuclear complex" ;
+        "nuclear complex",
+        "nuclear complex of neuraxis" ;
     rdfs:subClassOf UBERON:0002020 .
 
 UBERON:0007247 a owl:Class ;
     rdfs:label "nucleus of superior olivary complex" ;
-    NIFRID:synonym "superior olivary complex nucleus" ;
+    NIFRID:synonym "nucleus of superior olivary complex",
+        "superior olivary complex nucleus" ;
     rdfs:subClassOf UBERON:0006331,
         UBERON:0009662,
         [ a owl:Restriction ;
@@ -16817,58 +21528,67 @@ UBERON:0007247 a owl:Class ;
 
 UBERON:0007251 a owl:Class ;
     rdfs:label "preoptic nucleus" ;
+    NIFRID:synonym "preoptic nucleus" ;
     rdfs:subClassOf UBERON:0006569,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001928 ] .
+
+UBERON:0007269 a owl:Class ;
+    rdfs:label "pectoral appendage musculature" ;
+    NIFRID:synonym "pectoral appendage musculature",
+        "pectoral fin muscle",
+        "pectoral fin musculature" ;
+    rdfs:subClassOf UBERON:0007271,
+        UBERON:0014793,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004710 ] .
+
+UBERON:0007270 a owl:Class ;
+    rdfs:label "pelvic appendage musculature" ;
+    NIFRID:synonym "pelvic fin musculature" ;
+    rdfs:subClassOf UBERON:0007271,
+        UBERON:0014792,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004709 ] .
+
+UBERON:0007271 a owl:Class ;
+    rdfs:label "appendage musculature" ;
+    NIFRID:synonym "appendage musculature",
+        "fin musculature" ;
+    rdfs:subClassOf UBERON:0001015,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000026 ] .
 
 UBERON:0007324 a owl:Class ;
     rdfs:label "pancreatic lobule" ;
     NIFRID:synonym "lobulus pancreaticus",
         "pancreas lobe",
         "pancreatic lobule" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000064,
-        UBERON:0004119,
+    rdfs:subClassOf UBERON:0000064,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000017 ] .
 
-UBERON:0007359 a owl:Class ;
-    rdfs:label "ruminant forestomach" ;
-    NIFRID:synonym "forestomach" ;
-    rdfs:subClassOf UBERON:0011954,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007366 ] .
-
-UBERON:0007362 a owl:Class ;
-    rdfs:label "omasum" ;
-    NIFRID:synonym "omasum" ;
-    rdfs:subClassOf UBERON:0011954,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007359 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007364 ] .
-
-UBERON:0007364 a owl:Class ;
-    rdfs:label "reticulorumen" ;
-    NIFRID:synonym "retriculo-rumen" ;
-    rdfs:subClassOf UBERON:0004921,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007366 ] .
-
-UBERON:0007366 a owl:Class ;
-    rdfs:label "ruminant stomach" ;
-    NIFRID:synonym "plurilocular stomach" ;
-    rdfs:subClassOf UBERON:0000945 .
+UBERON:0007376 a owl:Class ;
+    rdfs:label "outer epithelium" ;
+    NIFRID:synonym "epidermis",
+        "epidermis (sensu Metazoa)",
+        "hypoderm",
+        "hypodermis",
+        "outer epidermal layer",
+        "outer epithelial layer",
+        "outer epithelium" ;
+    rdfs:subClassOf UBERON:0000483,
+        UBERON:0003102 .
 
 UBERON:0007414 a owl:Class ;
     rdfs:label "nucleus of midbrain tegmentum" ;
-    NIFRID:synonym "tegmental nuclei",
+    NIFRID:synonym "nucleus of midbrain tegmentum",
+        "tegmental nuclei",
         "tegmental nucleus" ;
     rdfs:subClassOf UBERON:0000125 .
 
@@ -16876,7 +21596,8 @@ UBERON:0007415 a owl:Class ;
     rdfs:label "nucleus of midbrain reticular formation" ;
     NIFRID:synonym "mesencephalic reticular nucleus",
         "midbrain reticular formation nucleus",
-        "midbrain reticular nucleus" ;
+        "midbrain reticular nucleus",
+        "nucleus of midbrain reticular formation" ;
     rdfs:subClassOf UBERON:0006331,
         UBERON:0007414,
         UBERON:0009661,
@@ -16884,55 +21605,42 @@ UBERON:0007415 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002639 ] .
 
-UBERON:0007417 a owl:Class ;
-    rdfs:label "peduncle of neuraxis" ;
-    NIFRID:synonym "neuraxis peduncle" ;
-    rdfs:subClassOf UBERON:0002316 .
-
-UBERON:0007499 a owl:Class ;
-    rdfs:label "epithelial sac" ;
-    rdfs:subClassOf UBERON:0003914,
-        UBERON:0009856 .
-
-UBERON:0007501 a owl:Class ;
-    rdfs:label "arborizing epithelial duct system" ;
-    NIFRID:synonym "arborising epithelial duct system" ;
-    rdfs:subClassOf UBERON:0007499 .
-
-UBERON:0007502 a owl:Class ;
-    rdfs:label "epithelial plexus" ;
-    rdfs:subClassOf UBERON:0003914 .
-
 UBERON:0007521 a owl:Class ;
     rdfs:label "smooth muscle sphincter" ;
+    NIFRID:synonym "smooth muscle sphincter" ;
+    rdfs:subClassOf UBERON:0004590 .
+
+UBERON:0007522 a owl:Class ;
+    rdfs:label "striated muscle sphincter" ;
+    NIFRID:synonym "striated muscle sphincter" ;
     rdfs:subClassOf UBERON:0004590 .
 
 UBERON:0007592 a owl:Class ;
     rdfs:label "ciliated columnar epithelium" ;
+    NIFRID:synonym "ciliated columnar epithelium" ;
     rdfs:subClassOf UBERON:0000485,
-        UBERON:0007601,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007196 ] .
+        UBERON:0007601 .
 
 UBERON:0007601 a owl:Class ;
     rdfs:label "ciliated epithelium" ;
+    NIFRID:synonym "ciliated epithelium" ;
     rdfs:subClassOf UBERON:0000483 .
 
-UBERON:0007628 a owl:Class ;
-    rdfs:label "lateral septal complex" ;
-    NIFRID:synonym "lateral septal area",
-        "lateral septum",
-        "lateral septum complex" ;
-    rdfs:subClassOf UBERON:0002663,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002435 ] .
+UBERON:0007612 a owl:Class ;
+    rdfs:label "extensor digitorum communis" ;
+    NIFRID:synonym "extensor communis",
+        "extensor digitorum",
+        "extensor digitorum communis muscle",
+        "musculus extensor digitorum" ;
+    rdfs:subClassOf UBERON:0011024 .
 
-UBERON:0007629 a owl:Class ;
-    rdfs:label "medial septal complex" ;
-    NIFRID:synonym "medial septum complex" ;
-    rdfs:subClassOf UBERON:0002663 .
+UBERON:0007614 a owl:Class ;
+    rdfs:label "extensor digiti minimi muscle" ;
+    NIFRID:synonym "extensor digiti minimi",
+        "extensor digiti minimi (hand)",
+        "extensor digiti quinti proprius",
+        "musculus extensor digiti minimi" ;
+    rdfs:subClassOf UBERON:0011024 .
 
 UBERON:0007631 a owl:Class ;
     rdfs:label "accessory olfactory bulb glomerular layer" ;
@@ -16965,7 +21673,8 @@ UBERON:0007633 a owl:Class ;
         "trapezoid nuclear complex",
         "trapezoid nuclei",
         "Tz" ;
-    rdfs:subClassOf UBERON:0007247,
+    rdfs:subClassOf UBERON:0006331,
+        UBERON:0007247,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000988 ],
@@ -16986,6 +21695,7 @@ UBERON:0007634 a owl:Class ;
 
 UBERON:0007635 a owl:Class ;
     rdfs:label "nucleus of medulla oblongata" ;
+    NIFRID:synonym "nucleus of medulla oblongata" ;
     rdfs:subClassOf UBERON:0006331,
         UBERON:0009662,
         [ a owl:Restriction ;
@@ -16993,14 +21703,14 @@ UBERON:0007635 a owl:Class ;
             owl:someValuesFrom UBERON:0001896 ] .
 
 UBERON:0007639 a owl:Class ;
-    rdfs:label "Alveus",
-        "hippocampus alveus" ;
+    rdfs:label "hippocampus alveus" ;
     NIFRID:synonym "alveus",
         "alveus hippocampi",
         "alveus of fornix",
         "alveus of hippocampus",
         "alveus of the hippocampus",
         "CA2 alveus",
+        "hippocampus alveus",
         "neuraxis alveus" ;
     rdfs:subClassOf UBERON:0011215,
         UBERON:0016549,
@@ -17014,13 +21724,20 @@ UBERON:0007640 a owl:Class ;
         "stratum hippocampi moleculare et substratum lacunosum",
         "stratum lacunosum moleculare",
         "stratum lacunosum-moleculare" ;
-    rdfs:subClassOf UBERON:0002305 .
+    rdfs:subClassOf UBERON:0002305,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001954 ] .
 
 UBERON:0007641 a owl:Class ;
     rdfs:label "trigeminal nuclear complex" ;
     NIFRID:synonym "nuclei trigemini",
+        "trigeminal nuclear complex",
         "trigeminal nuclei" ;
-    rdfs:subClassOf UBERON:0007245 .
+    rdfs:subClassOf UBERON:0007245,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
 
 UBERON:0007651 a owl:Class ;
     rdfs:label "anatomical junction" ;
@@ -17028,23 +21745,62 @@ UBERON:0007651 a owl:Class ;
         "junction" ;
     rdfs:subClassOf UBERON:0000061 .
 
+UBERON:0007684 a owl:Class ;
+    rdfs:label "uriniferous tubule" ;
+    rdfs:subClassOf UBERON:0003914,
+        UBERON:0004819,
+        UBERON:0006555,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002113 ] .
+
+UBERON:0007685 a owl:Class ;
+    rdfs:label "region of nephron tubule" ;
+    NIFRID:synonym "region of renal tubule",
+        "renal tubule region" ;
+    rdfs:subClassOf UBERON:0001231,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001231 ] .
+
 UBERON:0007692 a owl:Class ;
     rdfs:label "nucleus of thalamus" ;
     NIFRID:synonym "nuclear complex of thalamus",
+        "nucleus of thalamus",
         "thalamic nucleus" ;
     rdfs:subClassOf UBERON:0006569,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001897 ] .
 
+UBERON:0007699 a owl:Class ;
+    rdfs:label "tract of spinal cord" ;
+    NIFRID:synonym "spinal cord tract",
+        "tract of spinal cord" ;
+    rdfs:subClassOf UBERON:0001018,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002240 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002316 ] .
+
 UBERON:0007702 a owl:Class ;
     rdfs:label "tract of brain" ;
     NIFRID:synonym "brain tract",
-        "landmark tracts" ;
+        "landmark tracts",
+        "tract of brain" ;
     rdfs:subClassOf UBERON:0001018,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000955 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002316 ] .
+
+UBERON:0007703 a owl:Class ;
+    rdfs:label "spinothalamic tract" ;
+    rdfs:subClassOf UBERON:0007702,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002316 ] .
@@ -17080,6 +21836,7 @@ UBERON:0007715 a owl:Class ;
     rdfs:label "thoracic subsegment of spinal cord" ;
     NIFRID:synonym "segment part of thoracic spinal cord" ;
     rdfs:subClassOf UBERON:0003038,
+        UBERON:0005844,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0003038 ] .
@@ -17088,6 +21845,7 @@ UBERON:0007716 a owl:Class ;
     rdfs:label "lumbar subsegment of spinal cord" ;
     NIFRID:synonym "segment part of lumbar spinal cord" ;
     rdfs:subClassOf UBERON:0002792,
+        UBERON:0005844,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002792 ] .
@@ -17099,16 +21857,6 @@ UBERON:0007717 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0005843 ] .
-
-UBERON:0007767 a owl:Class ;
-    rdfs:label "dorsal premammillary nucleus" ;
-    NIFRID:synonym "premammillary nucleus dorsal part" ;
-    rdfs:subClassOf UBERON:0002712 .
-
-UBERON:0007768 a owl:Class ;
-    rdfs:label "ventral premammillary nucleus" ;
-    NIFRID:synonym "premammillary nucleus ventral part" ;
-    rdfs:subClassOf UBERON:0002712 .
 
 UBERON:0007769 a owl:Class ;
     rdfs:label "medial preoptic region" ;
@@ -17122,39 +21870,31 @@ UBERON:0007769 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002272 ] .
 
+UBERON:0007771 a owl:Class ;
+    rdfs:label "epidermis gland" ;
+    NIFRID:synonym "epidermal gland",
+        "epidermis gland",
+        "gland of epidermis" ;
+    rdfs:subClassOf UBERON:0002419,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001003 ] .
+
 UBERON:0007798 a owl:Class ;
     rdfs:label "vascular system" ;
-    rdfs:subClassOf UBERON:0000467,
+    NIFRID:synonym "vascular system" ;
+    rdfs:subClassOf UBERON:0000465,
+        UBERON:0000467,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004535 ] .
-
-UBERON:0007809 a owl:Class ;
-    rdfs:label "fascia of Camper" ;
-    NIFRID:synonym "adipose layer of superficial fascia of abdomen",
-        "Camper's fascia",
-        "camper's fascia",
-        "fascia investiens intermedia abdominis",
-        "fatty layer of subcutaneous tissue of abdomen",
-        "fatty layer of superficial fascia of abdomen",
-        "intermediate investing fascia of abdomen",
-        "panniculus adiposus abdominis",
-        "panniculus adiposus telae subcutaneae abdominis",
-        "superficial layer of superficial fascia of abdomen" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0013493,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0006635 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0013488 ] .
 
 UBERON:0007811 a owl:Class ;
     rdfs:label "craniocervical region" ;
     NIFRID:synonym "cephalic area",
         "cephalic part of animal",
         "cephalic region",
+        "craniocervical region",
         "head and neck",
         "head or neck" ;
     rdfs:subClassOf UBERON:0000475,
@@ -17165,31 +21905,143 @@ UBERON:0007811 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0013702 ] .
 
-UBERON:0007845 a owl:Class ;
-    rdfs:label "regular connective tissue" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0002384 .
+UBERON:0007823 a owl:Class ;
+    rdfs:label "appendage girdle region" ;
+    NIFRID:synonym "appendage girdle region",
+        "fin girdle",
+        "fin girdle region",
+        "girdle",
+        "girdle region",
+        "limb girdle",
+        "limb girdle region" ;
+    rdfs:subClassOf UBERON:0000475,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010707 ] .
 
-UBERON:0007846 a owl:Class ;
-    rdfs:label "dense regular connective tissue" ;
-    NIFRID:synonym "dense fibrous connective tissue",
-        "dense regular collagenous connective tissue",
-        "dense regular collagenous tissue",
-        "regular dense connective tissue",
-        "typus regularis (textus connectivus collagenosus compactus)" ;
-    rdfs:subClassOf UBERON:0007845,
-        UBERON:0011823 .
+UBERON:0007828 a owl:Class ;
+    rdfs:label "girdle bone/zone" ;
+    NIFRID:synonym "girdle bone",
+        "girdle bone/zone" ;
+    rdfs:subClassOf UBERON:0010740,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007823 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010719 ] .
+
+UBERON:0007830 a owl:Class ;
+    rdfs:label "pelvic girdle bone/zone" ;
+    NIFRID:synonym "bone of pelvic girdle",
+        "pelvic girdle bone" ;
+    rdfs:subClassOf UBERON:0003828,
+        UBERON:0005179,
+        UBERON:0005913,
+        UBERON:0007828,
+        UBERON:0010742,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007832 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002091 ] .
+
+UBERON:0007831 a owl:Class ;
+    rdfs:label "pectoral girdle skeleton" ;
+    NIFRID:synonym "cingulum pectorale",
+        "pectoral girdle",
+        "pectoral girdle skeleton",
+        "scapular girdle",
+        "skeletal parts of pectoral girdle",
+        "skeleton of pectoral girdle" ;
+    rdfs:subClassOf UBERON:0010719,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001421 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002091 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012475 ] .
+
+UBERON:0007832 a owl:Class ;
+    rdfs:label "pelvic girdle skeleton" ;
+    NIFRID:synonym "pelvic girdle",
+        "pelvic girdle skeleton",
+        "skeletal parts of pelvic girdle",
+        "skeleton of pelvic girdle" ;
+    rdfs:subClassOf UBERON:0010719,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001271 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012476 ] .
+
+UBERON:0007838 a owl:Class ;
+    rdfs:label "spinal cord white commissure" ;
+    NIFRID:synonym "white commissure of spinal cord" ;
+    rdfs:subClassOf UBERON:0001020,
+        UBERON:0008882,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002240 ] .
+
+UBERON:0008114 a owl:Class ;
+    rdfs:label "joint of girdle" ;
+    NIFRID:synonym "girdle joint",
+        "joint of girdle" ;
+    rdfs:subClassOf UBERON:0000982,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007823 ] .
 
 UBERON:0008193 a owl:Class ;
     rdfs:label "pneumatized bone" ;
     NIFRID:synonym "hollow bone",
         "os pneumaticum",
-        "pneumatic bone" ;
+        "pneumatic bone",
+        "pneumatized bone" ;
     rdfs:subClassOf UBERON:0001474 .
+
+UBERON:0008196 a owl:Class ;
+    rdfs:label "muscle of pectoral girdle" ;
+    NIFRID:synonym "muscle of pectoral girdle",
+        "muscle of shoulder girdle",
+        "pectoral girdle muscle" ;
+    rdfs:subClassOf UBERON:0010891,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001421 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004471 ] .
+
+UBERON:0008229 a owl:Class ;
+    rdfs:label "craniocervical region musculature" ;
+    NIFRID:synonym "craniocervical region musculature",
+        "head muscles",
+        "head or neck muscle" ;
+    rdfs:subClassOf UBERON:0001015,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007811 ] .
+
+UBERON:0008230 a owl:Class ;
+    rdfs:label "tibialis" ;
+    NIFRID:synonym "tibialis muscle" ;
+    rdfs:subClassOf UBERON:0000366,
+        UBERON:0004256,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003823 ] .
 
 UBERON:0008231 a owl:Class ;
     rdfs:label "dorsal thoracic segment of trunk" ;
     NIFRID:synonym "back of thorax",
+        "dorsal thoracic segment of trunk",
         "dorsum of thorax",
         "posterior part of thorax",
         "thoracic back",
@@ -17209,6 +22061,9 @@ UBERON:0008323 a owl:Class ;
         UBERON:0005156,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002411 ] .
 
 UBERON:0008324 a owl:Class ;
@@ -17224,18 +22079,195 @@ UBERON:0008331 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002411 ] .
 
+UBERON:0008338 a owl:Class ;
+    rdfs:label "plantar part of pes" ;
+    NIFRID:synonym "pelma",
+        "planta",
+        "plantar part of foot",
+        "plantar region",
+        "regio plantaris",
+        "sole",
+        "sole of foot",
+        "sole of the foot",
+        "soles of the feet" ;
+    rdfs:subClassOf UBERON:0005445,
+        UBERON:0008837,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002387 ] .
+
+UBERON:0008446 a owl:Class ;
+    rdfs:label "flexor pollicis longus muscle" ;
+    NIFRID:synonym "flexor pollicis",
+        "flexor pollicis longus",
+        "flexor pollicis muscle",
+        "musculus flexor pollicis longus" ;
+    rdfs:subClassOf UBERON:0004254,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002386 ] .
+
+UBERON:0008450 a owl:Class ;
+    rdfs:label "psoas muscle" ;
+    NIFRID:synonym "psoas" ;
+    rdfs:subClassOf UBERON:0008549 .
+
+UBERON:0008454 a owl:Class ;
+    rdfs:label "rectus capitis posterior major" ;
+    NIFRID:synonym "greater posterior rectus capitis",
+        "musculus rectus capitis posterior major",
+        "recti capitis posteriores major",
+        "rectus capitis posterior major",
+        "rectus capitis posterior major muscle",
+        "rectus capitus posterior major",
+        "rectus capitus posterior major muscle",
+        "rectus posterior major" ;
+    rdfs:subClassOf UBERON:0002377,
+        UBERON:0004518,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000974 ] .
+
+UBERON:0008455 a owl:Class ;
+    rdfs:label "rectus capitis posterior minor" ;
+    NIFRID:synonym "lesser posterior rectus capitis",
+        "musculus rectus capitis posterior minor",
+        "recti capitis posteriores minores",
+        "rectus capitis posterior minor",
+        "rectus capitis posterior minor muscle",
+        "rectus capitus posterior minor",
+        "rectus capitus posterior minor muscle",
+        "rectus posterior minor" ;
+    rdfs:subClassOf UBERON:0002377,
+        UBERON:0004518,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000974 ] .
+
+UBERON:0008464 a owl:Class ;
+    rdfs:label "abductor hallucis muscle" ;
+    NIFRID:synonym "abductor hallucis",
+        "musculus abductor hallucis" ;
+    rdfs:subClassOf UBERON:0001498,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0008338 ] .
+
+UBERON:0008465 a owl:Class ;
+    rdfs:label "abductor pollicis brevis muscle" ;
+    NIFRID:synonym "abductor brevis",
+        "abductor pollicis brevis",
+        "musculus abductor pollicis brevis" ;
+    rdfs:subClassOf UBERON:0001500,
+        UBERON:0011534,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
+
+UBERON:0008521 a owl:Class ;
+    rdfs:label "gluteus minimus" ;
+    NIFRID:synonym "glutaeus minimus",
+        "gluteus minimus",
+        "gluteus minimus muscle",
+        "gluteus profundus",
+        "glutæus minimus",
+        "musculus gluteus minimus" ;
+    rdfs:subClassOf UBERON:0002000,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004470 ] .
+
+UBERON:0008529 a owl:Class ;
+    rdfs:label "piriformis muscle" ;
+    NIFRID:synonym "m.piriformis",
+        "musculus piriformis",
+        "piriform muscle",
+        "piriformis",
+        "piriformis muscle" ;
+    rdfs:subClassOf UBERON:0002000,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004470 ] .
+
+UBERON:0008537 a owl:Class ;
+    rdfs:label "quadratus femoris" ;
+    NIFRID:synonym "musculus quadratus femoris",
+        "quadratus femoris muscle" ;
+    rdfs:subClassOf UBERON:0002000,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004470 ] .
+
+UBERON:0008544 a owl:Class ;
+    rdfs:label "splenius cervicis" ;
+    NIFRID:synonym "musculus splenius cervicis",
+        "splenius cervicis muscle" ;
+    rdfs:subClassOf UBERON:0002252 .
+
+UBERON:0008549 a owl:Class ;
+    rdfs:label "prevertebral muscle" ;
+    NIFRID:synonym "flexor muscle of vertebral column",
+        "prevertebral muscle" ;
+    rdfs:subClassOf UBERON:0004518 .
+
+UBERON:0008617 a owl:Class ;
+    rdfs:label "innermost intercostal muscle" ;
+    NIFRID:synonym "musculus intercostalis intimus" ;
+    rdfs:subClassOf UBERON:0001111 .
+
+UBERON:0008713 a owl:Class ;
+    rdfs:label "pectoral girdle and thoracic body wall skeletal muscle" ;
+    rdfs:subClassOf UBERON:0001134 .
+
 UBERON:0008715 a owl:Class ;
     rdfs:label "muscle tissue of prostate" ;
     NIFRID:synonym "prostate gland muscle tissue",
         "prostate muscle tissue",
         "prostatic muscle",
         "prostatic musclular tissue" ;
-    rdfs:subClassOf UBERON:0000077,
-        UBERON:0002385,
+    rdfs:subClassOf UBERON:0002385,
         UBERON:0005156,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002367 ] .
+
+UBERON:0008777 a owl:Class ;
+    rdfs:label "hypaxial musculature" ;
+    NIFRID:synonym "hypaxial muscle",
+        "hypaxial muscles" ;
+    rdfs:subClassOf UBERON:0004120,
+        UBERON:0004479,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001774 ] .
+
+UBERON:0008779 a owl:Class ;
+    rdfs:label "subclavius" ;
+    NIFRID:synonym "musculus subclavius",
+        "subclavicular muscle" ;
+    rdfs:subClassOf UBERON:0001495 .
+
+UBERON:0008784 a owl:Class ;
+    rdfs:label "lower limb segment" ;
+    NIFRID:synonym "free lower limb segment",
+        "free lower limb subdivision",
+        "segment of free lower limb",
+        "subdivision of free lower limb" ;
+    rdfs:subClassOf UBERON:0002529,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002103 ] .
+
+UBERON:0008785 a owl:Class ;
+    rdfs:label "upper limb segment" ;
+    NIFRID:synonym "free upper limb segment",
+        "free upper limb subdivision",
+        "segment of free upper limb",
+        "subdivision of free upper limb" ;
+    rdfs:subClassOf UBERON:0002529,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
 
 UBERON:0008810 a owl:Class ;
     rdfs:label "nasopalatine nerve" ;
@@ -17244,7 +22276,10 @@ UBERON:0008810 a owl:Class ;
         "nasopalatine nerves",
         "nervus nasopalatinus",
         "Scarpa's nerve" ;
-    rdfs:subClassOf UBERON:0011779 .
+    rdfs:subClassOf UBERON:0011779,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000377 ] .
 
 UBERON:0008811 a owl:Class ;
     rdfs:label "intromittent organ" ;
@@ -17259,15 +22294,33 @@ UBERON:0008811 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000990 ] .
 
+UBERON:0008837 a owl:Class ;
+    rdfs:label "palmar/plantar part of autopod" ;
+    rdfs:subClassOf UBERON:0002529,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002470 ] .
+
+UBERON:0008846 a owl:Class ;
+    rdfs:label "skeletal ligament" ;
+    NIFRID:synonym "articular larua",
+        "articular ligament",
+        "ligament",
+        "true ligament" ;
+    rdfs:subClassOf UBERON:0000211,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001434 ] .
+
 UBERON:0008856 a owl:Class ;
     rdfs:label "stomach muscularis externa" ;
     NIFRID:synonym "gastric muscularis",
         "muscle layer of stomach",
         "muscularis externa of stomach",
+        "stomach muscularis externa",
         "tunica muscularis (gaster)",
         "tunica muscularis gastris" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0018261,
+    rdfs:subClassOf UBERON:0018261,
         UBERON:0034933,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -17290,8 +22343,7 @@ UBERON:0008857 a owl:Class ;
         "stratum circulare (tunica muscularis)(gaster)",
         "stratum circulare gastris",
         "stratum circulare tunicae muscularis gastricae" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0012368,
+    rdfs:subClassOf UBERON:0012368,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0008856 ],
@@ -17304,7 +22356,7 @@ UBERON:0008862 a owl:Class ;
     NIFRID:synonym "inner oblique muscle layer of stomach",
         "oblique fiber layer of gastric muscularis",
         "oblique muscle layer of stomach" ;
-    rdfs:subClassOf UBERON:0004120,
+    rdfs:subClassOf UBERON:0004923,
         UBERON:0034933,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -17320,8 +22372,7 @@ UBERON:0008863 a owl:Class ;
         "outer longitudinal muscle layer of stomach",
         "stratum longitudinale (tunica muscularis)(gaster)",
         "stratum longitudinale tunicae muscularis gastricae" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0012369,
+    rdfs:subClassOf UBERON:0012369,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0008856 ],
@@ -17329,12 +22380,34 @@ UBERON:0008863 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0008856 ] .
 
+UBERON:0008878 a owl:Class ;
+    rdfs:label "palmar part of manus" ;
+    NIFRID:synonym "front of hand",
+        "palm",
+        "palm of hand",
+        "palmar region",
+        "regio palmaris" ;
+    rdfs:subClassOf UBERON:0005451,
+        UBERON:0008837 .
+
+UBERON:0008882 a owl:Class ;
+    rdfs:label "spinal cord commissure" ;
+    NIFRID:synonym "spinal cord commissure" ;
+    rdfs:subClassOf UBERON:0001020,
+        UBERON:0007699,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002240 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002240 ] .
+
 UBERON:0008886 a owl:Class ;
     rdfs:label "pulmonary vascular system" ;
     NIFRID:synonym "pulmonary circulatory system",
-        "pulmonary system" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0007798,
+        "pulmonary system",
+        "pulmonary vascular system" ;
+    rdfs:subClassOf UBERON:0007798,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004535 ] .
@@ -17369,44 +22442,23 @@ UBERON:0008933 a owl:Class ;
 
 UBERON:0008946 a owl:Class ;
     rdfs:label "lung parenchyma" ;
-    NIFRID:synonym "parenchyma of lung",
+    NIFRID:synonym "lung parenchyma",
+        "parenchyma of lung",
         "pulmonary parenchyma",
         "respiratory portion of lung" ;
     rdfs:subClassOf UBERON:0000353,
-        UBERON:0004119,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002048 ] .
 
-UBERON:0008982 a owl:Class ;
-    rdfs:label "fascia" ;
-    NIFRID:synonym "fascia cluster" ;
-    rdfs:subClassOf UBERON:0007846,
+UBERON:0008987 a owl:Class ;
+    rdfs:label "renal parenchyma" ;
+    NIFRID:synonym "kidney parenchyma",
+        "parenchyma of kidney" ;
+    rdfs:subClassOf UBERON:0000353,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002204 ] .
-
-UBERON:0008993 a owl:Class ;
-    rdfs:label "habenular nucleus" ;
-    NIFRID:synonym "ganglion habenulae",
-        "habenular nuclei",
-        "nucleus habenulae" ;
-    rdfs:subClassOf UBERON:0007692,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001904 ] .
-
-UBERON:0008995 a owl:Class ;
-    rdfs:label "nucleus of cerebellar nuclear complex" ;
-    NIFRID:synonym "cerebellar nucleus",
-        "deep cerebellar nucleus" ;
-    rdfs:subClassOf UBERON:0009662,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002130 ],
-        [ a owl:Restriction ;
-            owl:onProperty RO:0002433 ;
-            owl:someValuesFrom UBERON:0002037 ] .
+            owl:someValuesFrom UBERON:0002113 ] .
 
 UBERON:0009009 a owl:Class ;
     rdfs:label "carotid sinus nerve" ;
@@ -17416,7 +22468,10 @@ UBERON:0009009 a owl:Class ;
         "ramus sinus carotici nervi glossopharyngei",
         "ramus sinus carotici nervus glossopharyngei",
         "sinus nerve of Hering" ;
-    rdfs:subClassOf UBERON:0011779 .
+    rdfs:subClassOf UBERON:0011779,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001649 ] .
 
 UBERON:0009010 a owl:Class ;
     rdfs:label "periurethral tissue" ;
@@ -17444,24 +22499,56 @@ UBERON:0009050 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002126 ] .
 
-UBERON:0009097 a owl:Class ;
-    rdfs:label "gravid organism" ;
-    NIFRID:synonym "gravid",
-        "pregnant adult",
-        "pregnant adult stage",
-        "pregnant organism",
-        "pregnant stage" ;
-    rdfs:subClassOf UBERON:0007023 .
-
 UBERON:0009127 a owl:Class ;
     rdfs:label "epibranchial ganglion" ;
-    NIFRID:synonym "epibranchial ganglia" ;
+    NIFRID:synonym "epibranchial ganglia",
+        "epibranchial ganglion" ;
     rdfs:subClassOf UBERON:0001714,
         UBERON:0004121 .
+
+UBERON:0009132 a owl:Class ;
+    rdfs:label "peroneus" ;
+    NIFRID:synonym "fibularis",
+        "fibularis muscle",
+        "peroneal muscle",
+        "peroneal muscle group",
+        "peroneal muscles",
+        "peroneus muscle",
+        "peronæus muscle" ;
+    rdfs:subClassOf UBERON:0004256,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003823 ] .
+
+UBERON:0009551 a owl:Class ;
+    rdfs:label "distal segment of digit" ;
+    NIFRID:synonym "digit tip",
+        "distal digit segment",
+        "tip of digit" ;
+    rdfs:subClassOf UBERON:0002529,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002544 ] .
+
+UBERON:0009564 a owl:Class ;
+    rdfs:label "distal limb integumentary appendage" ;
+    NIFRID:synonym "hoof or claw",
+        "hoof, claw or nail",
+        "keratin plate",
+        "keratin sheath",
+        "unguis" ;
+    rdfs:subClassOf UBERON:0013703,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001003 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0009551 ] .
 
 UBERON:0009569 a owl:Class ;
     rdfs:label "subdivision of trunk" ;
     NIFRID:synonym "region of trunk",
+        "subdivision of trunk",
         "trunk subdivision" ;
     rdfs:subClassOf UBERON:0000475,
         [ a owl:Restriction ;
@@ -17471,6 +22558,7 @@ UBERON:0009569 a owl:Class ;
 UBERON:0009623 a owl:Class ;
     rdfs:label "spinal nerve root" ;
     NIFRID:synonym "root of spinal nerve",
+        "spinal nerve root",
         "spinal neural root",
         "spinal root" ;
     rdfs:subClassOf UBERON:0002211,
@@ -17484,6 +22572,7 @@ UBERON:0009623 a owl:Class ;
 UBERON:0009630 a owl:Class ;
     rdfs:label "root of thoracic nerve" ;
     NIFRID:synonym "nerve root part of thoracic spinal cord",
+        "root of thoracic nerve",
         "thoracic nerve root",
         "thoracic neural root" ;
     rdfs:subClassOf UBERON:0009623 .
@@ -17500,6 +22589,7 @@ UBERON:0009632 a owl:Class ;
     NIFRID:synonym "cervical neural root",
         "cervical spinal root",
         "nerve root part of cervical spinal cord",
+        "root of cervical nerve",
         "root of cervical spinal nerve" ;
     rdfs:subClassOf UBERON:0009623 .
 
@@ -17518,6 +22608,7 @@ UBERON:0009658 a owl:Class ;
 
 UBERON:0009661 a owl:Class ;
     rdfs:label "midbrain nucleus" ;
+    NIFRID:synonym "midbrain nucleus" ;
     rdfs:subClassOf UBERON:0002308,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -17525,6 +22616,7 @@ UBERON:0009661 a owl:Class ;
 
 UBERON:0009662 a owl:Class ;
     rdfs:label "hindbrain nucleus" ;
+    NIFRID:synonym "hindbrain nucleus" ;
     rdfs:subClassOf UBERON:0002308,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -17532,6 +22624,7 @@ UBERON:0009662 a owl:Class ;
 
 UBERON:0009663 a owl:Class ;
     rdfs:label "telencephalic nucleus" ;
+    NIFRID:synonym "telencephalic nucleus" ;
     rdfs:subClassOf UBERON:0002308,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -17547,67 +22640,116 @@ UBERON:0009675 a owl:Class ;
         "parasympathetic root of submandibular ganglion",
         "radix parasympathica ganglii submandibularis",
         "tympanic cord" ;
-    rdfs:subClassOf UBERON:0001785 .
+    rdfs:subClassOf UBERON:0001785,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001647 ] .
+
+UBERON:0009758 a owl:Class ;
+    rdfs:label "abdominal ganglion" ;
+    NIFRID:synonym "abdominal ganglion" ;
+    rdfs:subClassOf UBERON:0007134,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002417 ] .
+
+UBERON:0009773 a owl:Class ;
+    rdfs:label "renal tubule" ;
+    NIFRID:synonym "renal tubule (generic)",
+        "tubule of excretory system" ;
+    rdfs:subClassOf UBERON:0003914,
+        UBERON:0006555,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001008 ] .
 
 UBERON:0009842 a owl:Class ;
     rdfs:label "glandular acinus" ;
     NIFRID:synonym "acini",
-        "acinus" ;
+        "acinus",
+        "glandular acinus" ;
     rdfs:subClassOf UBERON:0034922,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002530 ] .
 
+UBERON:0009854 a owl:Class ;
+    rdfs:label "digestive tract diverticulum" ;
+    NIFRID:synonym "digestive tract diverticulum",
+        "diverticulum of gut",
+        "intestinal pouch" ;
+    rdfs:subClassOf UBERON:0004921,
+        UBERON:0009856,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001555 ] .
+
 UBERON:0009856 a owl:Class ;
     rdfs:label "sac" ;
     NIFRID:synonym "diverticulum",
-        "pouch" ;
+        "pouch",
+        "sac" ;
     rdfs:subClassOf UBERON:0000061 .
 
 UBERON:0009870 a owl:Class ;
     rdfs:label "zone of stomach" ;
     NIFRID:synonym "gastric zone",
         "region of stomach",
-        "section of stomach" ;
+        "section of stomach",
+        "zone of stomach" ;
     rdfs:subClassOf UBERON:0004921,
         UBERON:0034944,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000945 ] .
 
+UBERON:0009877 a owl:Class ;
+    rdfs:label "metapodium region" ;
+    NIFRID:synonym "cannon region",
+        "equine cannon region",
+        "metacarpal or metatarsal part of limb",
+        "metacarpus/metatarsus",
+        "metacarpus/metatarsus region",
+        "metapodial segment",
+        "metapodium" ;
+    rdfs:subClassOf UBERON:0002529,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002470 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012140 ] .
+
 UBERON:0009911 a owl:Class ;
     rdfs:label "lobule" ;
-    NIFRID:synonym "lobulus" ;
+    NIFRID:synonym "lobule",
+        "lobulus" ;
     rdfs:subClassOf UBERON:0000063 .
 
 UBERON:0009912 a owl:Class ;
     rdfs:label "anatomical lobe" ;
-    NIFRID:synonym "lobus" ;
+    NIFRID:synonym "anatomical lobe",
+        "lobus" ;
     rdfs:subClassOf UBERON:0000063 .
-
-UBERON:0009916 a owl:Class ;
-    rdfs:label "wall of ureter" ;
-    NIFRID:synonym "ureteral wall" ;
-    rdfs:subClassOf UBERON:0000060,
-        UBERON:0004120,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000056 ] .
 
 UBERON:0009918 a owl:Class ;
     rdfs:label "retrotrapezoid nucleus" ;
-    rdfs:subClassOf UBERON:0007635,
+    NIFRID:synonym "retrotrapezoid nucleus" ;
+    rdfs:subClassOf UBERON:0000125,
+        UBERON:0007635,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001896 ] .
 
 UBERON:0009950 a owl:Class ;
     rdfs:label "olfactory bulb plexiform layer" ;
-    NIFRID:synonym "plexiform layer" ;
+    NIFRID:synonym "olfactory bulb plexiform layer",
+        "plexiform layer" ;
     rdfs:subClassOf UBERON:0004001 .
 
 UBERON:0009951 a owl:Class ;
     rdfs:label "main olfactory bulb" ;
+    NIFRID:synonym "main olfactory bulb" ;
     rdfs:subClassOf UBERON:0002616,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -17618,8 +22760,7 @@ UBERON:0009960 a owl:Class ;
     NIFRID:synonym "circular muscle layer of esophagus",
         "esophagus smooth muscle circular layer",
         "inner circular muscle layer of esophagus" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0012368,
+    rdfs:subClassOf UBERON:0012368,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001043 ],
@@ -17632,8 +22773,7 @@ UBERON:0009961 a owl:Class ;
     NIFRID:synonym "esophagus smooth muscle longitudinal layer",
         "longitudinal muscle layer of esophagus",
         "outer longitudinal muscle layer of esophagus" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0012369,
+    rdfs:subClassOf UBERON:0012369,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002112 ],
@@ -17643,7 +22783,8 @@ UBERON:0009961 a owl:Class ;
 
 UBERON:0010000 a owl:Class ;
     rdfs:label "multicellular anatomical structure" ;
-    NIFRID:synonym "multicellular structure" ;
+    NIFRID:synonym "multicellular anatomical structure",
+        "multicellular structure" ;
     rdfs:subClassOf UBERON:0000061 .
 
 UBERON:0010001 a owl:Class ;
@@ -17653,7 +22794,8 @@ UBERON:0010001 a owl:Class ;
 
 UBERON:0010009 a owl:Class ;
     rdfs:label "aggregate regional part of brain" ;
-    NIFRID:synonym "set of nuclei of neuraxis" ;
+    NIFRID:synonym "aggregate regional part of brain",
+        "set of nuclei of neuraxis" ;
     rdfs:subClassOf UBERON:0034923,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -17666,6 +22808,7 @@ UBERON:0010011 a owl:Class ;
         "basal nuclei",
         "basal nuclei (basal ganglia)",
         "cerebral nuclei",
+        "collection of basal ganglia",
         "set of basal ganglia",
         "set of basal nuclei",
         "subcortical nuclei" ;
@@ -17676,6 +22819,7 @@ UBERON:0010011 a owl:Class ;
 
 UBERON:0010039 a owl:Class ;
     rdfs:label "food storage organ" ;
+    NIFRID:synonym "food storage organ" ;
     rdfs:subClassOf UBERON:0013765,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -17691,6 +22835,7 @@ UBERON:0010047 a owl:Class ;
         "gland of oral region",
         "mouth gland",
         "oral cavity gland",
+        "oral gland",
         "oral region gland" ;
     rdfs:subClassOf UBERON:0002365,
         UBERON:0003408,
@@ -17707,39 +22852,6 @@ UBERON:0010074 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000949 ] .
-
-UBERON:0010133 a owl:Class ;
-    rdfs:label "neuroendocrine gland" ;
-    NIFRID:synonym "neuroendocrine system gland" ;
-    rdfs:subClassOf UBERON:0002368,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001016 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:8600018 ] .
-
-UBERON:0010134 a owl:Class ;
-    rdfs:label "secretory circumventricular organ" ;
-    rdfs:subClassOf UBERON:0005408,
-        UBERON:0010133,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000949 ] .
-
-UBERON:0010135 a owl:Class ;
-    rdfs:label "sensory circumventricular organ" ;
-    NIFRID:synonym "humerosensory circumventricular organ",
-        "humerosensory system",
-        "humerosensory system organ",
-        "sensitive circumventricular organs",
-        "sensitive organs",
-        "sensory circumventricular organs",
-        "sensory CVOs" ;
-    rdfs:subClassOf UBERON:0005408,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001032 ] .
 
 UBERON:0010147 a owl:Class ;
     rdfs:label "male accessory sex gland" ;
@@ -17765,13 +22877,27 @@ UBERON:0010186 a owl:Class ;
 
 UBERON:0010191 a owl:Class ;
     rdfs:label "aortic system" ;
+    NIFRID:synonym "aortic system" ;
     rdfs:subClassOf UBERON:0011216,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004571 ] .
 
+UBERON:0010194 a owl:Class ;
+    rdfs:label "hepatic portal system" ;
+    NIFRID:synonym "hepatic portal system",
+        "hepatic-portal system",
+        "portal system of liver" ;
+    rdfs:subClassOf UBERON:0005806 .
+
+UBERON:0010199 a owl:Class ;
+    rdfs:label "bona-fide anatomical boundary" ;
+    NIFRID:synonym "bona-fide anatomical boundary" ;
+    rdfs:subClassOf UBERON:0000466 .
+
 UBERON:0010225 a owl:Class ;
     rdfs:label "thalamic complex" ;
+    NIFRID:synonym "thalamic complex" ;
     rdfs:subClassOf UBERON:0007245,
         UBERON:0019269,
         [ a owl:Restriction ;
@@ -17784,9 +22910,9 @@ UBERON:0010230 a owl:Class ;
         "eye",
         "eye globe",
         "eyeball",
+        "eyeball of camera-type eye",
         "globe" ;
     rdfs:subClassOf UBERON:0000020,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000019 ],
@@ -17794,18 +22920,25 @@ UBERON:0010230 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000019 ] .
 
+UBERON:0010243 a owl:Class ;
+    rdfs:label "merocrine gland" ;
+    rdfs:subClassOf UBERON:0002365 .
+
 UBERON:0010313 a owl:Class ;
     rdfs:label "neural crest-derived structure" ;
+    NIFRID:synonym "neural crest-derived structure" ;
     rdfs:subClassOf UBERON:0004121,
         UBERON:0010314 .
 
 UBERON:0010314 a owl:Class ;
     rdfs:label "structure with developmental contribution from neural crest" ;
+    NIFRID:synonym "structure with developmental contribution from neural crest" ;
     rdfs:subClassOf UBERON:0000061 .
 
 UBERON:0010323 a owl:Class ;
     rdfs:label "cranial skeletal system" ;
-    NIFRID:synonym "cranial skeleton",
+    NIFRID:synonym "cranial skeletal system",
+        "cranial skeleton",
         "cranium",
         "osteocranium" ;
     rdfs:subClassOf UBERON:0000075,
@@ -17813,12 +22946,17 @@ UBERON:0010323 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0011137 ] .
 
+UBERON:0010363 a owl:Class ;
+    rdfs:label "endochondral element" ;
+    NIFRID:synonym "endochondral element",
+        "endochondral replacement element" ;
+    rdfs:subClassOf UBERON:0004765 .
+
 UBERON:0010368 a owl:Class ;
     rdfs:label "pulmonary lobule" ;
-    NIFRID:synonym "lobulus pulmonis" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0004119,
-        UBERON:0009911,
+    NIFRID:synonym "lobulus pulmonis",
+        "pulmonary lobule" ;
+    rdfs:subClassOf UBERON:0009911,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002048 ],
@@ -17837,7 +22975,8 @@ UBERON:0010369 a owl:Class ;
 
 UBERON:0010371 a owl:Class ;
     rdfs:label "ecto-epithelium" ;
-    NIFRID:synonym "ectoderm-derived epithelium" ;
+    NIFRID:synonym "ecto-epithelium",
+        "ectoderm-derived epithelium" ;
     rdfs:subClassOf UBERON:0000483,
         UBERON:0004121 .
 
@@ -17847,8 +22986,7 @@ UBERON:0010393 a owl:Class ;
 
 UBERON:0010394 a owl:Class ;
     rdfs:label "lymphocyte domain" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0005057,
+    rdfs:subClassOf UBERON:0005057,
         UBERON:0010001,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -17859,42 +22997,82 @@ UBERON:0010398 a owl:Class ;
     NIFRID:synonym "splenic marginal sinus" ;
     rdfs:subClassOf UBERON:0001959 .
 
-UBERON:0010403 a owl:Class ;
-    rdfs:label "brain marginal zone" ;
-    NIFRID:synonym "brain marginal zone" ;
-    rdfs:subClassOf UBERON:0005423,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000955 ] .
-
 UBERON:0010409 a owl:Class ;
     rdfs:label "ocular surface region" ;
     NIFRID:synonym "eye surface",
         "eye surface region",
-        "ocular surface" ;
+        "ocular surface",
+        "ocular surface region" ;
     rdfs:subClassOf UBERON:0000063,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000019 ] .
 
+UBERON:0010428 a owl:Class ;
+    rdfs:label "flat bone" ;
+    NIFRID:synonym "flat bone",
+        "os planum" ;
+    rdfs:subClassOf UBERON:0001474 .
+
+UBERON:0010467 a owl:Class ;
+    rdfs:label "teres muscle" ;
+    NIFRID:synonym "teres" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0034908 .
+
+UBERON:0010496 a owl:Class ;
+    rdfs:label "teres minor muscle" ;
+    NIFRID:synonym "musculus teres minor",
+        "teres minor" ;
+    rdfs:subClassOf UBERON:0010467,
+        UBERON:0010891,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003683 ] .
+
 UBERON:0010498 a owl:Class ;
     rdfs:label "pseudostratified columnar epithelium" ;
+    NIFRID:synonym "pseudostratified columnar epithelium" ;
     rdfs:subClassOf UBERON:0000485 .
 
 UBERON:0010499 a owl:Class ;
     rdfs:label "pseudostratified ciliated columnar epithelium" ;
-    NIFRID:synonym "epithelium pseudostratificatum columnare ciliatum (trachea et bronchi)" ;
+    NIFRID:synonym "epithelium pseudostratificatum columnare ciliatum (trachea et bronchi)",
+        "pseudostratified ciliated columnar epithelium" ;
     rdfs:subClassOf UBERON:0007592,
         UBERON:0010498 .
 
 UBERON:0010523 a owl:Class ;
     rdfs:label "microcirculatory vessel" ;
-    NIFRID:synonym "microcirculatory vessels" ;
+    NIFRID:synonym "microcirculatory vessel",
+        "microcirculatory vessels" ;
     rdfs:subClassOf UBERON:0000055,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002049 ] .
+
+UBERON:0010524 a owl:Class ;
+    rdfs:label "fibularis tertius" ;
+    NIFRID:synonym "fibularis tertius",
+        "fibularis tertius muscle",
+        "musculus peroneus tertius",
+        "peronaeus tertius",
+        "peroneus digit V",
+        "peroneus digiti minimi",
+        "peroneus digiti quinti",
+        "peroneus tertius",
+        "peroneus tertius muscle" ;
+    rdfs:subClassOf UBERON:0009132 .
+
+UBERON:0010526 a owl:Class ;
+    rdfs:label "fibularis brevis" ;
+    NIFRID:synonym "fibularis brevis",
+        "musculus peroneus brevis",
+        "peronaeus brevis",
+        "peroneus brevis",
+        "peroneus brevis muscle",
+        "peronius brevis" ;
+    rdfs:subClassOf UBERON:0009132 .
 
 UBERON:0010538 a owl:Class ;
     rdfs:label "paired limb/fin segment" ;
@@ -17907,6 +23085,7 @@ UBERON:0010538 a owl:Class ;
 UBERON:0010707 a owl:Class ;
     rdfs:label "appendage girdle complex" ;
     NIFRID:synonym "appendage complex",
+        "appendage girdle complex",
         "appendage-girdle complex",
         "appendage/girdle complex",
         "girdle plus limb or fin",
@@ -17914,13 +23093,82 @@ UBERON:0010707 a owl:Class ;
     rdfs:subClassOf UBERON:0000475,
         UBERON:0015212 .
 
+UBERON:0010708 a owl:Class ;
+    rdfs:label "pectoral complex" ;
+    NIFRID:synonym "pectoral appendage/girdle complex",
+        "pectoral complex",
+        "pectoral girdle plus anterior limb or fin",
+        "pectoral girdle plus pectoral limb or fin",
+        "upper limb",
+        "upper limb and pectoral girdle",
+        "upper limb and shoulder" ;
+    rdfs:subClassOf UBERON:0010707,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000153 ] .
+
+UBERON:0010709 a owl:Class ;
+    rdfs:label "pelvic complex" ;
+    NIFRID:synonym "lower limb",
+        "lower limb and pelvic girdle",
+        "lower limb and pelvis",
+        "pelvic appendage/girdle complex",
+        "pelvic girdle plus pelvic limb or fin",
+        "pelvic girdle plus posterior limb or fin" ;
+    rdfs:subClassOf UBERON:0010707,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000154 ] .
+
+UBERON:0010719 a owl:Class ;
+    rdfs:label "girdle skeleton" ;
+    NIFRID:synonym "girdle skeleton",
+        "skeleton of girdle" ;
+    rdfs:subClassOf UBERON:0010912,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002091 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007823 ] .
+
+UBERON:0010740 a owl:Class ;
+    rdfs:label "bone of appendage girdle complex" ;
+    NIFRID:synonym "bone of appendage girdle complex",
+        "bone of extended limb/fin region",
+        "limb bone" ;
+    rdfs:subClassOf UBERON:0001474,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002091 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010707 ],
+        [ a owl:Restriction ;
+            owl:onProperty RO:0002433 ;
+            owl:someValuesFrom UBERON:0002091 ] .
+
+UBERON:0010742 a owl:Class ;
+    rdfs:label "bone of pelvic complex" ;
+    NIFRID:synonym "hindlimb bone" ;
+    rdfs:subClassOf UBERON:0010740,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002091 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010709 ] .
+
 UBERON:0010743 a owl:Class ;
     rdfs:label "meningeal cluster" ;
     NIFRID:synonym "cerebral meninges",
         "cluster of meninges",
+        "meningeal cluster",
         "meninges" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0034925,
+    rdfs:subClassOf UBERON:0034925,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001017 ] .
@@ -17934,26 +23182,169 @@ UBERON:0010758 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000026 ] .
 
-UBERON:0010899 a owl:Class ;
-    rdfs:label "synchronous hermaphroditic organism" ;
-    NIFRID:synonym "serially hermaphroditic organism",
-        "simultaneous hermaphroditic organism" ;
-    rdfs:subClassOf UBERON:0007197 .
+UBERON:0010890 a owl:Class ;
+    rdfs:label "pelvic complex muscle" ;
+    NIFRID:synonym "lower limb muscle",
+        "muscle of lower limb",
+        "muscle of pelvic girdle and leg",
+        "pelvic girdle and hind limb muscles",
+        "pelvic girdle or hind limb muscle",
+        "pelvic girdle or posterior limb muscle" ;
+    rdfs:subClassOf UBERON:0014892,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010709 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0014792 ] .
+
+UBERON:0010891 a owl:Class ;
+    rdfs:label "pectoral complex muscle" ;
+    NIFRID:synonym "muscle of pectoral girdle and limb",
+        "muscle of pectoral girdle and wing",
+        "muscle of upper limb",
+        "pectoral complex muscle",
+        "pectoral girdle and fore limb muscles",
+        "upper limb muscle" ;
+    rdfs:subClassOf UBERON:0014892,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010708 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0014793 ] .
+
+UBERON:0010912 a owl:Class ;
+    rdfs:label "subdivision of skeleton" ;
+    NIFRID:synonym "skeletal subdivision",
+        "subdivision of skeleton",
+        "subdivision of skeleton (in vivo)" ;
+    rdfs:subClassOf UBERON:0011216,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000075 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004288 ] .
+
+UBERON:0010959 a owl:Class ;
+    rdfs:label "craniocervical muscle" ;
+    NIFRID:synonym "craniocervical muscle",
+        "muscle of head and neck",
+        "muscle of head or neck" ;
+    rdfs:subClassOf UBERON:0014892,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007811 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0008229 ] .
+
+UBERON:0011011 a owl:Class ;
+    rdfs:label "brachioradialis" ;
+    NIFRID:synonym "brachioradialis muscle",
+        "musculus brachioradialis" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0001499,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001460 ] .
+
+UBERON:0011012 a owl:Class ;
+    rdfs:label "flexor pollicis brevis muscle" ;
+    NIFRID:synonym "flexor pollicis brevis",
+        "musculus flexor pollicis brevis" ;
+    rdfs:subClassOf UBERON:0001500,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
+
+UBERON:0011015 a owl:Class ;
+    rdfs:label "iliac fossa" ;
+    rdfs:subClassOf UBERON:0005913,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001273 ] .
+
+UBERON:0011016 a owl:Class ;
+    rdfs:label "pyramidalis" ;
+    NIFRID:synonym "musculus pyramidalis",
+        "pyramidalis",
+        "pyramidalis muscle" ;
+    rdfs:subClassOf UBERON:0002461 .
+
+UBERON:0011022 a owl:Class ;
+    rdfs:label "flexor hallucis brevis muscle" ;
+    NIFRID:synonym "flexor digit I brevis",
+        "flexor hallucis brevis",
+        "flexor hallucis brevis muscle",
+        "m.flexor hallucis brevis",
+        "musculus flexor hallucis brevis" ;
+    rdfs:subClassOf UBERON:0000366,
+        UBERON:0014378,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002387 ] .
+
+UBERON:0011024 a owl:Class ;
+    rdfs:label "extrinsic extensor muscle of manus" ;
+    NIFRID:synonym "extrinsic extensor muscle of hand" ;
+    rdfs:subClassOf UBERON:0000311,
+        UBERON:0004254,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002386 ] .
+
+UBERON:0011043 a owl:Class ;
+    rdfs:label "obturator muscle" ;
+    NIFRID:synonym "obturator" ;
+    rdfs:subClassOf UBERON:0002000 .
+
+UBERON:0011048 a owl:Class ;
+    rdfs:label "obturator internus" ;
+    NIFRID:synonym "internal obturator",
+        "internus obturator",
+        "musculus obturator internus",
+        "musculus obturatorius internus",
+        "obturator internus muscle",
+        "obturatorius internus" ;
+    rdfs:subClassOf UBERON:0011043,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004470 ] .
 
 UBERON:0011096 a owl:Class ;
     rdfs:label "lacrimal nerve" ;
     NIFRID:synonym "nervus lacrimalis" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0011779 .
+    rdfs:subClassOf UBERON:0011779,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000348 ] .
 
-UBERON:0011134 a owl:Class ;
-    rdfs:label "nonsynovial joint" ;
-    NIFRID:synonym "solid joint" ;
-    rdfs:subClassOf UBERON:0000982 .
+UBERON:0011108 a owl:Class ;
+    rdfs:label "synovial joint of pectoral girdle" ;
+    NIFRID:synonym "joint of shoulder girdle",
+        "pectoral girdle joint",
+        "synovial joint of pectoral girdle" ;
+    rdfs:subClassOf UBERON:0002217,
+        UBERON:0008114,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001421 ] .
 
 UBERON:0011137 a owl:Class ;
     rdfs:label "axial skeletal system" ;
+    NIFRID:synonym "axial skeletal system" ;
     rdfs:subClassOf UBERON:0000075 .
+
+UBERON:0011139 a owl:Class ;
+    rdfs:label "synovial limb joint" ;
+    NIFRID:synonym "synovial joint of free limb segment" ;
+    rdfs:subClassOf UBERON:0002217,
+        UBERON:0003657,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002101 ] .
 
 UBERON:0011143 a owl:Class ;
     rdfs:label "upper urinary tract" ;
@@ -17963,9 +23354,25 @@ UBERON:0011143 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001008 ] .
 
+UBERON:0011144 a owl:Class ;
+    rdfs:label "adductor muscle of hip" ;
+    NIFRID:synonym "adductor group (leg)",
+        "muscle of adductor group" ;
+    rdfs:subClassOf UBERON:0003658,
+        UBERON:0011145,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001464 ] .
+
+UBERON:0011145 a owl:Class ;
+    rdfs:label "adductor muscle" ;
+    NIFRID:synonym "adductor" ;
+    rdfs:subClassOf UBERON:0014892 .
+
 UBERON:0011158 a owl:Class ;
     rdfs:label "primary subdivision of skull" ;
-    NIFRID:synonym "skull subdivision",
+    NIFRID:synonym "primary subdivision of skull",
+        "skull subdivision",
         "subdivision of skull" ;
     rdfs:subClassOf UBERON:0000075,
         [ a owl:Restriction ;
@@ -17974,6 +23381,7 @@ UBERON:0011158 a owl:Class ;
 
 UBERON:0011159 a owl:Class ;
     rdfs:label "primary subdivision of cranial skeletal system" ;
+    NIFRID:synonym "primary subdivision of cranial skeletal system" ;
     rdfs:subClassOf UBERON:0000075,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -18001,8 +23409,7 @@ UBERON:0011183 a owl:Class ;
         "corpus cavernosum urethrae",
         "corpus spongiosum",
         "spongiose body of penis" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0005156,
+    rdfs:subClassOf UBERON:0005156,
         UBERON:0008324,
         UBERON:0009010,
         [ a owl:Restriction ;
@@ -18011,7 +23418,8 @@ UBERON:0011183 a owl:Class ;
 
 UBERON:0011189 a owl:Class ;
     rdfs:label "lamina propria of large intestine" ;
-    NIFRID:synonym "lamina propria of mucosa of large intestine",
+    NIFRID:synonym "lamina propria of large intestine",
+        "lamina propria of mucosa of large intestine",
         "large intestinal lamina propria",
         "large intestine lamina propria" ;
     rdfs:subClassOf UBERON:0004780,
@@ -18033,28 +23441,80 @@ UBERON:0011194 a owl:Class ;
         "plexus ophthalmicus" ;
     rdfs:subClassOf UBERON:0001810 .
 
+UBERON:0011198 a owl:Class ;
+    rdfs:label "muscle layer of large intestine" ;
+    NIFRID:synonym "muscle layer of large intestine",
+        "muscular coat of large intestine",
+        "muscular layer of large intestine",
+        "muscularis externa of large intestine",
+        "tunica muscularis intestini crassi" ;
+    rdfs:subClassOf UBERON:0012367,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000059 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001169 ] .
+
+UBERON:0011201 a owl:Class ;
+    rdfs:label "muscle layer of small intestine" ;
+    NIFRID:synonym "muscle layer of small intestine",
+        "muscular coat of small intestine",
+        "muscular layer of small intestine",
+        "muscularis externa of small intestine",
+        "small intestine muscularis propria",
+        "tunica muscularis (intestinum tenue)",
+        "tunica muscularis intestini tenuis" ;
+    rdfs:subClassOf UBERON:0012367,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001168 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002108 ] .
+
+UBERON:0011213 a owl:Class ;
+    rdfs:label "root of vagus nerve" ;
+    NIFRID:synonym "root of vagus nerve",
+        "rootlet of vagus nerve",
+        "rX",
+        "vagal root",
+        "vagus nerve root",
+        "vagus neural rootlet",
+        "vagus root" ;
+    rdfs:subClassOf UBERON:0002211 .
+
 UBERON:0011215 a owl:Class ;
     rdfs:label "central nervous system cell part cluster" ;
     NIFRID:synonym "cell part cluster of neuraxis",
+        "central nervous system cell part cluster",
         "neuraxis layer" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0005162,
+    rdfs:subClassOf UBERON:0005162,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001017 ] .
 
 UBERON:0011216 a owl:Class ;
     rdfs:label "organ system subdivision" ;
+    NIFRID:synonym "organ system subdivision" ;
     rdfs:subClassOf UBERON:0010000,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000467 ] .
 
+UBERON:0011217 a owl:Class ;
+    rdfs:label "serratus dorsalis muscle" ;
+    NIFRID:synonym "serratus dorsalis",
+        "serratus posterior",
+        "serratus posterior muscle" ;
+    rdfs:subClassOf UBERON:0004518 .
+
 UBERON:0011222 a owl:Class ;
     rdfs:label "intra-ocular muscle" ;
-    NIFRID:synonym "intrinsic muscle of eyeball",
+    NIFRID:synonym "intra-ocular muscle",
+        "intrinsic muscle of eyeball",
         "intrinsic ocular muscle" ;
-    rdfs:subClassOf UBERON:0004120,
+    rdfs:subClassOf UBERON:0001630,
         UBERON:0004277,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -18065,12 +23525,14 @@ UBERON:0011222 a owl:Class ;
 
 UBERON:0011249 a owl:Class ;
     rdfs:label "appendicular skeletal system" ;
+    NIFRID:synonym "appendicular skeletal system" ;
     rdfs:subClassOf UBERON:0000075 .
 
 UBERON:0011270 a owl:Class ;
     rdfs:label "dorsal trunk" ;
     NIFRID:synonym "back of trunk",
         "dorsal part of trunk",
+        "dorsal trunk",
         "dorsum of trunk",
         "trunk back" ;
     rdfs:subClassOf UBERON:0009569,
@@ -18078,20 +23540,10 @@ UBERON:0011270 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001137 ] .
 
-UBERON:0011299 a owl:Class ;
-    rdfs:label "white matter of telencephalon" ;
-    NIFRID:synonym "predominantly white regional part of telencephalon",
-        "telencephalic tract/commissure",
-        "telencephalic tracts",
-        "telencephalic white matter" ;
-    rdfs:subClassOf UBERON:0019261,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001893 ] .
-
 UBERON:0011300 a owl:Class ;
     rdfs:label "gray matter of telencephalon" ;
-    NIFRID:synonym "predominantly gray regional part of telencephalon" ;
+    NIFRID:synonym "gray matter of telencephalon",
+        "predominantly gray regional part of telencephalon" ;
     rdfs:subClassOf UBERON:0019264,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -18104,16 +23556,51 @@ UBERON:0011326 a owl:Class ;
         "superior laryngeal branch of inferior vagal ganglion",
         "superior laryngeal branch of vagus" ;
     rdfs:subClassOf UBERON:0011779,
-        UBERON:0035642 .
-
-UBERON:0011374 a owl:Class ;
-    rdfs:label "prepuce" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0005156,
-        UBERON:0034929,
+        UBERON:0035642,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0003133 ] .
+            owl:someValuesFrom UBERON:0001759 ] .
+
+UBERON:0011362 a owl:Class ;
+    rdfs:label "cranial blood vasculature" ;
+    NIFRID:synonym "cranial blood vasculature",
+        "cranial blood vessel",
+        "cranial blood vessels",
+        "set of blood vessels of head" ;
+    rdfs:subClassOf UBERON:0002200,
+        UBERON:0004537,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000033 ] .
+
+UBERON:0011380 a owl:Class ;
+    rdfs:label "female external urethral sphincter" ;
+    NIFRID:synonym "compressor urethrae",
+        "external urethral sphincter of female urethra",
+        "musculus sphincter urethrae externus (urethra feminina)",
+        "musculus sphincter urethrae externus urethrae femininae",
+        "outer muscle layer of female urethra",
+        "rhabdosphincter of female urethra",
+        "sphincter urethrovaginalis",
+        "striated muscle layer of female urethra",
+        "urethrovaginal sphincter" ;
+    rdfs:subClassOf UBERON:0004919,
+        UBERON:0005156,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000474 ] .
+
+UBERON:0011389 a owl:Class ;
+    rdfs:label "bulbospongiosus muscle" ;
+    NIFRID:synonym "bulbocavernosus",
+        "bulbocavernosus muscle",
+        "bulbocavernous",
+        "bulbospongiosus",
+        "musculus bulbospongiosus" ;
+    rdfs:subClassOf UBERON:0002379,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002356 ] .
 
 UBERON:0011390 a owl:Class ;
     rdfs:label "pudendal nerve" ;
@@ -18130,19 +23617,42 @@ UBERON:0011390 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002355 ] .
 
+UBERON:0011391 a owl:Class ;
+    rdfs:label "perineal nerve" ;
+    NIFRID:synonym "perineal branch of pudendal nerve" ;
+    rdfs:subClassOf UBERON:0003444,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0011390 ] .
+
+UBERON:0011534 a owl:Class ;
+    rdfs:label "abductor pollicis muscle" ;
+    rdfs:subClassOf UBERON:0003662,
+        UBERON:0006845,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
+
 UBERON:0011595 a owl:Class ;
     rdfs:label "jaw region" ;
+    NIFRID:synonym "jaw region" ;
     rdfs:subClassOf UBERON:0000475,
         UBERON:0010314,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000165 ] .
 
+UBERON:0011645 a owl:Class ;
+    rdfs:label "iliofemoralis muscle" ;
+    NIFRID:synonym "iliofemoralis" ;
+    rdfs:subClassOf UBERON:0001325 .
+
 UBERON:0011676 a owl:Class ;
     rdfs:label "subdivision of organism along main body axis" ;
     NIFRID:synonym "axial subdivision of organism",
         "body segment",
-        "main body segment" ;
+        "main body segment",
+        "subdivision of organism along main body axis" ;
     rdfs:subClassOf UBERON:0000475,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -18158,6 +23668,7 @@ UBERON:0011775 a owl:Class ;
         "tenth cranial nerve nucleus",
         "vagal nucleus",
         "vagal X nucleus",
+        "vagus nerve nucleus",
         "vagus nucleus" ;
     rdfs:subClassOf UBERON:0000126,
         UBERON:0009662,
@@ -18167,7 +23678,8 @@ UBERON:0011775 a owl:Class ;
 
 UBERON:0011777 a owl:Class ;
     rdfs:label "nucleus of spinal cord" ;
-    NIFRID:synonym "spinal cord nucleus" ;
+    NIFRID:synonym "nucleus of spinal cord",
+        "spinal cord nucleus" ;
     rdfs:subClassOf UBERON:0000125,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -18185,7 +23697,8 @@ UBERON:0011778 a owl:Class ;
 UBERON:0011779 a owl:Class ;
     rdfs:label "nerve of head region" ;
     NIFRID:synonym "cephalic nerve",
-        "head nerve" ;
+        "head nerve",
+        "nerve of head region" ;
     rdfs:subClassOf UBERON:0001021,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -18193,31 +23706,41 @@ UBERON:0011779 a owl:Class ;
 
 UBERON:0011821 a owl:Class ;
     rdfs:label "irregular connective tissue" ;
+    NIFRID:synonym "irregular connective tissue" ;
     rdfs:subClassOf UBERON:0002384 .
 
 UBERON:0011822 a owl:Class ;
     rdfs:label "dense irregular connective tissue" ;
-    NIFRID:synonym "irregular dense connective tissue",
+    NIFRID:synonym "dense irregular connective tissue",
+        "irregular dense connective tissue",
         "typus irregularis (textus connectivus collagenosus compactus)" ;
     rdfs:subClassOf UBERON:0011821,
         UBERON:0011823 .
 
 UBERON:0011823 a owl:Class ;
     rdfs:label "dense connective tissue" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0002384 .
+    NIFRID:synonym "dense connective tissue" ;
+    rdfs:subClassOf UBERON:0002384 .
 
 UBERON:0011858 a owl:Class ;
     rdfs:label "acinus of exocrine gland" ;
-    NIFRID:synonym "exocrine gland acinus" ;
+    NIFRID:synonym "acinus of exocrine gland",
+        "exocrine gland acinus" ;
     rdfs:subClassOf UBERON:0009842,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002365 ] .
 
+UBERON:0011867 a owl:Class ;
+    rdfs:label "extensor carpi radialis muscle" ;
+    NIFRID:synonym "extensor carpi radialis" ;
+    rdfs:subClassOf UBERON:0001482,
+        UBERON:0011024 .
+
 UBERON:0011892 a owl:Class ;
     rdfs:label "anterior uvea" ;
     NIFRID:synonym "anterior part of uveal tract",
+        "anterior uvea",
         "anterior uveal tract",
         "anterior vascular layer of the eyeball",
         "anterior vascular tunic of the eye",
@@ -18227,7 +23750,10 @@ UBERON:0011892 a owl:Class ;
         "vasculosa oculi",
         "ventral uveal tract" ;
     rdfs:subClassOf UBERON:0000481,
-        UBERON:0004121,
+        UBERON:0010314,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom NCBITaxon:6072 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001768 ],
@@ -18240,6 +23766,15 @@ UBERON:0011892 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0001801 ] .
+
+UBERON:0011905 a owl:Class ;
+    rdfs:label "plantaris" ;
+    NIFRID:synonym "musculus plantaris",
+        "plantaris" ;
+    rdfs:subClassOf UBERON:0004256,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003823 ] .
 
 UBERON:0011924 a owl:Class ;
     rdfs:label "postganglionic autonomic fiber" ;
@@ -18267,30 +23802,13 @@ UBERON:0011929 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004293 ] .
 
-UBERON:0011932 a owl:Class ;
-    rdfs:label "pilosebaceous unit" ;
-    NIFRID:synonym "fabrica pilosebacea",
-        "pilo-sebaceous apparatus",
-        "pilo-sebaceous unit",
-        "pilosebaceous apparatus",
-        "pilosebaceous gland" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000063,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0006003 ] .
-
-UBERON:0011933 a owl:Class ;
-    rdfs:label "vibrissa unit" ;
-    NIFRID:synonym "vibrissa" ;
-    rdfs:subClassOf UBERON:0011932 .
-
-UBERON:0011954 a owl:Class ;
-    rdfs:label "stomach non-glandular region" ;
-    NIFRID:synonym "stomach cutaneous region",
-        "stomach ependymal region" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0009870 .
+UBERON:0011968 a owl:Class ;
+    rdfs:label "radio-carpal joint" ;
+    NIFRID:synonym "articulatio radiocarpea",
+        "radiocarpal articulation",
+        "radiocarpal joint",
+        "wrist joint" ;
+    rdfs:subClassOf UBERON:0001491 .
 
 UBERON:0012069 a owl:Class ;
     rdfs:label "epithelium-associated lymphoid tissue" ;
@@ -18303,57 +23821,75 @@ UBERON:0012102 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001567 ] .
 
-UBERON:0012125 a owl:Class ;
-    rdfs:label "dermatological-muscosal system" ;
-    NIFRID:synonym "dermatological system" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000467 .
-
-UBERON:0012170 a owl:Class ;
-    rdfs:label "core of nucleus accumbens" ;
-    NIFRID:synonym "accumbens nucleus core",
-        "accumbens nucleus, core",
-        "core of nucleus accumbens",
-        "core region of nucleus accumbens",
-        "nucleus accumbens core",
-        "nucleusa ccumbens core" ;
-    rdfs:subClassOf UBERON:0002616,
+UBERON:0012139 a owl:Class ;
+    rdfs:label "segment of autopod" ;
+    rdfs:subClassOf UBERON:0002529,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001882 ] .
+            owl:someValuesFrom UBERON:0002470 ] .
 
-UBERON:0012171 a owl:Class ;
-    rdfs:label "shell of nucleus accumbens" ;
-    NIFRID:synonym "accumbens nucleus shell",
-        "accumbens nucleus, shell",
-        "nucleus accumbens shell",
-        "shell of nucleus accumbens",
-        "shell region of nucleus accumbens" ;
-    rdfs:subClassOf UBERON:0002616,
+UBERON:0012140 a owl:Class ;
+    rdfs:label "digitopodium region" ;
+    NIFRID:synonym "acropodium (Wagner)" ;
+    rdfs:subClassOf UBERON:0012139 .
+
+UBERON:0012141 a owl:Class ;
+    rdfs:label "manual digitopodium region" ;
+    rdfs:subClassOf UBERON:0005451,
+        UBERON:0012140,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001882 ] .
+            owl:someValuesFrom UBERON:0002398 ] .
 
 UBERON:0012254 a owl:Class ;
     rdfs:label "abdominal aorta artery" ;
-    NIFRID:synonym "abdominal artery",
+    NIFRID:synonym "abdominal aorta artery",
+        "abdominal artery",
         "artery of abdomen" ;
-    rdfs:subClassOf UBERON:0004573 .
+    rdfs:subClassOf UBERON:0004573,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001516 ] .
 
 UBERON:0012274 a owl:Class ;
     rdfs:label "columnar epithelium" ;
+    NIFRID:synonym "columnar epithelium" ;
     rdfs:subClassOf UBERON:0000483 .
 
 UBERON:0012275 a owl:Class ;
     rdfs:label "meso-epithelium" ;
-    NIFRID:synonym "mesoderm-derived epithelium",
+    NIFRID:synonym "meso-epithelium",
+        "mesoderm-derived epithelium",
         "mesoepithelium" ;
     rdfs:subClassOf UBERON:0000483,
         UBERON:0004120 .
 
+UBERON:0012354 a owl:Class ;
+    rdfs:label "acropodium region" ;
+    NIFRID:synonym "acropodial limb segment",
+        "acropodial region",
+        "acropodial segment of autopod",
+        "set of digits" ;
+    rdfs:subClassOf UBERON:0012139,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012140 ] .
+
+UBERON:0012361 a owl:Class ;
+    rdfs:label "internal anal region" ;
+    NIFRID:synonym "internal anal region" ;
+    rdfs:subClassOf UBERON:0000481,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom NCBITaxon:6072 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001353 ] .
+
 UBERON:0012367 a owl:Class ;
     rdfs:label "muscle layer of intestine" ;
     NIFRID:synonym "intestinal muscularis propria",
+        "muscle layer of intestine",
         "muscularis externa of intestine",
         "smooth muscle of intestine" ;
     rdfs:subClassOf UBERON:0018261,
@@ -18386,17 +23922,119 @@ UBERON:0012369 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0006660 ] .
 
+UBERON:0012377 a owl:Class ;
+    rdfs:label "muscle layer of jejunum" ;
+    NIFRID:synonym "jejunal smooth muscle",
+        "muscularis externa of jejunum",
+        "muscularis propria of jejunum",
+        "smooth muscle of jejunum" ;
+    rdfs:subClassOf UBERON:0011201,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002115 ] .
+
 UBERON:0012399 a owl:Class ;
     rdfs:label "large intestine smooth muscle longitudinal layer" ;
     NIFRID:synonym "longitudinal muscle layer of zone of large intestine" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0012369,
+    rdfs:subClassOf UBERON:0012369,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004220 ] .
 
+UBERON:0012419 a owl:Class ;
+    rdfs:label "taenia coli" ;
+    NIFRID:synonym "longitudinal band of large intestine muscularis",
+        "longitudinal bands",
+        "taeniae coli",
+        "tenia coli",
+        "teniae coli" ;
+    rdfs:subClassOf UBERON:0034933,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0011198 ] .
+
+UBERON:0012469 a owl:Class ;
+    rdfs:label "external anal region" ;
+    NIFRID:synonym "external anal region" ;
+    rdfs:subClassOf UBERON:0000481,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom NCBITaxon:6072 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001353 ] .
+
+UBERON:0012475 a owl:Class ;
+    rdfs:label "skeleton of pectoral complex" ;
+    NIFRID:synonym "bones of upper limb",
+        "ossa membri superioris",
+        "pectoral complex skeleton",
+        "set of bones of upper limb",
+        "skeleton of anterior limb/fin and girdle",
+        "skeleton of pectoral complex",
+        "upper limb skeleton" ;
+    rdfs:subClassOf UBERON:0010912,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002091 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010708 ] .
+
+UBERON:0012476 a owl:Class ;
+    rdfs:label "skeleton of pelvic complex" ;
+    NIFRID:synonym "bones of lower limb",
+        "lower limb skeleton",
+        "ossa membri inferioris",
+        "pelvic complex skeleton",
+        "set of bones of lower limb",
+        "skeleton of posterior limb/fin and girdle" ;
+    rdfs:subClassOf UBERON:0010912,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002091 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010709 ] .
+
+UBERON:0012477 a owl:Class ;
+    rdfs:label "dorsal part of neck" ;
+    NIFRID:synonym "back of neck",
+        "dorsal part of neck",
+        "hindneck",
+        "nape",
+        "nape of neck",
+        "neck back",
+        "nucha",
+        "nuchal region",
+        "posterior cervical region",
+        "posterior neck region",
+        "posterior part of neck",
+        "regio cervicalis posterior" ;
+    rdfs:subClassOf UBERON:0005434,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000974 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001137 ] .
+
+UBERON:0012490 a owl:Class ;
+    rdfs:label "muscle layer of anal canal" ;
+    NIFRID:synonym "anal canal muscularis propria",
+        "anal muscularis propria",
+        "muscle layer of anal canal",
+        "muscular coat of anal canal",
+        "muscular layer of anal canal",
+        "muscularis externa of anal canal",
+        "muscularis propria of anal canal" ;
+    rdfs:subClassOf UBERON:0011198,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000159 ] .
+
 UBERON:0012648 a owl:Class ;
-    rdfs:label "ampulla of uterine tube" ;
+    rdfs:label "ampulla of fallopian tube" ;
     NIFRID:synonym "ampulla of fallopian tube",
         "ampulla of oviduct",
         "ampulla of the fallopian tube",
@@ -18404,18 +24042,10 @@ UBERON:0012648 a owl:Class ;
         "ampulla tubae uterinae",
         "uterine tube ampulla" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004120,
         UBERON:0005156,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0003889 ] .
-
-UBERON:0012652 a owl:Class ;
-    rdfs:label "colorectum" ;
-    rdfs:subClassOf UBERON:0004921,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000059 ] .
 
 UBERON:0013199 a owl:Class ;
     rdfs:label "stria of neuraxis" ;
@@ -18427,7 +24057,8 @@ UBERON:0013199 a owl:Class ;
 
 UBERON:0013232 a owl:Class ;
     rdfs:label "serous acinus" ;
-    NIFRID:synonym "acinus of serous gland" ;
+    NIFRID:synonym "acinus of serous gland",
+        "serous acinus" ;
     rdfs:subClassOf UBERON:0011858,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -18442,46 +24073,6 @@ UBERON:0013473 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001043 ] .
-
-UBERON:0013488 a owl:Class ;
-    rdfs:label "panniculus adiposus" ;
-    NIFRID:synonym "panniculus adiposus group",
-        "subcutaneous fat" ;
-    rdfs:subClassOf UBERON:0002190,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002072 ] .
-
-UBERON:0013489 a owl:Class ;
-    rdfs:label "superficial cervical fascia" ;
-    NIFRID:synonym "lamina superficialis fasciae cervicalis",
-        "superficial cervical fascia",
-        "superficial layer of cervical fascia",
-        "superficial layer of deep cervical fascia" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0013491,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0013488 ] .
-
-UBERON:0013491 a owl:Class ;
-    rdfs:label "cervical fascia" ;
-    NIFRID:synonym "fascia of neck" ;
-    rdfs:subClassOf UBERON:0003568,
-        UBERON:0008982,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000974 ] .
-
-UBERON:0013493 a owl:Class ;
-    rdfs:label "abdominal fascia" ;
-    NIFRID:synonym "endo-abdominopelvic fascia",
-        "fascia of abdomen" ;
-    rdfs:subClassOf UBERON:0003567,
-        UBERON:0008982,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0000916 ] .
 
 UBERON:0013515 a owl:Class ;
     rdfs:label "subdivision of oviduct" ;
@@ -18498,39 +24089,56 @@ UBERON:0013515 a owl:Class ;
 
 UBERON:0013522 a owl:Class ;
     rdfs:label "subdivision of tube" ;
+    NIFRID:synonym "subdivision of tube" ;
     rdfs:subClassOf UBERON:0000064,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000025 ] .
 
-UBERON:0013657 a owl:Class ;
-    rdfs:label "hump" ;
-    NIFRID:synonym "camel hump",
-        "CamelHump" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0000481,
+UBERON:0013691 a owl:Class ;
+    rdfs:label "buttock" ;
+    NIFRID:synonym "buttocks",
+        "clunis",
+        "gluteal part of pelvic girdle",
+        "gluteal region",
+        "regio glutealis" ;
+    rdfs:subClassOf UBERON:0015212,
+        UBERON:0034929,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001137 ] .
+            owl:someValuesFrom UBERON:0001271 ] .
+
+UBERON:0013700 a owl:Class ;
+    rdfs:label "axial musculature" ;
+    NIFRID:synonym "axial musculature" ;
+    rdfs:subClassOf UBERON:0001015,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0013701 ] .
 
 UBERON:0013701 a owl:Class ;
     rdfs:label "main body axis" ;
+    NIFRID:synonym "main body axis" ;
     rdfs:subClassOf UBERON:0000475 .
 
 UBERON:0013702 a owl:Class ;
     rdfs:label "body proper" ;
     NIFRID:synonym "body",
+        "body proper",
         "whole body" ;
     rdfs:subClassOf UBERON:0000475,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0013701 ] .
 
-UBERON:0013754 a owl:Class ;
-    rdfs:label "integumentary system layer" ;
-    NIFRID:synonym "layer of skin",
-        "skin layer" ;
-    rdfs:subClassOf UBERON:0004923,
+UBERON:0013703 a owl:Class ;
+    rdfs:label "integumentary projection" ;
+    NIFRID:synonym "skin projection" ;
+    rdfs:subClassOf UBERON:0004529,
+        UBERON:0006003,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002416 ] .
@@ -18538,6 +24146,7 @@ UBERON:0013754 a owl:Class ;
 UBERON:0013765 a owl:Class ;
     rdfs:label "digestive system element" ;
     NIFRID:synonym "digestive organ",
+        "digestive system element",
         "digestive system organ" ;
     rdfs:subClassOf UBERON:0000062,
         [ a owl:Restriction ;
@@ -18547,8 +24156,29 @@ UBERON:0013765 a owl:Class ;
 UBERON:0013768 a owl:Class ;
     rdfs:label "great vessel of heart" ;
     NIFRID:synonym "great vessel",
+        "great vessel of heart",
         "great vessel of thorax" ;
     rdfs:subClassOf UBERON:0001981 .
+
+UBERON:0013776 a owl:Class ;
+    rdfs:label "skin of palmar/plantar part of autopod" ;
+    rdfs:subClassOf UBERON:0015790,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0008837 ] .
+
+UBERON:0013777 a owl:Class ;
+    rdfs:label "skin of palm of manus" ;
+    NIFRID:synonym "palmar skin of hand",
+        "skin of palmar area of hand" ;
+    rdfs:subClassOf UBERON:0001519,
+        UBERON:0013776,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001519 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0008878 ] .
 
 UBERON:0014277 a owl:Class ;
     rdfs:label "piriform cortex layer 1" ;
@@ -18583,15 +24213,70 @@ UBERON:0014284 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002023 ] .
 
-UBERON:0014510 a owl:Class ;
-    rdfs:label "lamina of omasum" ;
-    NIFRID:synonym "omasal lamina",
-        "omasal laminae" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0004923,
+UBERON:0014375 a owl:Class ;
+    rdfs:label "intrinsic muscle of manus" ;
+    NIFRID:synonym "intrinsic hand muscle",
+        "intrinsic muscle of hand" ;
+    rdfs:subClassOf UBERON:0001500,
+        UBERON:0035112,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007362 ] .
+            owl:someValuesFrom UBERON:0002398 ] .
+
+UBERON:0014376 a owl:Class ;
+    rdfs:label "thenar muscle" ;
+    NIFRID:synonym "thenar compartment",
+        "thenar eminence",
+        "thenar muscle",
+        "thenar muscles" ;
+    rdfs:subClassOf UBERON:0014375 .
+
+UBERON:0014377 a owl:Class ;
+    rdfs:label "hypothenar muscle" ;
+    NIFRID:synonym "hypothenar",
+        "hypothenar muscle",
+        "hypothenar muscles" ;
+    rdfs:subClassOf UBERON:0014375 .
+
+UBERON:0014378 a owl:Class ;
+    rdfs:label "intrinsic muscle of pes" ;
+    NIFRID:synonym "intrinsic muscle of foot" ;
+    rdfs:subClassOf UBERON:0001498,
+        UBERON:0035112,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002387 ] .
+
+UBERON:0014379 a owl:Class ;
+    rdfs:label "adductor hallucis muscle" ;
+    NIFRID:synonym "adductor hallucis",
+        "adductor transversus hallucis",
+        "contrahens I muscle" ;
+    rdfs:subClassOf UBERON:0014378 .
+
+UBERON:0014390 a owl:Class ;
+    rdfs:label "muscle layer of ileum" ;
+    NIFRID:synonym "ileal smooth muscle",
+        "muscularis externa of ileum",
+        "muscularis propria of ileum",
+        "smooth muscle of ileum" ;
+    rdfs:subClassOf UBERON:0011201,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002116 ] .
+
+UBERON:0014463 a owl:Class ;
+    rdfs:label "cardiac ganglion" ;
+    NIFRID:synonym "cardiac ganglia",
+        "cardiac ganglia set",
+        "cardiac ganglion of Wrisberg",
+        "ganglia cardiaca",
+        "ganglion of Wrisberg",
+        "Wrisberg ganglion" ;
+    rdfs:subClassOf UBERON:0001808,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000011 ] .
 
 UBERON:0014548 a owl:Class ;
     rdfs:label "pyramidal layer of CA1" ;
@@ -18624,6 +24309,7 @@ UBERON:0014550 a owl:Class ;
     NIFRID:synonym "CA3 part of stratum pyramidale hippocampi",
         "CA3 stratum pyramidale hippocampi",
         "field CA3, pyramidal layer",
+        "pyramidal layer of CA3",
         "stratum pyramidale of CA3",
         "stratum pyramidale of the CA3 field" ;
     rdfs:subClassOf UBERON:0035788,
@@ -18697,28 +24383,6 @@ UBERON:0014556 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0005372 ] .
 
-UBERON:0014557 a owl:Class ;
-    rdfs:label "CA1 stratum lacunosum moleculare" ;
-    NIFRID:synonym "CA1 part of stratum lacunosum moleculare",
-        "CA1 stratum lacunosum moleculare",
-        "lacunar-molecular layer of CA1 field",
-        "stratum lacunosum moleculare of the CA1 field" ;
-    rdfs:subClassOf UBERON:0035786,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007640 ] .
-
-UBERON:0014559 a owl:Class ;
-    rdfs:label "CA3 stratum lacunosum moleculare" ;
-    NIFRID:synonym "CA3 part of stratum lacunosum moleculare",
-        "CA3 stratum lacunosum moleculare",
-        "lacunar-molecular layer of CA3 field",
-        "stratum lacunosum moleculare of the CA3 field" ;
-    rdfs:subClassOf UBERON:0035788,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0007640 ] .
-
 UBERON:0014570 a owl:Class ;
     rdfs:label "CA1 alveus" ;
     NIFRID:synonym "alveus of the CA1 field" ;
@@ -18729,11 +24393,21 @@ UBERON:0014570 a owl:Class ;
 
 UBERON:0014571 a owl:Class ;
     rdfs:label "CA3 alveus" ;
-    NIFRID:synonym "alveus of the CA3 field" ;
+    NIFRID:synonym "alveus of the CA3 field",
+        "CA3 alveus" ;
     rdfs:subClassOf UBERON:0035788,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0007639 ] .
+
+UBERON:0014609 a owl:Class ;
+    rdfs:label "thoracic spinal cord dorsal horn" ;
+    NIFRID:synonym "thoracic spinal cord dorsal horn",
+        "thoracic spinal cord posterior horn" ;
+    rdfs:subClassOf UBERON:0002256,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003038 ] .
 
 UBERON:0014617 a owl:Class ;
     rdfs:label "Ventral nerve root of thoracic spinal cord" ;
@@ -18742,8 +24416,7 @@ UBERON:0014617 a owl:Class ;
     rdfs:subClassOf UBERON:0009630 .
 
 UBERON:0014631 a owl:Class ;
-    rdfs:label "dorsal gray commissure of spinal cord",
-        "Spinal cord posterior gray commissure" ;
+    rdfs:label "dorsal gray commissure of spinal cord" ;
     NIFRID:synonym "commissura grisea posterior medullae spinalis",
         "dorsal gray commissure",
         "dorsal grey commissure of spinal cord",
@@ -18761,36 +24434,162 @@ UBERON:0014634 a owl:Class ;
     rdfs:subClassOf UBERON:0002260,
         UBERON:0009632 .
 
-UBERON:0014778 a owl:Class ;
-    rdfs:label "cell group" ;
-    NIFRID:synonym "group of cells" ;
-    rdfs:subClassOf UBERON:0000061 .
+UBERON:0014703 a owl:Class ;
+    rdfs:label "anal membrane ectodermal component" ;
+    NIFRID:synonym "anal membrane ectodermal component" ;
+    rdfs:subClassOf UBERON:0000490,
+        UBERON:0010371,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001353 ] .
+
+UBERON:0014761 a owl:Class ;
+    rdfs:label "spinal trigeminal tract" ;
+    NIFRID:synonym "descending root of V",
+        "descending tract of trigeminal",
+        "spinal root of trigeminal",
+        "spinal tract of the trigeminal nerve",
+        "spinal tract of trigeminal nerve",
+        "spinal trigeminal tract",
+        "spinal V tract",
+        "tract of descending root of trigeminal",
+        "tractus spinalis nervi trigeminalis",
+        "tractus spinalis nervi trigemini",
+        "trigeminospinal tract" ;
+    rdfs:subClassOf UBERON:0007702,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002298 ] .
+
+UBERON:0014791 a owl:Class ;
+    rdfs:label "musculature of forelimb stylopod" ;
+    NIFRID:synonym "arm musculature",
+        "muscle group of arm",
+        "musculature of arm",
+        "set of muscles of arm" ;
+    rdfs:subClassOf UBERON:0004474,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003822 ] .
+
+UBERON:0014792 a owl:Class ;
+    rdfs:label "musculature of pelvic complex" ;
+    NIFRID:synonym "muscles of lower limb",
+        "musculature of lower limb",
+        "musculi membri inferioris" ;
+    rdfs:subClassOf UBERON:0001015,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010709 ] .
+
+UBERON:0014793 a owl:Class ;
+    rdfs:label "musculature of pectoral complex" ;
+    NIFRID:synonym "muscles of upper limb",
+        "musculature of pectoral complex",
+        "musculature of upper limb",
+        "musculi membri superioris",
+        "set of muscles of upper limb",
+        "upper limb musculature" ;
+    rdfs:subClassOf UBERON:0001015,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0010708 ] .
+
+UBERON:0014794 a owl:Class ;
+    rdfs:label "pectoral appendage muscle" ;
+    NIFRID:synonym "pectoral appendage muscle" ;
+    rdfs:subClassOf UBERON:0010891,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004710 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007269 ] .
+
+UBERON:0014795 a owl:Class ;
+    rdfs:label "pelvic appendage muscle" ;
+    rdfs:subClassOf UBERON:0010890,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004709 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007270 ] .
+
+UBERON:0014847 a owl:Class ;
+    rdfs:label "vastus intermedius" ;
+    NIFRID:synonym "cruraeus",
+        "crureus",
+        "intermediate great muscle",
+        "intermediate vastus muscle",
+        "musculus vastus intermedius",
+        "vastus intermedialis",
+        "vastus intermedius" ;
+    rdfs:subClassOf UBERON:0001377,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001377 ] .
 
 UBERON:0014891 a owl:Class ;
     rdfs:label "brainstem white matter" ;
     NIFRID:synonym "brain stem white matter",
         "brainstem tract/commissure",
         "brainstem tracts",
-        "brainstem tracts and commissures" ;
+        "brainstem tracts and commissures",
+        "brainstem white matter" ;
     rdfs:subClassOf UBERON:0003544,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002298 ] .
 
 UBERON:0014892 a owl:Class ;
-    rdfs:label "skeletal muscle organ" ;
-    NIFRID:synonym "skeletal muscle" ;
+    rdfs:label "skeletal muscle organ, vertebrate" ;
+    NIFRID:synonym "skeletal muscle",
+        "skeletal muscle organ, vertebrate" ;
     rdfs:subClassOf UBERON:0001630,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002529 ],
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0018254 ] .
 
+UBERON:0015054 a owl:Class ;
+    rdfs:label "iliac endochondral element" ;
+    NIFRID:synonym "iliac element",
+        "iliac skeletal element" ;
+    rdfs:subClassOf UBERON:0005179,
+        UBERON:0010363,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0007832 ] .
+
+UBERON:0015128 a owl:Class ;
+    rdfs:label "subepicardial layer of epicardium" ;
+    NIFRID:synonym "perimysial connective tissue of subepicardium",
+        "subepicardial connective tissue",
+        "subepicardial layer of epicardium" ;
+    rdfs:subClassOf UBERON:0001136,
+        UBERON:0007188,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002348 ] .
+
+UBERON:0015129 a owl:Class ;
+    rdfs:label "epicardial fat" ;
+    NIFRID:synonym "epicardial adipose tissue",
+        "epicardial fat",
+        "pericardial adipose tissue" ;
+    rdfs:subClassOf UBERON:0003837,
+        UBERON:0035814,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0015128 ] .
+
 UBERON:0015152 a owl:Class ;
     rdfs:label "gland of ocular region" ;
-    NIFRID:synonym "ocular gland",
+    NIFRID:synonym "gland of ocular region",
+        "ocular gland",
         "orbital gland" ;
     rdfs:subClassOf UBERON:0002530,
         [ a owl:Restriction ;
@@ -18817,6 +24616,9 @@ UBERON:0015173 a owl:Class ;
     rdfs:subClassOf UBERON:0015177,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001296 ] .
 
 UBERON:0015177 a owl:Class ;
@@ -18830,20 +24632,27 @@ UBERON:0015177 a owl:Class ;
 
 UBERON:0015203 a owl:Class ;
     rdfs:label "non-connected functional system" ;
+    NIFRID:synonym "non-connected functional system" ;
     rdfs:subClassOf UBERON:0034923 .
 
 UBERON:0015204 a owl:Class ;
     rdfs:label "glandular system" ;
+    NIFRID:synonym "glandular system" ;
     rdfs:subClassOf UBERON:0015203 .
 
 UBERON:0015212 a owl:Class ;
     rdfs:label "lateral structure" ;
-    rdfs:subClassOf UBERON:0000061 .
+    NIFRID:synonym "lateral structure" ;
+    rdfs:subClassOf UBERON:0000061,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000465 ] .
 
 UBERON:0015228 a owl:Class ;
     rdfs:label "circulatory organ" ;
     NIFRID:synonym "cardiac pump",
         "cardiac structure",
+        "circulatory organ",
         "circulatory vessel",
         "heart",
         "heart or heart like organ" ;
@@ -18855,19 +24664,12 @@ UBERON:0015228 a owl:Class ;
 UBERON:0015233 a owl:Class ;
     rdfs:label "nucleus of dorsal thalamus" ;
     NIFRID:synonym "dorsal thalamic nucleus",
+        "nucleus of dorsal thalamus",
         "nucleus of thalamus proper" ;
     rdfs:subClassOf UBERON:0007692,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004703 ] .
-
-UBERON:0015234 a owl:Class ;
-    rdfs:label "nucleus of ventral thalamus" ;
-    NIFRID:synonym "ventral thalamic nucleus" ;
-    rdfs:subClassOf UBERON:0007692,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001900 ] .
 
 UBERON:0015244 a owl:Class ;
     rdfs:label "accessory olfactory bulb granule cell layer" ;
@@ -18881,13 +24683,29 @@ UBERON:0015244 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0005378 ] .
 
+UBERON:0015249 a owl:Class ;
+    rdfs:label "digit skin" ;
+    rdfs:subClassOf UBERON:0015790,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002544 ] .
+
 UBERON:0015410 a owl:Class ;
     rdfs:label "heart plus pericardium" ;
-    NIFRID:synonym "heart/pericardium" ;
+    NIFRID:synonym "heart plus pericardium",
+        "heart/pericardium" ;
     rdfs:subClassOf UBERON:0005178,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004535 ] .
+
+UBERON:0015423 a owl:Class ;
+    rdfs:label "hilar portion of hepatic duct" ;
+    NIFRID:synonym "hilar part of hepatic duct" ;
+    rdfs:subClassOf UBERON:0005171,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0005604 ] .
 
 UBERON:0015432 a owl:Class ;
     rdfs:label "accessory olfactory bulb mitral cell layer" ;
@@ -18900,6 +24718,16 @@ UBERON:0015432 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0004186 ] .
 
+UBERON:0015716 a owl:Class ;
+    rdfs:label "anal canal epithelium" ;
+    NIFRID:synonym "anal canal epithelium",
+        "epithelium of anal canal" ;
+    rdfs:subClassOf UBERON:0001278,
+        UBERON:0014703,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000159 ] .
+
 UBERON:0015757 a owl:Class ;
     rdfs:label "heterogeneous tissue" ;
     NIFRID:synonym "portion of heterogeneous tissue" ;
@@ -18907,51 +24735,45 @@ UBERON:0015757 a owl:Class ;
 
 UBERON:0015787 a owl:Class ;
     rdfs:label "upper respiratory conduit" ;
-    NIFRID:synonym "respiratory conduit" ;
+    NIFRID:synonym "respiratory conduit",
+        "upper respiratory conduit" ;
     rdfs:subClassOf UBERON:0004111,
-        UBERON:0004119,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001557 ] .
 
 UBERON:0015788 a owl:Class ;
     rdfs:label "olfactory apparatus chamber" ;
-    rdfs:subClassOf UBERON:0004121,
-        UBERON:0015787,
+    NIFRID:synonym "olfactory apparatus chamber" ;
+    rdfs:subClassOf UBERON:0015787,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000004 ] .
 
-UBERON:0015793 a owl:Class ;
-    rdfs:label "induseum griseum" ;
-    NIFRID:synonym "gray stria of Lancisi",
-        "gyrus epicallosus",
-        "gyrus indusium griseum",
-        "indusium griseum",
-        "supracallosal gyrus" ;
-    rdfs:subClassOf UBERON:0016536,
-        UBERON:0016555,
+UBERON:0015790 a owl:Class ;
+    rdfs:label "autopod skin" ;
+    NIFRID:synonym "paw skin" ;
+    rdfs:subClassOf UBERON:0001419,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002421 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002665 ] .
+            owl:someValuesFrom UBERON:0002470 ] .
 
-UBERON:0015800 a owl:Class ;
-    rdfs:label "taenia tectum of brain" ;
-    NIFRID:synonym "taenia tecta",
-        "taenia tectum",
-        "tenia tecta",
-        "tenia tectum" ;
-    rdfs:subClassOf UBERON:0016536,
-        UBERON:0016555,
+UBERON:0015796 a owl:Class ;
+    rdfs:label "liver blood vessel" ;
+    NIFRID:synonym "hepatic blood vessel",
+        "liver blood vessel" ;
+    rdfs:subClassOf UBERON:0003497,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002264 ],
+            owl:someValuesFrom UBERON:0002107 ] .
+
+UBERON:0015833 a owl:Class ;
+    rdfs:label "foregut epithelium" ;
+    NIFRID:synonym "foregut epithelium" ;
+    rdfs:subClassOf UBERON:0003929,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002665 ] .
+            owl:someValuesFrom UBERON:0001041 ] .
 
 UBERON:0015860 a owl:Class ;
     rdfs:label "visceral abdominal lymph node" ;
@@ -18959,10 +24781,21 @@ UBERON:0015860 a owl:Class ;
 
 UBERON:0016490 a owl:Class ;
     rdfs:label "auditory system" ;
+    NIFRID:synonym "auditory system" ;
     rdfs:subClassOf UBERON:0007037,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002105 ] .
+
+UBERON:0016493 a owl:Class ;
+    rdfs:label "palmaris longus muscle" ;
+    NIFRID:synonym "musculus palmaris longus",
+        "palmaris",
+        "palmaris longus" ;
+    rdfs:subClassOf UBERON:0003662,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
 
 UBERON:0016508 a owl:Class ;
     rdfs:label "pelvic ganglion" ;
@@ -18976,27 +24809,21 @@ UBERON:0016526 a owl:Class ;
         "cerebral hemisphere lobe",
         "cerebral lobe",
         "lobe of cerebral cortex",
+        "lobe of cerebral hemisphere",
         "lobe parts of cerebral cortex",
         "lobes of the brain",
         "lobi cerebri",
         "regional organ part of cerebral cortex",
         "segment of cerebral cortex" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001869 ] .
 
-UBERON:0016527 a owl:Class ;
-    rdfs:label "white matter of cerebral lobe" ;
-    rdfs:subClassOf UBERON:0002437,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0016526 ] .
-
 UBERON:0016529 a owl:Class ;
     rdfs:label "cortex of cerebral lobe" ;
     NIFRID:synonym "cortex of cerebral hemisphere lobe",
+        "cortex of cerebral lobe",
         "cortex of lobe of cerebral hemisphere",
         "gray matter of lobe of cerebral hemisphere",
         "neocortical part of cerebral hemisphere" ;
@@ -19012,6 +24839,7 @@ UBERON:0016530 a owl:Class ;
     rdfs:label "parietal cortex" ;
     NIFRID:synonym "cortex of parietal lobe",
         "gray matter of parietal lobe",
+        "parietal cortex",
         "parietal lobe cortex",
         "parietal neocortex" ;
     rdfs:subClassOf UBERON:0016529,
@@ -19019,16 +24847,10 @@ UBERON:0016530 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001872 ] .
 
-UBERON:0016536 a owl:Class ;
-    rdfs:label "white matter of limbic lobe" ;
-    rdfs:subClassOf UBERON:0016527,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002600 ] .
-
 UBERON:0016548 a owl:Class ;
     rdfs:label "central nervous system gray matter layer" ;
-    NIFRID:synonym "CNS gray matter layer",
+    NIFRID:synonym "central nervous system gray matter layer",
+        "CNS gray matter layer",
         "CNS grey matter layer",
         "gray matter layer of neuraxis",
         "grey matter layer",
@@ -19037,13 +24859,15 @@ UBERON:0016548 a owl:Class ;
 
 UBERON:0016549 a owl:Class ;
     rdfs:label "central nervous system white matter layer" ;
-    NIFRID:synonym "CNS white matter layer",
+    NIFRID:synonym "central nervous system white matter layer",
+        "CNS white matter layer",
         "white matter layer",
         "white matter layer of neuraxis" ;
     rdfs:subClassOf UBERON:0022303 .
 
 UBERON:0016550 a owl:Class ;
     rdfs:label "spinal cord column" ;
+    NIFRID:synonym "spinal cord column" ;
     rdfs:subClassOf UBERON:0011215,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19056,26 +24880,10 @@ UBERON:0016551 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0005375 ] .
 
-UBERON:0016554 a owl:Class ;
-    rdfs:label "white matter of midbrain" ;
-    NIFRID:synonym "mesencephalic white matter" ;
-    rdfs:subClassOf UBERON:0003544,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001891 ] .
-
-UBERON:0016555 a owl:Class ;
-    rdfs:label "stria of telencephalon" ;
-    NIFRID:synonym "telencephalon stria" ;
-    rdfs:subClassOf UBERON:0011299,
-        UBERON:0013199,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001893 ] .
-
 UBERON:0016570 a owl:Class ;
     rdfs:label "lamina of gray matter of spinal cord" ;
-    NIFRID:synonym "rexed lamina" ;
+    NIFRID:synonym "lamina of gray matter of spinal cord",
+        "rexed lamina" ;
     rdfs:subClassOf UBERON:0011215,
         UBERON:0022303,
         [ a owl:Restriction ;
@@ -19132,49 +24940,6 @@ UBERON:0016610 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002256 ] .
 
-UBERON:0016618 a owl:Class ;
-    rdfs:label "baleen feeding system" ;
-    rdfs:subClassOf UBERON:0011216,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001007 ] .
-
-UBERON:0016621 a owl:Class ;
-    rdfs:label "lunge feeding organ" ;
-    rdfs:subClassOf UBERON:0000020,
-        UBERON:0013765,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0006606 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0016618 ] .
-
-UBERON:0016630 a owl:Class ;
-    rdfs:label "neurovascular bundle" ;
-    rdfs:subClassOf UBERON:0034921,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0016621 ] .
-
-UBERON:0016632 a owl:Class ;
-    rdfs:label "isthmus of fallopian tube" ;
-    NIFRID:synonym "isthmus of oviduct",
-        "isthmus of uterine tube",
-        "isthmus tubae uterinae",
-        "uterine tube isthmus" ;
-    rdfs:subClassOf UBERON:0003889,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0003889 ] .
-
-UBERON:0016848 a owl:Class ;
-    rdfs:label "retroambiguus nucleus" ;
-    NIFRID:synonym "nucleus retroambigualis",
-        "nucleus retroambiguus",
-        "retroambiguus nucleus" ;
-    rdfs:subClassOf UBERON:0007635 .
-
 UBERON:0016850 a owl:Class ;
     rdfs:label "nucleus of phrenic nerve" ;
     NIFRID:synonym "nucleus nervi phrenici",
@@ -19186,11 +24951,37 @@ UBERON:0016850 a owl:Class ;
         "phrenic nucleus of anterior column of spinal cord" ;
     rdfs:subClassOf UBERON:0011777 .
 
+UBERON:0016884 a owl:Class ;
+    rdfs:label "shoulder joint" ;
+    NIFRID:synonym "joint of shoulder region" ;
+    rdfs:subClassOf UBERON:0000982,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001467 ] .
+
+UBERON:0016885 a owl:Class ;
+    rdfs:label "epithelium of terminal part of digestive tract" ;
+    NIFRID:synonym "epithelium of terminal part of digestive tract",
+        "rectum epithelium" ;
+    rdfs:subClassOf UBERON:0003929,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006866 ] .
+
+UBERON:0017618 a owl:Class ;
+    rdfs:label "extensor pollicis brevis muscle" ;
+    NIFRID:synonym "extensor pollicis",
+        "extensor pollicis brevis" ;
+    rdfs:subClassOf UBERON:0011024 .
+
 UBERON:0017642 a owl:Class ;
     rdfs:label "communicating branch of spinal nerve" ;
     NIFRID:synonym "rami communicantes",
         "rami communicantes of spinal nerve" ;
-    rdfs:subClassOf UBERON:0001021 .
+    rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0005476 ] .
 
 UBERON:0017672 a owl:Class ;
     rdfs:label "abdominal viscera" ;
@@ -19203,35 +24994,22 @@ UBERON:0017672 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000916 ] .
 
-UBERON:0018237 a owl:Class ;
-    rdfs:label "dorsal column-medial lemniscus pathway" ;
-    NIFRID:synonym "DCML",
-        "DCML pathway",
-        "dorsal column",
-        "dorsal column tract",
-        "dorsal column-medial lemniscus pathway",
-        "dorsal column-medial lemniscus system",
-        "dorsal column-medial lemniscus tract",
-        "medial lemniscus tracts",
-        "posterior column pathway",
-        "posterior column-medial leminscus pathway",
-        "posterior column-medial lemniscus system",
-        "posterior column/medial leminscus pathway" ;
-    rdfs:subClassOf UBERON:0000122 .
-
-UBERON:0018238 a owl:Class ;
-    rdfs:label "dorsal column nucleus" ;
-    NIFRID:synonym "dorsal column nuclei" ;
-    rdfs:subClassOf UBERON:0007635,
+UBERON:0018111 a owl:Class ;
+    rdfs:label "muscle layer of rectum" ;
+    NIFRID:synonym "muscle layer of rectum",
+        "muscular coat of rectum",
+        "muscularis externa of rectum",
+        "rectal muscularis propria",
+        "tunica muscularis (rectum)",
+        "tunica muscularis recti" ;
+    rdfs:subClassOf UBERON:0011198,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001896 ],
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0018237 ] .
+            owl:someValuesFrom UBERON:0001052 ] .
 
 UBERON:0018254 a owl:Class ;
     rdfs:label "skeletal musculature" ;
+    NIFRID:synonym "skeletal musculature" ;
     rdfs:subClassOf UBERON:0000061,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19239,6 +25017,7 @@ UBERON:0018254 a owl:Class ;
 
 UBERON:0018257 a owl:Class ;
     rdfs:label "submucosa of digestive tract" ;
+    NIFRID:synonym "submucosa of digestive tract" ;
     rdfs:subClassOf UBERON:0000009,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19246,11 +25025,13 @@ UBERON:0018257 a owl:Class ;
 
 UBERON:0018260 a owl:Class ;
     rdfs:label "layer of muscle tissue" ;
+    NIFRID:synonym "layer of muscle tissue" ;
     rdfs:subClassOf UBERON:0004923 .
 
 UBERON:0018261 a owl:Class ;
     rdfs:label "muscular coat of digestive tract" ;
-    NIFRID:synonym "muscular layer of digestive tract",
+    NIFRID:synonym "muscular coat of digestive tract",
+        "muscular layer of digestive tract",
         "muscularis externa of digestive tract",
         "tunica externa of digestive tract",
         "tunica muscularis of digestive tract" ;
@@ -19265,7 +25046,10 @@ UBERON:0018412 a owl:Class ;
         "nerve of the pterygoid canal",
         "pterygoid canal nerve",
         "vidian nerve" ;
-    rdfs:subClassOf UBERON:0011779 .
+    rdfs:subClassOf UBERON:0011779,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001647 ] .
 
 UBERON:0018675 a owl:Class ;
     rdfs:label "pelvic splanchnic nerve" ;
@@ -19281,10 +25065,19 @@ UBERON:0018675 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000011 ] .
 
+UBERON:0018676 a owl:Class ;
+    rdfs:label "renal nerve plexus" ;
+    NIFRID:synonym "plexus renalis",
+        "renal plexus" ;
+    rdfs:subClassOf UBERON:0001816 .
+
 UBERON:0018679 a owl:Class ;
     rdfs:label "thoracic splanchnic nerve" ;
     rdfs:subClassOf UBERON:0003715,
-        UBERON:0003824 .
+        UBERON:0003824,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004863 ] .
 
 UBERON:0018680 a owl:Class ;
     rdfs:label "greater splanchnic nerve" ;
@@ -19303,49 +25096,107 @@ UBERON:0018683 a owl:Class ;
 
 UBERON:0018707 a owl:Class ;
     rdfs:label "bladder organ" ;
-    NIFRID:synonym "bladder" ;
+    NIFRID:synonym "bladder",
+        "bladder organ" ;
     rdfs:subClassOf UBERON:0000489,
         UBERON:0009856 .
 
 UBERON:0019042 a owl:Class ;
     rdfs:label "reproductive system mucosa" ;
-    NIFRID:synonym "genital mucosa" ;
+    NIFRID:synonym "genital mucosa",
+        "reproductive system mucosa" ;
     rdfs:subClassOf UBERON:0000344,
         UBERON:0005156,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000990 ] .
 
+UBERON:0019201 a owl:Class ;
+    rdfs:label "gemellus muscle" ;
+    rdfs:subClassOf UBERON:0004252 .
+
+UBERON:0019202 a owl:Class ;
+    rdfs:label "inferior gemellus muscle" ;
+    NIFRID:synonym "gemellus inferior",
+        "gemellus inferior muscle",
+        "inferior gemellus",
+        "musculus gemellus inferior" ;
+    rdfs:subClassOf UBERON:0019201 .
+
+UBERON:0019203 a owl:Class ;
+    rdfs:label "superior gemellus muscle" ;
+    NIFRID:synonym "cemellus superior",
+        "gemellus superior",
+        "gemellus superior muscle",
+        "musculus gemellus superior",
+        "superior cemellus",
+        "superior cemellus muscle",
+        "superior gemellus" ;
+    rdfs:subClassOf UBERON:0019201 .
+
 UBERON:0019207 a owl:Class ;
     rdfs:label "chorioretinal region" ;
     NIFRID:synonym "chorioretina",
+        "chorioretinal region",
         "choroid and retina",
         "retinachoroid",
         "retinachoroidal region" ;
     rdfs:subClassOf UBERON:0000481,
-        UBERON:0004121,
-        UBERON:0010314,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom NCBITaxon:6072 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0010230 ] .
 
+UBERON:0019221 a owl:Class ;
+    rdfs:label "digit 1 or 5" ;
+    NIFRID:synonym "lateral digit",
+        "outer digit",
+        "outermost digit" ;
+    rdfs:subClassOf UBERON:0002544 .
+
+UBERON:0019222 a owl:Class ;
+    rdfs:label "digit 2, 3 or 4" ;
+    NIFRID:synonym "medial digit",
+        "mesoaxial digit" ;
+    rdfs:subClassOf UBERON:0002544 .
+
+UBERON:0019231 a owl:Class ;
+    rdfs:label "manual digit 1 or 5" ;
+    NIFRID:synonym "lateral finger",
+        "lateral manual digit",
+        "outer manual digit",
+        "outermost manual digit" ;
+    rdfs:subClassOf UBERON:0002389,
+        UBERON:0019221,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
+
+UBERON:0019232 a owl:Class ;
+    rdfs:label "manual digit 2, 3 or 4" ;
+    NIFRID:synonym "medial manual digit",
+        "mesoaxial manual digit",
+        "mesoxaxial finger" ;
+    rdfs:subClassOf UBERON:0002389,
+        UBERON:0019222,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
+
 UBERON:0019258 a owl:Class ;
     rdfs:label "white matter of hindbrain" ;
+    NIFRID:synonym "white matter of hindbrain" ;
     rdfs:subClassOf UBERON:0003544,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002028 ] .
 
-UBERON:0019261 a owl:Class ;
-    rdfs:label "white matter of forebrain" ;
-    rdfs:subClassOf UBERON:0003544,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0001890 ] .
-
 UBERON:0019263 a owl:Class ;
     rdfs:label "gray matter of hindbrain" ;
-    NIFRID:synonym "gray matter of the hindbrain" ;
+    NIFRID:synonym "gray matter of hindbrain",
+        "gray matter of the hindbrain" ;
     rdfs:subClassOf UBERON:0003528,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19353,6 +25204,7 @@ UBERON:0019263 a owl:Class ;
 
 UBERON:0019264 a owl:Class ;
     rdfs:label "gray matter of forebrain" ;
+    NIFRID:synonym "gray matter of forebrain" ;
     rdfs:subClassOf UBERON:0003528,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19360,6 +25212,7 @@ UBERON:0019264 a owl:Class ;
 
 UBERON:0019267 a owl:Class ;
     rdfs:label "gray matter of midbrain" ;
+    NIFRID:synonym "gray matter of midbrain" ;
     rdfs:subClassOf UBERON:0003528,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19367,6 +25220,7 @@ UBERON:0019267 a owl:Class ;
 
 UBERON:0019269 a owl:Class ;
     rdfs:label "gray matter of diencephalon" ;
+    NIFRID:synonym "gray matter of diencephalon" ;
     rdfs:subClassOf UBERON:0019264,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19374,6 +25228,7 @@ UBERON:0019269 a owl:Class ;
 
 UBERON:0019291 a owl:Class ;
     rdfs:label "white matter of metencephalon" ;
+    NIFRID:synonym "white matter of metencephalon" ;
     rdfs:subClassOf UBERON:0019258,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19381,6 +25236,7 @@ UBERON:0019291 a owl:Class ;
 
 UBERON:0019292 a owl:Class ;
     rdfs:label "white matter of pons" ;
+    NIFRID:synonym "white matter of pons" ;
     rdfs:subClassOf UBERON:0014891,
         UBERON:0019291,
         [ a owl:Restriction ;
@@ -19393,6 +25249,7 @@ UBERON:0019293 a owl:Class ;
         "predominantly white regional part of pontine tegmentum",
         "substantia alba tegmenti pontis",
         "white matter of pontile tegmentum",
+        "white matter of pontine tegmentum",
         "white substance of pontile tegmentum" ;
     rdfs:subClassOf UBERON:0019292,
         [ a owl:Restriction ;
@@ -19401,6 +25258,7 @@ UBERON:0019293 a owl:Class ;
 
 UBERON:0019304 a owl:Class ;
     rdfs:label "sensory organ epithelium" ;
+    NIFRID:synonym "sensory organ epithelium" ;
     rdfs:subClassOf UBERON:0000483,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19408,11 +25266,22 @@ UBERON:0019304 a owl:Class ;
 
 UBERON:0019306 a owl:Class ;
     rdfs:label "nose epithelium" ;
-    rdfs:subClassOf UBERON:0010371,
-        UBERON:0019304,
+    NIFRID:synonym "nose epithelium" ;
+    rdfs:subClassOf UBERON:0019304,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000004 ] .
+
+UBERON:0019319 a owl:Class ;
+    rdfs:label "exocrine gland of integumental system" ;
+    NIFRID:synonym "exocrine gland of integumental system",
+        "integumental exocrine gland",
+        "integumental system exocrine gland" ;
+    rdfs:subClassOf UBERON:0002365,
+        UBERON:0003297,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002416 ] .
 
 UBERON:0022278 a owl:Class ;
     rdfs:label "nucleus of pudendal nerve" ;
@@ -19422,18 +25291,34 @@ UBERON:0022278 a owl:Class ;
     rdfs:subClassOf UBERON:0011777,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002257 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0005853 ] .
+
+UBERON:0022300 a owl:Class ;
+    rdfs:label "nasociliary nerve" ;
+    NIFRID:synonym "nasal nerve",
+        "nasociliary",
+        "nasociliary nerve",
+        "nervus nasociliaris" ;
+    rdfs:subClassOf UBERON:0011779,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000942 ] .
 
 UBERON:0022301 a owl:Class ;
     rdfs:label "long ciliary nerve" ;
     NIFRID:synonym "long ciliary nerve",
         "nervi ciliares longi" ;
     rdfs:subClassOf UBERON:0003438,
-        UBERON:0004121,
-        UBERON:0011779 .
+        UBERON:0011779,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0022300 ] .
 
 UBERON:0022302 a owl:Class ;
     rdfs:label "short ciliary nerve" ;
@@ -19443,14 +25328,17 @@ UBERON:0022302 a owl:Class ;
         "short ciliary nerve" ;
     rdfs:subClassOf UBERON:0003438,
         UBERON:0004293,
-        UBERON:0010313,
-        UBERON:0011779 .
+        UBERON:0011779,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002058 ] .
 
 UBERON:0022303 a owl:Class ;
     rdfs:label "Cell layer",
         "nervous system cell part layer" ;
     NIFRID:synonym "lamina",
-        "layer" ;
+        "layer",
+        "nervous system cell part layer" ;
     rdfs:subClassOf UBERON:0005162,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19466,6 +25354,7 @@ UBERON:0022303 a owl:Class ;
 UBERON:0022317 a owl:Class ;
     rdfs:label "olfactory cortex layer 1" ;
     NIFRID:synonym "layer 1 of olfactory cortex",
+        "olfactory cortex layer 1",
         "olfactory cortex plexiform layer" ;
     rdfs:subClassOf UBERON:0011215,
         UBERON:0022303,
@@ -19475,7 +25364,8 @@ UBERON:0022317 a owl:Class ;
 
 UBERON:0022318 a owl:Class ;
     rdfs:label "olfactory cortex layer 2" ;
-    NIFRID:synonym "layer 2 of olfactory cortex" ;
+    NIFRID:synonym "layer 2 of olfactory cortex",
+        "olfactory cortex layer 2" ;
     rdfs:subClassOf UBERON:0011215,
         UBERON:0022303,
         [ a owl:Restriction ;
@@ -19492,20 +25382,21 @@ UBERON:0022326 a owl:Class ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002829 ] .
 
-UBERON:0022347 a owl:Class ;
-    rdfs:label "dentate gyrus molecular layer inner" ;
-    NIFRID:synonym "DG inner stratum moleculare",
-        "inner layer of dentate gyrus molecular layer" ;
-    rdfs:subClassOf UBERON:0002304,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0004679 ] .
-
 UBERON:0022350 a owl:Class ;
     rdfs:label "visceral serous membrane" ;
-    NIFRID:synonym "visceral wall of serous membrane" ;
-    rdfs:subClassOf UBERON:0004120,
-        UBERON:0004923,
+    NIFRID:synonym "visceral serous membrane",
+        "visceral wall of serous membrane" ;
+    rdfs:subClassOf UBERON:0004923,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000042 ] .
+
+UBERON:0022351 a owl:Class ;
+    rdfs:label "parietal serous membrane" ;
+    NIFRID:synonym "cavity lining",
+        "parietal serous membrane",
+        "parietal wall of serous membrane" ;
+    rdfs:subClassOf UBERON:0004923,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000042 ] .
@@ -19556,8 +25447,7 @@ UBERON:0029636 a owl:Class ;
             owl:someValuesFrom UBERON:0002792 ] .
 
 UBERON:0033483 a owl:Class ;
-    rdfs:label "Lumbar spinal cord gray commissure",
-        "lumbar spinal cord gray commissure" ;
+    rdfs:label "lumbar spinal cord gray commissure" ;
     NIFRID:synonym "lumbar spinal cord gray commissure" ;
     rdfs:subClassOf UBERON:0014631,
         UBERON:0029636,
@@ -19573,28 +25463,52 @@ UBERON:0034713 a owl:Class ;
     NIFRID:synonym "cranial nerve fiber bundle",
         "cranial nerve fiber tract",
         "cranial nerve or tract",
+        "cranial neuron projection bundle",
         "neuron projection bundle from brain" ;
     rdfs:subClassOf UBERON:0000122,
-        UBERON:0015212 .
+        UBERON:0015212,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000033 ] .
 
 UBERON:0034728 a owl:Class ;
     rdfs:label "autonomic nerve" ;
-    NIFRID:synonym "nervus visceralis",
+    NIFRID:synonym "autonomic nerve",
+        "nervus visceralis",
         "visceral nerve" ;
     rdfs:subClassOf UBERON:0011779,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002410 ] .
+            owl:someValuesFrom UBERON:0002410 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0036264 ] .
 
 UBERON:0034729 a owl:Class ;
     rdfs:label "sympathetic nerve" ;
+    NIFRID:synonym "sympathetic nerve" ;
     rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ],
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000013 ] .
 
+UBERON:0034736 a owl:Class ;
+    rdfs:label "coracoclavicular ligament" ;
+    NIFRID:synonym "accessory ligament of acromioclavicular joint" ;
+    rdfs:subClassOf UBERON:0008846,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0003692 ] .
+
 UBERON:0034768 a owl:Class ;
     rdfs:label "morphological feature" ;
+    NIFRID:synonym "morphological feature" ;
     rdfs:subClassOf UBERON:0000061,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19604,50 +25518,70 @@ UBERON:0034769 a owl:Class ;
     rdfs:label "lymphomyeloid tissue" ;
     rdfs:subClassOf UBERON:0015757 .
 
+UBERON:0034908 a owl:Class ;
+    rdfs:label "scapular muscle" ;
+    rdfs:subClassOf UBERON:0014892 .
+
 UBERON:0034921 a owl:Class ;
     rdfs:label "multi organ part structure" ;
-    NIFRID:synonym "anatomical cluster" ;
+    NIFRID:synonym "anatomical cluster",
+        "multi organ part structure" ;
     rdfs:subClassOf UBERON:0010000 .
 
 UBERON:0034922 a owl:Class ;
     rdfs:label "cell cluster" ;
+    NIFRID:synonym "cell cluster" ;
     rdfs:subClassOf UBERON:0010000 .
 
 UBERON:0034923 a owl:Class ;
     rdfs:label "disconnected anatomical group" ;
+    NIFRID:synonym "disconnected anatomical group" ;
     rdfs:subClassOf UBERON:0000465 .
 
 UBERON:0034925 a owl:Class ;
     rdfs:label "anatomical collection" ;
+    NIFRID:synonym "anatomical collection" ;
     rdfs:subClassOf UBERON:0000465 .
 
 UBERON:0034929 a owl:Class ;
     rdfs:label "external soft tissue zone" ;
-    rdfs:subClassOf PR:000050567,
-        UBERON:0010000,
+    NIFRID:synonym "external soft tissue zone" ;
+    rdfs:subClassOf UBERON:0010000,
+        UBERON:0010314,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000475 ] .
 
-UBERON:0034933 a owl:Class ;
-    rdfs:label "layer of smooth muscle tissue" ;
-    rdfs:subClassOf UBERON:0018260,
+UBERON:0034932 a owl:Class ;
+    rdfs:label "epithelium of biliary system" ;
+    NIFRID:synonym "biliary epithelium",
+        "biliary system epithelium",
+        "biliary tract epithelium",
+        "epithelium of biliary system" ;
+    rdfs:subClassOf UBERON:0000483,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0014510 ] .
+            owl:someValuesFrom UBERON:0002294 ] .
+
+UBERON:0034933 a owl:Class ;
+    rdfs:label "layer of smooth muscle tissue" ;
+    NIFRID:synonym "layer of smooth muscle tissue" ;
+    rdfs:subClassOf UBERON:0018260 .
 
 UBERON:0034944 a owl:Class ;
     rdfs:label "zone of organ" ;
     NIFRID:synonym "organ region with floating fiat boundary",
         "organ sector",
         "organ zonal region",
-        "organ zone" ;
+        "organ zone",
+        "zone of organ" ;
     rdfs:subClassOf UBERON:0000064 .
 
 UBERON:0034969 a owl:Class ;
     rdfs:label "epithelial layer of duct" ;
     NIFRID:synonym "duct epithelium",
-        "ductal epithelium" ;
+        "ductal epithelium",
+        "epithelial layer of duct" ;
     rdfs:subClassOf UBERON:0003914,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19663,6 +25597,30 @@ UBERON:0034979 a owl:Class ;
     rdfs:label "nonchromaffin paraganglion" ;
     rdfs:subClassOf UBERON:0034978 .
 
+UBERON:0034984 a owl:Class ;
+    rdfs:label "nerve to quadratus femoris" ;
+    NIFRID:synonym "nerve to quadratus femoris",
+        "nerve to the quadratus femoris",
+        "nerve to the quadratus femoris and gemellus inferior",
+        "nerve to the quadratus femoris muscle" ;
+    rdfs:subClassOf UBERON:0001021,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0034986 ] .
+
+UBERON:0034986 a owl:Class ;
+    rdfs:label "sacral nerve plexus" ;
+    NIFRID:synonym "plexus sacralis",
+        "sacral plexus" ;
+    rdfs:subClassOf UBERON:0001815 .
+
+UBERON:0034987 a owl:Class ;
+    rdfs:label "lumbar nerve plexus" ;
+    NIFRID:synonym "femoral plexus",
+        "lumbar plexus",
+        "plexus lumbalis" ;
+    rdfs:subClassOf UBERON:0001815 .
+
 UBERON:0035011 a owl:Class ;
     rdfs:label "central gray substance" ;
     NIFRID:synonym "central gray",
@@ -19677,23 +25635,91 @@ UBERON:0035011 a owl:Class ;
 
 UBERON:0035014 a owl:Class ;
     rdfs:label "functional part of brain" ;
+    NIFRID:synonym "functional part of brain" ;
     rdfs:subClassOf UBERON:0002616 .
+
+UBERON:0035032 a owl:Class ;
+    rdfs:label "abdominal oblique muscle" ;
+    NIFRID:synonym "oblique abdominal muscle" ;
+    rdfs:subClassOf UBERON:0002461,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0006635 ] .
 
 UBERON:0035044 a owl:Class ;
     rdfs:label "olfactory cortex layer 3" ;
+    NIFRID:synonym "olfactory cortex layer 3" ;
     rdfs:subClassOf UBERON:0011215,
         UBERON:0022303,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002894 ] .
 
+UBERON:0035109 a owl:Class ;
+    rdfs:label "plantar nerve" ;
+    NIFRID:synonym "nerve, plantar" ;
+    rdfs:subClassOf UBERON:0003431,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001323 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002103 ] .
+
+UBERON:0035110 a owl:Class ;
+    rdfs:label "lateral plantar nerve" ;
+    NIFRID:synonym "external plantar nerve",
+        "nervus plantaris lateralis" ;
+    rdfs:subClassOf UBERON:0035109 .
+
+UBERON:0035111 a owl:Class ;
+    rdfs:label "medial plantar nerve" ;
+    NIFRID:synonym "internal plantar nerve",
+        "nervus plantaris medialis" ;
+    rdfs:subClassOf UBERON:0035109 .
+
+UBERON:0035112 a owl:Class ;
+    rdfs:label "intrinsic muscle" ;
+    rdfs:subClassOf UBERON:0014892 .
+
+UBERON:0035207 a owl:Class ;
+    rdfs:label "deep fibular nerve" ;
+    NIFRID:synonym "deep peroneal nerve" ;
+    rdfs:subClassOf UBERON:0003431,
+        UBERON:0035652,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001324 ] .
+
+UBERON:0035258 a owl:Class ;
+    rdfs:label "mons pubis" ;
+    NIFRID:synonym "mons",
+        "mons veneris",
+        "public mound" ;
+    rdfs:subClassOf UBERON:0000475,
+        UBERON:0005156,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000997 ] .
+
+UBERON:0035526 a owl:Class ;
+    rdfs:label "superficial fibular nerve" ;
+    NIFRID:synonym "superficial peroneal nerve" ;
+    rdfs:subClassOf UBERON:0003431,
+        UBERON:0035652,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001324 ] .
+
 UBERON:0035553 a owl:Class ;
     rdfs:label "left cardiac chamber" ;
+    NIFRID:synonym "left cardiac chamber" ;
     rdfs:subClassOf UBERON:0004151,
         UBERON:0015212 .
 
 UBERON:0035554 a owl:Class ;
     rdfs:label "right cardiac chamber" ;
+    NIFRID:synonym "right cardiac chamber" ;
     rdfs:subClassOf UBERON:0004151,
         UBERON:0015212 .
 
@@ -19707,6 +25733,7 @@ UBERON:0035639 a owl:Class ;
         "appendage of eye",
         "appendages of the eye",
         "eye adnexa",
+        "ocular adnexa",
         "set of accessory visual structures",
         "structurae oculi accessoriae" ;
     rdfs:subClassOf UBERON:0034921,
@@ -19716,6 +25743,12 @@ UBERON:0035639 a owl:Class ;
 
 UBERON:0035642 a owl:Class ;
     rdfs:label "laryngeal nerve" ;
+    NIFRID:synonym "laryngeal nerve" ;
+    rdfs:subClassOf UBERON:0001021 .
+
+UBERON:0035652 a owl:Class ;
+    rdfs:label "fibular nerve" ;
+    NIFRID:synonym "peroneal nerve" ;
     rdfs:subClassOf UBERON:0001021 .
 
 UBERON:0035769 a owl:Class ;
@@ -19731,7 +25764,10 @@ UBERON:0035770 a owl:Class ;
         "plexus mesentericus inferior",
         "plexus nervosus mesentericus inferior" ;
     rdfs:subClassOf UBERON:0000122,
-        UBERON:0035771 .
+        UBERON:0035771,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom RO:0002577 ] .
 
 UBERON:0035771 a owl:Class ;
     rdfs:label "mesenteric plexus" ;
@@ -19764,6 +25800,7 @@ UBERON:0035787 a owl:Class ;
 
 UBERON:0035788 a owl:Class ;
     rdfs:label "layer of CA3 field" ;
+    NIFRID:synonym "layer of CA3 field" ;
     rdfs:subClassOf UBERON:0002305,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
@@ -19771,36 +25808,68 @@ UBERON:0035788 a owl:Class ;
 
 UBERON:0035814 a owl:Class ;
     rdfs:label "pericardial fat" ;
+    NIFRID:synonym "pericardial fat" ;
     rdfs:subClassOf UBERON:0035818 .
 
 UBERON:0035818 a owl:Class ;
     rdfs:label "visceral fat" ;
+    NIFRID:synonym "visceral fat" ;
     rdfs:subClassOf UBERON:0001013 .
+
+UBERON:0035820 a owl:Class ;
+    rdfs:label "peritoneal sac" ;
+    NIFRID:synonym "peritoneal component",
+        "peritoneal sac" ;
+    rdfs:subClassOf UBERON:0002075,
+        UBERON:0005906 .
 
 UBERON:0035965 a owl:Class ;
     rdfs:label "wall of blood vessel" ;
     NIFRID:synonym "blood vessel wall",
-        "vascular wall" ;
+        "vascular wall",
+        "wall of blood vessel" ;
     rdfs:subClassOf UBERON:0000060,
-        UBERON:0004120,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001981 ] .
 
-UBERON:0035973 a owl:Class ;
-    rdfs:label "nucleus incertus" ;
-    NIFRID:synonym "central Gray pars 0",
-        "central Gray part alpha",
-        "charles Watson. - 5th ed.)",
-        "Inc",
-        "NI",
-        "NI, CG0, CGalpha, CGbeta",
-        "nucleus incertus (Streeter)" ;
-    rdfs:subClassOf UBERON:0006331,
-        UBERON:0009662,
+UBERON:0036014 a owl:Class ;
+    rdfs:label "gluteal sulcus" ;
+    NIFRID:synonym "gluteal crease",
+        "gluteal fold",
+        "horizontal gluteal crease",
+        "sulcus glutealis" ;
+    rdfs:subClassOf UBERON:0007651,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0003023 ] .
+            owl:someValuesFrom UBERON:0001137 ],
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002355 ] .
+
+UBERON:0036172 a owl:Class ;
+    rdfs:label "palmaris brevis" ;
+    NIFRID:synonym "musculus palmaris brevis",
+        "palmaris brevis muscle" ;
+    rdfs:subClassOf UBERON:0014377 .
+
+UBERON:0036174 a owl:Class ;
+    rdfs:label "flexor digiti minimi brevis of hand" ;
+    NIFRID:synonym "flexor brevis minimi digiti muscle (hand)",
+        "flexor digiti minimi brevis muscle",
+        "flexor digiti minimi brevis muscle of hand",
+        "flexor digiti quinti brevis muscle (hand)",
+        "musculus flexor digiti minimi brevis (manus)" ;
+    rdfs:subClassOf UBERON:0014377 .
+
+UBERON:0036176 a owl:Class ;
+    rdfs:label "opponens digiti minimi of hand" ;
+    NIFRID:synonym "musculus opponens digiti minimi (Manus)",
+        "opponens digiti minimi",
+        "opponens digiti minimi (hand)",
+        "opponens digiti minimi muscle of hand",
+        "opponens digiti quinti" ;
+    rdfs:subClassOf UBERON:0014377 .
 
 UBERON:0036216 a owl:Class ;
     rdfs:label "tympanic nerve" ;
@@ -19809,7 +25878,23 @@ UBERON:0036216 a owl:Class ;
         "tympanic",
         "tympanic branch",
         "tympanic branch of the glossopharyngeal" ;
-    rdfs:subClassOf UBERON:0011779 .
+    rdfs:subClassOf UBERON:0011779,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001649 ] .
+
+UBERON:0036264 a owl:Class ;
+    rdfs:label "zygomaticotemporal nerve" ;
+    NIFRID:synonym "ramus zygomaticotemporalis (Nervus zygomaticus)",
+        "ramus zygomaticotemporalis nervus zygomatici",
+        "zygomaticotemporal",
+        "zygomaticotemporal branch",
+        "zygomaticotemporal branch of zygomatic nerve",
+        "zygomaticotemporal nerve" ;
+    rdfs:subClassOf UBERON:0011779,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0000377 ] .
 
 UBERON:0036295 a owl:Class ;
     rdfs:label "renal pelvis/ureter" ;
@@ -19819,6 +25904,15 @@ UBERON:0036295 a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0011143 ] .
+
+UBERON:0037094 a owl:Class ;
+    rdfs:label "wall of common carotid artery" ;
+    NIFRID:synonym "common carotid arterial wall",
+        "wall of common carotid artery" ;
+    rdfs:subClassOf UBERON:0000415,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001530 ] .
 
 UBERON:0038727 a owl:Class ;
     rdfs:label "juxta-intestinal mesenteric lymph node" ;
@@ -19832,26 +25926,144 @@ UBERON:1000023 a owl:Class ;
         "pulp of spleen",
         "splenic pulp" ;
     rdfs:subClassOf UBERON:0000064,
-        UBERON:0004120,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:1000024 ] .
 
 UBERON:1000024 a owl:Class ;
     rdfs:label "parenchyma of spleen" ;
-    NIFRID:synonym "splenic parenchyma" ;
+    NIFRID:synonym "parenchyma of spleen",
+        "splenic parenchyma" ;
     rdfs:subClassOf UBERON:0000353,
-        UBERON:0004120,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0002106 ] .
 
+UBERON:2005260 a owl:Class ;
+    rdfs:label "fenestrated capillary" ;
+    NIFRID:synonym "fenestrated blood vessel endothelium",
+        "fenestrated capillary vessel" ;
+    rdfs:subClassOf UBERON:0001982,
+        UBERON:0004638 .
+
+UBERON:3000961 a owl:Class ;
+    rdfs:label "external integument structure" ;
+    NIFRID:synonym "external integument structure" ;
+    rdfs:subClassOf UBERON:0003102,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002199 ] .
+
+UBERON:4200013 a owl:Class ;
+    rdfs:label "flexor surface" ;
+    rdfs:subClassOf UBERON:4200230,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002495 ] .
+
+UBERON:4200230 a owl:Class ;
+    rdfs:label "surface of bone" ;
+    NIFRID:synonym "bone surface",
+        "surface of bone" ;
+    rdfs:subClassOf UBERON:0006984,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0001474 ] .
+
+UBERON:5001463 a owl:Class ;
+    rdfs:label "manual digit 1 plus metapodial segment" ;
+    NIFRID:synonym "manual digit 1",
+        "manual digit 1 ( phalanges plus metapodial) plus soft tissue",
+        "manual digit 1 digitopodial subdivision",
+        "manual digit 1 ray",
+        "manual digit I plus metapodial segment" ;
+    rdfs:subClassOf UBERON:5002389,
+        UBERON:5006048,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
+
+UBERON:5002389 a owl:Class ;
+    rdfs:label "manual digit plus metapodial segment" ;
+    NIFRID:synonym "manual digit",
+        "manual digit ( phalanges plus metapodial) plus soft tissue",
+        "manual digit digitopodial subdivision",
+        "manual digit ray" ;
+    rdfs:subClassOf UBERON:5002544,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002102 ] .
+
+UBERON:5002544 a owl:Class ;
+    rdfs:label "digit plus metapodial segment" ;
+    NIFRID:synonym "digit",
+        "digit ( phalanges plus metapodial) plus soft tissue",
+        "digit digitopodial subdivision",
+        "digit ray" ;
+    rdfs:subClassOf UBERON:0000475,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0012140 ] .
+
+UBERON:5003622 a owl:Class ;
+    rdfs:label "manual digit 2 plus metapodial segment" ;
+    NIFRID:synonym "manual digit 2",
+        "manual digit 2 ( phalanges plus metapodial) plus soft tissue",
+        "manual digit 2 digitopodial subdivision",
+        "manual digit 2 ray",
+        "manual digit II plus metapodial segment" ;
+    rdfs:subClassOf UBERON:5002389,
+        UBERON:5006049,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
+
+UBERON:5003623 a owl:Class ;
+    rdfs:label "manual digit 3 plus metapodial segment" ;
+    NIFRID:synonym "manual digit 3",
+        "manual digit 3 ( phalanges plus metapodial) plus soft tissue",
+        "manual digit 3 digitopodial subdivision",
+        "manual digit 3 ray",
+        "manual digit III plus metapodial segment" ;
+    rdfs:subClassOf UBERON:5002389,
+        UBERON:5006050,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0002398 ] .
+
+UBERON:5006048 a owl:Class ;
+    rdfs:label "digit 1 plus metapodial segment" ;
+    NIFRID:synonym "digit 1",
+        "digit 1 ( phalanges plus metapodial) plus soft tissue",
+        "digit 1 digitopodial subdivision",
+        "digit 1 ray",
+        "digit I plus metapodial segment" ;
+    rdfs:subClassOf UBERON:5002544 .
+
+UBERON:5006049 a owl:Class ;
+    rdfs:label "digit 2 plus metapodial segment" ;
+    NIFRID:synonym "digit 2",
+        "digit 2 ( phalanges plus metapodial) plus soft tissue",
+        "digit 2 digitopodial subdivision",
+        "digit 2 ray",
+        "digit II plus metapodial segment" ;
+    rdfs:subClassOf UBERON:5002544 .
+
+UBERON:5006050 a owl:Class ;
+    rdfs:label "digit 3 plus metapodial segment" ;
+    NIFRID:synonym "digit 3",
+        "digit 3 ( phalanges plus metapodial) plus soft tissue",
+        "digit 3 digitopodial subdivision",
+        "digit 3 ray",
+        "digit III plus metapodial segment" ;
+    rdfs:subClassOf UBERON:5002544 .
+
 UBERON:8410010 a owl:Class ;
-    rdfs:label "fimbria of uterine tube" ;
-    NIFRID:synonym "fimbria of fallopian tube",
+    rdfs:label "fimbria of fallopian tube" ;
+    NIFRID:synonym "fimbria of uterine tube",
         "fimbriae of fallopian tube",
         "fimbriae of uterine tube" ;
-    rdfs:subClassOf UBERON:0003889,
+    rdfs:subClassOf UBERON:0013515,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0003889 ] .
@@ -19890,35 +26102,19 @@ UBERON:8410063 a owl:Class ;
 
 UBERON:8410081 a owl:Class ;
     rdfs:label "blood microvessel" ;
-    NIFRID:synonym "microvasculature",
+    NIFRID:synonym "blood microvessel",
+        "microvasculature",
         "microvessel" ;
     rdfs:subClassOf UBERON:0001981,
         UBERON:0010523 .
 
 UBERON:8440004 a owl:Class ;
     rdfs:label "laminar subdivision of the cortex" ;
+    NIFRID:synonym "laminar subdivision of the cortex" ;
     rdfs:subClassOf UBERON:0011215,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0001950 ] .
-
-UBERON:8440013 a owl:Class ;
-    rdfs:label "fasciola cinerea" ;
-    NIFRID:synonym "FC" ;
-    rdfs:subClassOf UBERON:0000064,
-        UBERON:0004121,
-        [ a owl:Restriction ;
-            owl:onProperty partOf: ;
-            owl:someValuesFrom UBERON:0002421 ] .
-
-UBERON:8440015 a owl:Class ;
-    rdfs:label "noradrenergic cell groups" ;
-    rdfs:subClassOf UBERON:0002616 .
-
-UBERON:8440043 a owl:Class ;
-    rdfs:label "superior paraolivary nucleus" ;
-    NIFRID:synonym "SPON" ;
-    rdfs:subClassOf UBERON:0007247 .
 
 UBERON:8450001 a owl:Class ;
     rdfs:label "egg follicle" ;
@@ -19930,17 +26126,44 @@ UBERON:8450001 a owl:Class ;
 
 UBERON:8450002 a owl:Class ;
     rdfs:label "excretory system" ;
+    NIFRID:synonym "excretory system" ;
     rdfs:subClassOf UBERON:0000467 .
+
+UBERON:8450004 a owl:Class ;
+    rdfs:label "intercostal element" ;
+    rdfs:subClassOf UBERON:0000061 .
+
+UBERON:8480029 a owl:Class ;
+    rdfs:label "skin of external genitalia" ;
+    NIFRID:synonym "skin of external genitalia" ;
+    rdfs:subClassOf UBERON:0000014,
+        UBERON:0005156,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0004176 ] .
 
 UBERON:8480069 a owl:Class ;
     rdfs:label "temporofacial region" ;
     rdfs:subClassOf UBERON:0001444 .
 
+UBERON:8600004 a owl:Class ;
+    rdfs:label "visceral muscle tissue" ;
+    NIFRID:synonym "visceral muscle",
+        "visceral muscle tissue" ;
+    rdfs:subClassOf UBERON:0002385 .
+
+UBERON:8600006 a owl:Class ;
+    rdfs:label "visceral striated muscle tissue" ;
+    NIFRID:synonym "striated visceral muscle tissue",
+        "visceral striated muscle tissue" ;
+    rdfs:subClassOf UBERON:0002036,
+        UBERON:8600004 .
+
 UBERON:8600017 a owl:Class ;
     rdfs:label "bronchopulmonary segment" ;
-    NIFRID:synonym "lung segment" ;
+    NIFRID:synonym "bronchopulmonary segment",
+        "lung segment" ;
     rdfs:subClassOf UBERON:0000063,
-        UBERON:0004119,
         [ a owl:Restriction ;
             owl:onProperty partOf: ;
             owl:someValuesFrom UBERON:0000101 ],
@@ -19948,23 +26171,33 @@ UBERON:8600017 a owl:Class ;
             owl:onProperty RO:0002433 ;
             owl:someValuesFrom UBERON:0000101 ] .
 
-UBERON:8600018 a owl:Class ;
-    rdfs:label "neuroendocrine system" ;
-    NIFRID:synonym "NES" ;
-    rdfs:subClassOf UBERON:0000467 .
+UBERON:8600121 a owl:Class ;
+    rdfs:label "lumbar ganglion" ;
+    NIFRID:synonym "lumbar paravertebral ganglion",
+        "lumbar sympathetic ganglion" ;
+    rdfs:subClassOf UBERON:0001807,
+        UBERON:0009758,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0005462 ] .
+
+UBERON:8600122 a owl:Class ;
+    rdfs:label "sacral ganglion" ;
+    NIFRID:synonym "sacral sympathetic ganglion" ;
+    rdfs:subClassOf UBERON:0001807,
+        UBERON:0009758,
+        [ a owl:Restriction ;
+            owl:onProperty partOf: ;
+            owl:someValuesFrom UBERON:0005473 ] .
 
 ### Annotations
-
-ilxtr:cardiac-interganglionic-nerve rdfs:label "cardiac interganglionic nerve" .
 
 ilxtr:parcellationLabel rdfs:subClassOf UBERON:0001062 .
 
 ilxtr:Phenotype rdfs:subClassOf BFO:0000016 .
 
-ilxtr:vago-sympathetic-trunk rdfs:label "vago-sympathetic trunk" .
-
 overlaps: rdfs:label "overlaps" .
 
 SAO:1224657022 rdfs:subClassOf BFO:0000040 .
 
-### Serialized using the ttlser deterministic serializer v1.2.2
+### Serialized using the ttlser deterministic serializer v1.2.3

--- a/tests/test_query_28.py
+++ b/tests/test_query_28.py
@@ -37,7 +37,6 @@ def test_human_female_map():
 def test_human_rat_map():
     query = {**base_query, 'parameters': base_query['parameters'] + [{'column': 'source_id', 'value': RAT_UUID}]}
     response = cq_request(query)
-    print(MALE_UUID, response.json())
     assert_valid_query_response(
         response,
         expected_column_values={'expert_id': expected_expert_ids}

--- a/tests/test_query_29.py
+++ b/tests/test_query_29.py
@@ -1,0 +1,46 @@
+import pytest
+from utility import cq_request, assert_valid_query_response, MALE_UUID, FEMALE_UUID, RAT_UUID, SCKAN_VERSION, CQ_END_POINT
+
+base_query = {
+    'query_id': '29',
+    'parameters': [
+        {'column': 'feature_id', 'value': 'UBERON:0002080'}
+    ]
+}
+
+human_expected_path_ids = [
+    'ilxtr:neuron-type-aacar-11',
+    'ilxtr:neuron-type-aacar-6',
+    'ilxtr:neuron-type-aacar-7v',
+    'ilxtr:neuron-type-aacar-8v',
+    'ilxtr:neuron-type-aacar-9v'
+]
+
+rat_expected_node_ids = human_expected_path_ids + [
+        'ilxtr:neuron-type-aacar-13'
+    ]
+
+def test_human_male_map():
+
+    query = {**base_query, 'parameters': base_query['parameters'] + [{'column': 'source_id', 'value': MALE_UUID}]}
+    response = cq_request(query)
+    assert_valid_query_response(
+        response,
+        expected_column_values={'path_id': human_expected_path_ids}
+    )
+
+def test_human_female_map():
+    query = {**base_query, 'parameters': base_query['parameters'] + [{'column': 'source_id', 'value': FEMALE_UUID}]}
+    response = cq_request(query)
+    assert_valid_query_response(
+        response,
+        expected_column_values={'path_id': human_expected_path_ids}
+    )
+
+def test_human_rat_map():
+    query = {**base_query, 'parameters': base_query['parameters'] + [{'column': 'source_id', 'value': RAT_UUID}]}
+    response = cq_request(query)
+    assert_valid_query_response(
+        response,
+        expected_column_values={'path_id': rat_expected_node_ids}
+    )

--- a/tests/test_query_29.py
+++ b/tests/test_query_29.py
@@ -1,5 +1,5 @@
 import pytest
-from utility import cq_request, assert_valid_query_response, MALE_UUID, FEMALE_UUID, RAT_UUID, SCKAN_VERSION, CQ_END_POINT
+from utility import cq_request, assert_valid_query_response, MALE_UUID, FEMALE_UUID, RAT_UUID
 
 base_query = {
     'query_id': '29',

--- a/tests/test_query_30.py
+++ b/tests/test_query_30.py
@@ -1,5 +1,5 @@
 import pytest
-from utility import cq_request, assert_valid_query_response, MALE_UUID, FEMALE_UUID, RAT_UUID, SCKAN_VERSION, CQ_END_POINT
+from utility import cq_request, assert_valid_query_response, MALE_UUID, FEMALE_UUID, RAT_UUID
 
 base_query = {
     'query_id': '30',

--- a/tests/test_query_30.py
+++ b/tests/test_query_30.py
@@ -1,0 +1,38 @@
+import pytest
+from utility import cq_request, assert_valid_query_response, MALE_UUID, FEMALE_UUID, RAT_UUID, SCKAN_VERSION, CQ_END_POINT
+
+base_query = {
+    'query_id': '30',
+    'parameters': [
+        {'column': 'feature_id', 'value': 'UBERON:0002080'}
+    ]
+}
+
+human_expected_node_ids = [
+    '["UBERON:0002165", ["UBERON:0002080"]]',
+    '["UBERON:0002349", ["UBERON:0002080"]]'
+]
+
+def test_human_male_map():
+    query = {**base_query, 'parameters': base_query['parameters'] + [{'column': 'source_id', 'value': MALE_UUID}]}
+    response = cq_request(query)
+    assert_valid_query_response(
+        response,
+        expected_column_values={'node_id': human_expected_node_ids}
+    )
+
+def test_human_female_map():
+    query = {**base_query, 'parameters': base_query['parameters'] + [{'column': 'source_id', 'value': FEMALE_UUID}]}
+    response = cq_request(query)
+    assert_valid_query_response(
+        response,
+        expected_column_values={'node_id': human_expected_node_ids}
+    )
+
+def test_human_rat_map():
+    query = {**base_query, 'parameters': base_query['parameters'] + [{'column': 'source_id', 'value': RAT_UUID}]}
+    response = cq_request(query)
+    assert_valid_query_response(
+        response,
+        expected_column_values={'node_id': human_expected_node_ids}
+    )


### PR DESCRIPTION
#64
This PR updates term hierarchy generation so cached hierarchies rebuild correctly, fixes ILX parent resolution and version-check logic, and adds hierarchical competency support for anatomical features. It also introduces new competency queries and tests for retrieving paths and nodes under anatomical terms.